### PR TITLE
Fix 'sequence contains no element' error in MatchingService

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
@@ -278,4 +278,87 @@ public class MatchingTest : TestFixture
                 }
             );
     }
+
+    [Fact]
+    public async Task GetRoomName_UnrecognizedViewerId_UsesDefault()
+    {
+        this.MockPhotonStateApi
+            .Setup(x => x.GetGameById(911948))
+            .ReturnsAsync(
+                new ApiGame()
+                {
+                    RoomId = 911948,
+                    Name = "7942ce2a-c0ac-4e41-8472-0cf5918f3953",
+                    QuestId = 204550501,
+                    Players = new List<Player>()
+                    {
+                        new()
+                        {
+                            ViewerId = 40000,
+                            PartyNoList = new List<int>() { 1 }
+                        }
+                    },
+                    StartEntryTime = DateTimeOffset.FromUnixTimeSeconds(1662160789),
+                    EntryConditions = new()
+                    {
+                        UnacceptedElementTypeList = new List<int>() { 1, 2, 3, 4, 5 },
+                        UnacceptedWeaponTypeList = new List<int>() { 1, 2 },
+                        RequiredPartyPower = 100,
+                        ObjectiveTextId = 2,
+                    },
+                    MatchingCompatibleId = 36,
+                }
+            );
+
+        MatchingGetRoomNameData data = (
+            await this.Client.PostMsgpack<MatchingGetRoomNameData>(
+                $"{EndpointGroup}/get_room_name",
+                new MatchingGetRoomNameRequest() { room_id = 911948 }
+            )
+        ).data;
+
+        data.Should()
+            .BeEquivalentTo(
+                new MatchingGetRoomNameData()
+                {
+                    room_data = new()
+                    {
+                        room_id = 911948,
+                        room_name = "7942ce2a-c0ac-4e41-8472-0cf5918f3953",
+                        region = "jp",
+                        cluster_name = "jp",
+                        language = "en_us",
+                        status = RoomStatuses.Available,
+                        entry_type = 1,
+                        entry_guild_id = 0,
+                        host_viewer_id = 40000,
+                        host_name = "Euden",
+                        host_level = 1,
+                        leader_chara_id = Charas.ThePrince,
+                        leader_chara_rarity = 4,
+                        leader_chara_level = 1,
+                        quest_id = 204550501,
+                        quest_type = QuestTypes.Dungeon,
+                        room_member_list = new List<AtgenRoomMemberList>()
+                        {
+                            new() { viewer_id = 40000, }
+                        },
+                        start_entry_time = DateTimeOffset.FromUnixTimeSeconds(1662160789),
+                        entry_conditions = new()
+                        {
+                            unaccepted_element_type_list = new List<int>() { 1, 2, 3, 4, 5 },
+                            unaccepted_weapon_type_list = new List<int>() { 1, 2 },
+                            required_party_power = 100,
+                            objective_text_id = 2
+                        },
+                        compatible_id = 36,
+                        member_num = 1,
+                    },
+                    cluster_name = "jp",
+                    is_friend = 0,
+                    quest_id = 204550501,
+                    room_name = "7942ce2a-c0ac-4e41-8472-0cf5918f3953"
+                }
+            );
+    }
 }


### PR DESCRIPTION
Fixes errors seen in Seq about 'sequence containing no element' in MapRoomList. Most likely due to a failed DB query. Since these are only for deocrating the room UI element, it's probably OK to fallback on defaults.

![image](https://github.com/SapiensAnatis/Dawnshard/assets/5047192/3d497479-cff7-400b-a959-f0514a869710)
