### PR TITLE
Save import adjustments

### DIFF
--- a/DragaliaAPI/Services/Api/BaasApi.cs
+++ b/DragaliaAPI/Services/Api/BaasApi.cs
@@ -63,7 +63,7 @@ public class BaasApi : IBaasApi
         return jwks.GetSigningKeys();
     }
 
-    public async Task<LoadIndexData?> GetSavefile(string idToken)
+    public async Task<LoadIndexData> GetSavefile(string idToken)
     {
         HttpResponseMessage savefileResponse = await client.PostAsJsonAsync<object>(
             SavefileEndpoint,
@@ -81,9 +81,9 @@ public class BaasApi : IBaasApi
         }
 
         return (
-            await savefileResponse.Content.ReadFromJsonAsync<DragaliaResponse<LoadIndexData>>(
-                ApiJsonOptions.Instance
-            )
-        )?.data;
+                await savefileResponse.Content.ReadFromJsonAsync<DragaliaResponse<LoadIndexData>>(
+                    ApiJsonOptions.Instance
+                )
+            )?.data ?? throw new JsonException("Deserialized savefile was null");
     }
 }

--- a/DragaliaAPI/Services/Api/BaasApi.cs
+++ b/DragaliaAPI/Services/Api/BaasApi.cs
@@ -63,7 +63,7 @@ public class BaasApi : IBaasApi
         return jwks.GetSigningKeys();
     }
 
-    public async Task<LoadIndexData> GetSavefile(string idToken)
+    public async Task<LoadIndexData?> GetSavefile(string idToken)
     {
         HttpResponseMessage savefileResponse = await client.PostAsJsonAsync<object>(
             SavefileEndpoint,
@@ -81,9 +81,9 @@ public class BaasApi : IBaasApi
         }
 
         return (
-                await savefileResponse.Content.ReadFromJsonAsync<DragaliaResponse<LoadIndexData>>(
-                    ApiJsonOptions.Instance
-                )
-            )?.data ?? throw new NullReferenceException("Received null savefile from response");
+            await savefileResponse.Content.ReadFromJsonAsync<DragaliaResponse<LoadIndexData>>(
+                ApiJsonOptions.Instance
+            )
+        )?.data;
     }
 }

--- a/DragaliaAPI/Services/Api/IBaasApi.cs
+++ b/DragaliaAPI/Services/Api/IBaasApi.cs
@@ -6,5 +6,5 @@ namespace DragaliaAPI.Services.Api;
 public interface IBaasApi
 {
     Task<IList<SecurityKey>> GetKeys();
-    Task<LoadIndexData?> GetSavefile(string idToken);
+    Task<LoadIndexData> GetSavefile(string idToken);
 }

--- a/DragaliaAPI/Services/Api/IBaasApi.cs
+++ b/DragaliaAPI/Services/Api/IBaasApi.cs
@@ -6,5 +6,5 @@ namespace DragaliaAPI.Services.Api;
 public interface IBaasApi
 {
     Task<IList<SecurityKey>> GetKeys();
-    Task<LoadIndexData> GetSavefile(string idToken);
+    Task<LoadIndexData?> GetSavefile(string idToken);
 }

--- a/DragaliaAPI/Services/Game/AuthService.cs
+++ b/DragaliaAPI/Services/Game/AuthService.cs
@@ -119,13 +119,7 @@ public class AuthService : IAuthService
     {
         try
         {
-            LoadIndexData? pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
-
-            if (pendingSave is null)
-            {
-                this.logger.LogInformation("Savefile was null.");
-                return;
-            }
+            LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
 
             this.logger.LogDebug("UserData: {@userData}", pendingSave.user_data);
             await this.savefileService.ThreadSafeImport(pendingSave);

--- a/DragaliaAPI/Services/Game/AuthService.cs
+++ b/DragaliaAPI/Services/Game/AuthService.cs
@@ -98,23 +98,7 @@ public class AuthService : IAuthService
         DbPlayerUserData? userData = await this.userDataRepository.UserData.SingleOrDefaultAsync();
 
         if (GetPendingSaveImport(jwt, userData))
-        {
-            try
-            {
-                LoadIndexData pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
-                this.logger.LogDebug("UserData: {@userData}", pendingSave.user_data);
-                await this.savefileService.ThreadSafeImport(pendingSave);
-            }
-            catch (Exception e) when (e is JsonException or AutoMapperMappingException)
-            {
-                this.logger.LogWarning(e, "Savefile was invalid.");
-            }
-            catch (Exception e)
-            {
-                this.logger.LogError(e, "Error importing save");
-                // Let them log in regardless
-            }
-        }
+            await this.ImportSave(idToken);
 
         long viewerId = await this.GetViewerId();
 
@@ -129,6 +113,32 @@ public class AuthService : IAuthService
         );
 
         return new(viewerId, sessionId);
+    }
+
+    private async Task ImportSave(string idToken)
+    {
+        try
+        {
+            LoadIndexData? pendingSave = await this.baasRequestHelper.GetSavefile(idToken);
+
+            if (pendingSave is null)
+            {
+                this.logger.LogInformation("Savefile was null.");
+                return;
+            }
+
+            this.logger.LogDebug("UserData: {@userData}", pendingSave.user_data);
+            await this.savefileService.ThreadSafeImport(pendingSave);
+        }
+        catch (Exception e) when (e is JsonException or AutoMapperMappingException)
+        {
+            this.logger.LogInformation(e, "Savefile was invalid.");
+        }
+        catch (Exception e)
+        {
+            this.logger.LogWarning(e, "Error importing save");
+            // Let them log in regardless
+        }
     }
 
     private async Task<TokenValidationResult> ValidateToken(string idToken)


### PR DESCRIPTION
- Gracefully handle duplicate dragon/talisman key ids in party mapping logic
- Reduce logging severity:
   - Known user error on save import (JsonException/AutoMapper exception): Warning -> Information
   - Unknown error on save import (primary keys etc): Error -> Warning
   - Null savefile from BaaS: Error -> Information 