### PR TITLE
Disable codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,8 +66,9 @@ jobs:
           -p:CoverletOutputFormat="cobertura" 
           -p:CoverletOutput="coverage_report.xml"
           -p:Exclude=\"[*.Test]*,[DragaliaAPI.Test.Utils]*,[DragaliaAPI.Photon.Plugin]*,[DragaliaAPI.Database]DragaliaAPI.Database.Migrations.*,[DragaliaAPI]DragaliaAPI.Models.Generated.*\"
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage reports
+        uses: actions/upload-artifact@v3
         with:
-          files: ${{matrix.project}}/coverage_report.xml
-          name: codecov ${{ matrix.project }}
+          name: ${{ matrix.project }} coverage report
+          path: ${{ matrix.project }}/coverage_report.xml
+          retention-days: 2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dawnshard
 
-[![test](https://github.com/SapiensAnatis/DragaliaAPI/actions/workflows/test.yaml/badge.svg?branch=develop)](https://github.com/SapiensAnatis/DragaliaAPI/actions/workflows/test.yaml) [![Codecov](https://img.shields.io/codecov/c/github/sapiensanatis/dawnshard?logo=codecov)](https://app.codecov.io/gh/SapiensAnatis/Dawnshard) [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/sapiensanatis/dragalia-api?label=docker%20image&logo=docker)](https://hub.docker.com/r/sapiensanatis/dragalia-api)
+[![test](https://github.com/SapiensAnatis/DragaliaAPI/actions/workflows/test.yaml/badge.svg?branch=develop)](https://github.com/SapiensAnatis/DragaliaAPI/actions/workflows/test.yaml) [![Docker Image Version (latest by date)](https://img.shields.io/docker/v/sapiensanatis/dragalia-api?label=docker%20image&logo=docker)](https://hub.docker.com/r/sapiensanatis/dragalia-api)
 
 Dawnshard (internally named DragaliaAPI) is a server emulator for Dragalia Lost.
 
@@ -10,7 +10,7 @@ If you haven't already, please also consider joining the Dragalia Lost Reverse E
 
 ## Contributing
 
-Contributions are more than welcome! Feel free to fork the repository and open a pull request with these changes. 
+Contributions are more than welcome! Feel free to fork the repository and open a pull request with these changes.
 
 For guidance on contributing, including the process for setting up a development environment, please see the [GitHub Wiki](https://github.com/SapiensAnatis/Dawnshard/wiki).
 
@@ -18,7 +18,6 @@ See also the [API documentation](https://dragalia-api-docs.readthedocs.io/en/lat
 
 ## Hosting your own instance
 
-- On a dedicated server, it is recommended to use the [Kubernetes helm chart](https://github.com/SapiensAnatis/helm-charts). The application is deployed as three services: the main ASP.NET service which is stateless, and two stateful services in Redis (session management) and PostgreSQL (savefile storage). 
+- On a dedicated server, it is recommended to use the [Kubernetes helm chart](https://github.com/SapiensAnatis/helm-charts). The application is deployed as three services: the main ASP.NET service which is stateless, and two stateful services in Redis (session management) and PostgreSQL (savefile storage).
 - If you don't want to use Kubernetes, or are looking to host a local instance, you can use the docker-compose.yml file here with [the published Docker image](https://hub.docker.com/repository/docker/sapiensanatis/dragalia-api/general).
 - If you don't want to use Docker at all, see the [no-docker branch](https://github.com/sapiensAnatis/dragaliaAPI/tree/no-docker) which uses an SQLite DB and an in-memory IDistributedCache for session management. Please note that this version is not regularly updated and no guarantees are made that it functions correctly.
-


### PR DESCRIPTION
- Don't upload to codecov as we no longer wish to enforce code coverage statistics
- Instead upload coverage reports as an artefact for optional viewing