### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
+    environment:
+      name: Production
+      url: https://dawnshard.co.uk
     steps:
       - name: ssh and restart pods
         uses: appleboy/ssh-action@v0.1.6

--- a/.github/workflows/publish-api.yaml
+++ b/.github/workflows/publish-api.yaml
@@ -13,5 +13,6 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       ref: ${{ github.ref_name }}
-      image-tag: ${{ github.ref_name }}
+      dockerfile: "DragaliaAPI.Photon.StateManager/Dockerfile"
+      image-name: "dragalia-api"
     secrets: inherit

--- a/.github/workflows/publish-api.yaml
+++ b/.github/workflows/publish-api.yaml
@@ -13,6 +13,6 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       ref: ${{ github.ref_name }}
-      dockerfile: "DragaliaAPI.Photon.StateManager/Dockerfile"
+      dockerfile: "DragaliaAPI/Dockerfile"
       image-name: "dragalia-api"
     secrets: inherit

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -3,10 +3,23 @@ name: publish-tag-manual
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        type: string
+      ref:
         required: true
-        description: "Tag to publish"
+        type: string
+        description: ref to checkout
+      dockerfile:
+        required: true
+        type: string
+        description: path to Dockerfile
+      image-name:
+        required: true
+        type: string
+        description: Docker image name
+      image-tag:
+        required: false
+        default: "undefined"
+        type: string
+        description: Docker image tag
 
 env:
   HUSKY: 0
@@ -16,5 +29,7 @@ jobs:
     uses: ./.github/workflows/publish.yaml
     with:
       ref: ${{ inputs.tag }}
+      dockerfile: ${{ inputs.dockerfile }}
+      image-name: ${{ inputs.image-name }}
       image-tag: ${{ inputs.tag }}
     secrets: inherit

--- a/.github/workflows/publish-manual.yaml
+++ b/.github/workflows/publish-manual.yaml
@@ -28,8 +28,8 @@ jobs:
   publish:
     uses: ./.github/workflows/publish.yaml
     with:
-      ref: ${{ inputs.tag }}
+      ref: ${{ inputs.ref }}
       dockerfile: ${{ inputs.dockerfile }}
       image-name: ${{ inputs.image-name }}
-      image-tag: ${{ inputs.tag }}
+      image-tag: ${{ inputs.image-tag }}
     secrets: inherit

--- a/.github/workflows/publish-push.yaml
+++ b/.github/workflows/publish-push.yaml
@@ -16,7 +16,7 @@ jobs:
           [
             {
               dockerfile: "DragaliaAPI.Photon.StateManager/Dockerfile",
-              image: "dragalia-api-statemanager",
+              image: "photonstatemanager",
             },
             { dockerfile: "DragaliaAPI/Dockerfile", image: "dragalia-api" },
           ]

--- a/.github/workflows/publish-push.yaml
+++ b/.github/workflows/publish-push.yaml
@@ -16,7 +16,7 @@ jobs:
           [
             {
               dockerfile: "DragaliaAPI.Photon.StateManager/Dockerfile",
-              image: "photonstatemanager",
+              image: "photon-state-manager",
             },
             { dockerfile: "DragaliaAPI/Dockerfile", image: "dragalia-api" },
           ]

--- a/.github/workflows/publish-statemanager.yaml
+++ b/.github/workflows/publish-statemanager.yaml
@@ -1,0 +1,18 @@
+name: publish-tag
+
+on:
+  push:
+    tags:
+      - "statemanager@*"
+
+env:
+  HUSKY: 0
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yaml
+    with:
+      ref: ${{ github.ref_name }}
+      dockerfile: "DragaliaAPI.Photon.StateManager/Dockerfile"
+      image-name: "photon-state-manager"
+    secrets: inherit

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,6 +69,5 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Build and push
         run: |
-          echo "Building ${{ inputs.dockerfile }} into image ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}"
-          docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}
+          docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
           docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,11 +59,16 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+      - name: Log in to registry
