### PR TITLE
Fix LevelupEnd InvalidOperationException on missing smithy

### DIFF
--- a/DragaliaAPI/Controllers/Dragalia/FortController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/FortController.cs
@@ -216,8 +216,12 @@ public class FortController : DragaliaControllerBase
     public async Task<DragaliaResult> LevelupEnd(FortLevelupEndRequest request)
     {
         IEnumerable<BuildList> builds = await this.fortService.GetBuildList();
-        BuildList halidom = builds.First(x => x.plant_id == FortPlants.TheHalidom);
-        BuildList smithy = builds.First(x => x.plant_id == FortPlants.Smithy);
+
+        BuildList halidom =
+            builds.FirstOrDefault(x => x.plant_id == FortPlants.TheHalidom)
+            ?? throw new InvalidOperationException("Missing Halidom building!");
+
+        BuildList? smithy = builds.FirstOrDefault(x => x.plant_id == FortPlants.Smithy);
 
         FortBonusList bonusList = await bonusService.GetBonusList();
 
@@ -232,7 +236,7 @@ public class FortController : DragaliaControllerBase
                 result = 1,
                 build_id = request.build_id,
                 current_fort_level = halidom.level,
-                current_fort_craft_level = smithy.level,
+                current_fort_craft_level = smithy?.level ?? 0,
                 fort_bonus_list = bonusList,
                 production_rp = StubData.ProductionRp,
                 production_st = StubData.ProductionSt,


### PR DESCRIPTION
![image](https://github.com/SapiensAnatis/Dawnshard/assets/5047192/8b8639a5-e994-444c-853d-1f8dbaf0d411)