### PR TITLE
Fix game leave events

### DIFF
--- a/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
+++ b/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
@@ -17,5 +17,7 @@ namespace DragaliaAPI.Photon.Plugin.Constants
         public const string GoToIngameState = "GoToIngameState";
 
         public const string StartQuest = "StartQuest";
+
+        public const string RemovedFromRedis = "RemovedFromRedis";
     }
 }

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -303,7 +303,7 @@ namespace DragaliaAPI.Photon.Plugin
                     break;
                 case 3:
                     this.RaisePartyEvent(info);
-                    this.CloseGameAfterStart(info);
+                    this.HideGameAfterStart(info);
                     break;
                 default:
                     break;
@@ -425,14 +425,19 @@ namespace DragaliaAPI.Photon.Plugin
         }
 
         /// <summary>
-        /// Send a request to the Redis API to close a game as it is now started.
+        /// Send a request to the Redis API to hide a game as it is now started.
         /// </summary>
         /// <param name="info">Info from <see cref="OnSetProperties(ISetPropertiesCallInfo)"/>.</param>
-        private void CloseGameAfterStart(ISetPropertiesCallInfo info)
+        private void HideGameAfterStart(ISetPropertiesCallInfo info)
         {
             this.PostJsonRequest(
-                this.config.GameCloseEndpoint,
-                new GameModifyRequest { GameName = this.PluginHost.GameId, Player = null },
+                this.config.MatchingTypeEndpoint,
+                new GameModifyMatchingTypeRequest
+                {
+                    NewMatchingType = MatchingTypes.NoDisplay,
+                    GameName = this.PluginHost.GameId,
+                    Player = null
+                },
                 info,
                 true
             );

--- a/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
+++ b/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
@@ -84,7 +84,7 @@ public class GameLeaveTest : TestFixture
                     }
                 }
             );
-        storedGame!.Visible.Should().BeTrue();
+        storedGame!.MatchingType.Should().Be(Shared.MatchingTypes.Anyone);
     }
 
     [Fact]
@@ -130,6 +130,6 @@ public class GameLeaveTest : TestFixture
         RedisGame? storedGame = await this.RedisConnectionProvider.GetGame(game.Name);
         storedGame.Should().NotBeNull();
         storedGame!.Players.Should().BeEmpty();
-        storedGame!.Visible.Should().BeFalse();
+        storedGame!.MatchingType.Should().Be(Shared.MatchingTypes.NoDisplay);
     }
 }

--- a/DragaliaAPI.Photon.StateManager.Test/Get/ByIdTest.cs
+++ b/DragaliaAPI.Photon.StateManager.Test/Get/ByIdTest.cs
@@ -44,8 +44,7 @@ public class ByIdTest : TestFixture
                         ViewerId = 2,
                         PartyNoList = new List<int>() { 40 }
                     }
-                },
-                Visible = true
+                }
             };
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);

--- a/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
+++ b/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
@@ -47,34 +47,7 @@ public class GameListTest : TestFixture
                             ViewerId = 2,
                             PartyNoList = new List<int>() { 40 }
                         }
-                    },
-                    Visible = true
-                },
-                // Visible = false
-                new()
-                {
-                    RoomId = 12345,
-                    Name = "d492fde0-2110-44b9-8b35-03dd0b193e5f",
-                    MatchingCompatibleId = 36,
-                    MatchingType = Shared.MatchingTypes.Anyone,
-                    QuestId = 301010103,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 3,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    },
-                    Visible = false
+                    }
                 },
                 // Non-public matching
                 new()
@@ -99,8 +72,7 @@ public class GameListTest : TestFixture
                             ViewerId = 3,
                             PartyNoList = new List<int>() { 40 }
                         }
-                    },
-                    Visible = false
+                    }
                 },
             };
 
@@ -143,8 +115,7 @@ public class GameListTest : TestFixture
                             ViewerId = 2,
                             PartyNoList = new List<int>() { 40 }
                         }
-                    },
-                    Visible = true
+                    }
                 },
                 new()
                 {
@@ -168,8 +139,7 @@ public class GameListTest : TestFixture
                             ViewerId = 3,
                             PartyNoList = new List<int>() { 40 }
                         }
-                    },
-                    Visible = true
+                    }
                 },
             };
 

--- a/DragaliaAPI.Photon.StateManager/Controllers/EventController.cs
+++ b/DragaliaAPI.Photon.StateManager/Controllers/EventController.cs
@@ -1,3 +1,4 @@
+using DragaliaAPI.Photon.Shared;
 using DragaliaAPI.Photon.Shared.Models;
 using DragaliaAPI.Photon.Shared.Requests;
 using DragaliaAPI.Photon.StateManager.Authentication;
@@ -130,7 +131,7 @@ public class EventController : ControllerBase
         {
             // Don't remove it just yet, as Photon will request that shortly
             this.logger.LogDebug("Hiding game {@game}", game);
-            game.Visible = false;
+            game.MatchingType = MatchingTypes.NoDisplay;
         }
 
         await this.Games.UpdateAsync(game);

--- a/DragaliaAPI.Photon.StateManager/Controllers/GetController.cs
+++ b/DragaliaAPI.Photon.StateManager/Controllers/GetController.cs
@@ -34,7 +34,6 @@ public class GetController : ControllerBase
     {
         IRedisCollection<RedisGame> query = this.connectionProvider
             .RedisCollection<RedisGame>()
-            .Where(x => x.Visible == true)
             .Where(x => x.MatchingType == MatchingTypes.Anyone);
 
         if (questId is not null)
@@ -48,9 +47,10 @@ public class GetController : ControllerBase
     [HttpGet("[action]/{roomId}")]
     public async Task<ActionResult<ApiGame>> ById(int roomId)
     {
+        // Maybe this should filter by MatchingType.ById. Probably no harm letting it join any room for now though.
         IRedisCollection<RedisGame> query = this.connectionProvider
             .RedisCollection<RedisGame>()
-            .Where(x => x.Visible == true && x.RoomId == roomId);
+            .Where(x => x.RoomId == roomId);
 
         RedisGame? game = await query.FirstOrDefaultAsync();
         if (game is null)

--- a/DragaliaAPI.Photon.StateManager/Models/RedisGame.cs
+++ b/DragaliaAPI.Photon.StateManager/Models/RedisGame.cs
@@ -49,12 +49,6 @@ public class RedisGame : IGame
     public List<Player> Players { get; set; } = new List<Player>();
 
     /// <summary>
-    /// Whether or not to return the game from methods in <see cref="GetController"/>.
-    /// </summary>
-    [Indexed(Sortable = true)]
-    public bool Visible { get; set; } = true;
-
-    /// <summary>
     /// Create a new instance of the <see cref="RedisGame"/> class.
     /// </summary>
     /// <param name="game">Base game, e.g. <see cref="GameBase"/>.</param>


### PR DESCRIPTION
- Don't delete the room on start, as Photon will request to remove players from it after it concludes.
- Instead, make it invisible by setting the `MatchingType` property
   - Remove the Visible property as we can hide rooms using `MatchingType.NoDisplay`. 
   - Change this logic so only the host calls the state manager to do this.
- Handle duplicate leave events from Photon by setting a flag to ensure only one leave request per player is sent to the state manager