### PR TITLE
Fix for levelling up level 1 buildings

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/FortTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/FortTest.cs
@@ -1,4 +1,5 @@
 ﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 
@@ -346,7 +347,7 @@ public class FortTest : TestFixture
                 {
                     DeviceAccountId = DeviceAccountId,
                     PlantId = FortPlants.StaffDojo,
-                    Level = 2,
+                    Level = 1,
                     PositionX = 2,
                     PositionZ = 2,
                     BuildStartDate = DateTimeOffset.UnixEpoch,
@@ -371,7 +372,7 @@ public class FortTest : TestFixture
         result.build_start_date.Should().NotBe(DateTimeOffset.UnixEpoch);
         result.build_end_date.Should().NotBe(DateTimeOffset.UnixEpoch);
         result.build_end_date.Should().BeAfter(result.build_start_date);
-        result.level.Should().Be(3);
+        result.level.Should().Be(2);
     }
 
     [Fact]

--- a/DragaliaAPI/Services/FortService.cs
+++ b/DragaliaAPI/Services/FortService.cs
@@ -205,8 +205,8 @@ public class FortService : IFortService
                 LastIncomeDate = DateTimeOffset.UnixEpoch
             };
 
-        await this.fortRepository.AddBuild(build);
         await Upgrade(plantDetail);
+        await this.fortRepository.AddBuild(build);
 
         return build;
     }

--- a/DragaliaAPI/Services/FortService.cs
+++ b/DragaliaAPI/Services/FortService.cs
@@ -205,7 +205,8 @@ public class FortService : IFortService
                 LastIncomeDate = DateTimeOffset.UnixEpoch
             };
 
-        await Upgrade(build, plantDetail);
+        await this.fortRepository.AddBuild(build);
+        await Upgrade(plantDetail);
 
         return build;
     }
@@ -236,11 +237,11 @@ public class FortService : IFortService
             );
         }
 
+        await Upgrade(plantDetail);
+
         // Start level up
         DateTimeOffset startDate = DateTimeOffset.UtcNow;
         DateTimeOffset endDate = startDate.AddSeconds(plantDetail.Time);
-
-        await Upgrade(build, plantDetail);
 
         build.Level += 1;
         build.BuildStartDate = startDate;
@@ -268,7 +269,7 @@ public class FortService : IFortService
         await this.fortRepository.GetFortPlantIdList(fortPlantIdList);
     }
 
-    private async Task Upgrade(DbFortBuild build, FortPlantDetail plantDetail)
+    private async Task Upgrade(FortPlantDetail plantDetail)
     {
         FortDetail fortDetail = await this.GetFortDetail();
 
@@ -284,11 +285,5 @@ public class FortService : IFortService
         // Remove resources from player
         await this.userDataRepository.UpdateCoin(-plantDetail.Cost);
         await this.inventoryRepository.UpdateQuantity(plantDetail.CreateMaterialMap);
-
-        if (build.Level == 1)
-        {
-            // Only has to be added if it is being created for the first time
-            await this.fortRepository.AddBuild(build);
-        }
     }
 }


### PR DESCRIPTION
This was causing a primary key exception due to FortService attempting to add a build that already existed:

![image](https://user-images.githubusercontent.com/5047192/236914507-7b49f73c-6870-4e0d-8d0a-60e221b2ac67.png)