+        # This is where you will update the personal access token to GITHUB_TOKEN
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Build and push
         run: |
-          docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
-          docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
+          IMAGE=ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
+          
+          docker build . --file ${{ inputs.dockerfile }} --tag ${IMAGE}
+          docker push ${IMAGE}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,10 +59,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      - uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v3
         with:
@@ -70,4 +66,4 @@ jobs:
       - name: Build and push
         run: |
           docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
-          docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}
+          docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,8 @@ on:
         type: string
         description: Docker image name
       image-tag:
-        required: true
+        required: false
+        default: "undefined"
         type: string
         description: Docker image tag
 
@@ -31,6 +32,30 @@ jobs:
         dotnet-version: ["7.0.x"]
 
     steps:
+      - name: derive tag
+        id: derive-tag
+        run: |
+          TAG_REGEX="[\w]+?@v(.*)"
+          echo "Ref: ${{ inputs.ref }}"
+          echo "Tag: ${{ inputs.image-tag }}"
+          
+          if [ ${{ inputs.image-tag }} != "undefined" ]
+          then
+            echo "tag=${{ inputs.image-tag }}" >> "$GITHUB_OUTPUT"
+            exit 0;
+          fi
+          
+          if [ ${{ inputs.ref }} = "develop" ]
+          then
+             echo "tag=latest" >> "$GITHUB_OUTPUT"
+          elif [[ ${{ inputs.ref }} =~ $TAG_REGEX ]]
+          then
+             echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No image-tag provided and failed to derive image tag from ref"
+            exit 1;
+          fi
+          
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
@@ -42,11 +67,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - uses: docker/setup-buildx-action@v2
       - name: Build and push
-        uses: docker/build-push-action@v3
-        with:
-          context: .
-          file: ${{ inputs.dockerfile }}
-          push: true
-          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ inputs.image-name }}:${{ inputs.image-tag }}
+        run: |
+          docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}
+          docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,5 +69,6 @@ jobs:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Build and push
         run: |
+          echo "Building ${{ inputs.dockerfile }} into image ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}"
           docker build . --file ${{ inputs.dockerfile }} --tag ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}
           docker push ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.tag }}

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -31,10 +31,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "github", "github", "{1A23D4
 	ProjectSection(SolutionItems) = preProject
 		.github\workflows\deploy.yaml = .github\workflows\deploy.yaml
 		.github\workflows\lint.yaml = .github\workflows\lint.yaml
-		.github\workflows\publish-base.yaml = .github\workflows\publish-base.yaml
+		.github\workflows\publish.yaml = .github\workflows\publish.yaml
 		.github\workflows\publish-manual.yaml = .github\workflows\publish-manual.yaml
 		.github\workflows\publish-push.yaml = .github\workflows\publish-push.yaml
-		.github\workflows\publish-tag.yaml = .github\workflows\publish-tag.yaml
+		.github\workflows\publish-api.yaml = .github\workflows\publish-api.yaml
 		.github\workflows\test.yaml = .github\workflows\test.yaml
 	EndProjectSection
 EndProject

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -36,6 +36,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "github", "github", "{1A23D4
 		.github\workflows\publish-push.yaml = .github\workflows\publish-push.yaml
 		.github\workflows\publish-api.yaml = .github\workflows\publish-api.yaml
 		.github\workflows\test.yaml = .github\workflows\test.yaml
+		.github\workflows\publish-statemanager.yaml = .github\workflows\publish-statemanager.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DragaliaAPI.Test.Utils", "DragaliaAPI.Test.Utils\DragaliaAPI.Test.Utils.csproj", "{41916B7C-6304-4504-99C0-B24D23982F7E}"


### PR DESCRIPTION
- Allow publishing of Docker images of API / state manager separately using tags e.g. "api@v2.1.0" -> "dragalia-api:2.1.0"
- Push to GitHub container registry instead of Docker Hub
- Use environments to show deployment status on main repository page 