### PR TITLE
Fix being unable to clear early campaign stages

### DIFF
--- a/DragaliaAPI.Test/Controllers/DungeonRecordControllerTest.cs
+++ b/DragaliaAPI.Test/Controllers/DungeonRecordControllerTest.cs
@@ -39,7 +39,7 @@ public class DungeonRecordControllerTest
         this.mockUpdateDataService = new(MockBehavior.Strict);
         this.mockTutorialService = new(MockBehavior.Strict);
         this.mockMissionProgressionService = new(MockBehavior.Strict);
-        this.mockLogger = new(MockBehavior.Strict);
+        this.mockLogger = new(MockBehavior.Loose);
 
         this.dungeonRecordController = new(
             this.mockQuestRepository.Object,

--- a/DragaliaAPI/Features/Dungeon/DungeonRecordController.cs
+++ b/DragaliaAPI/Features/Dungeon/DungeonRecordController.cs
@@ -57,6 +57,8 @@ public class DungeonRecordController : DragaliaControllerBase
         // TODO: Turn this method into a service call
         DungeonSession session = await dungeonService.FinishDungeon(request.dungeon_key);
 
+        this.logger.LogDebug("Processing completion of quest {id}", session.QuestData.Id);
+
         DbQuest? oldQuestData = await questRepository.Quests.SingleOrDefaultAsync(
             x => x.QuestId == session.QuestData.Id
         );

--- a/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -51,12 +51,13 @@ public class QuestEnemyService : IQuestEnemyService
             )
         )
         {
-            questMultiplier = new(questId);
+            questMultiplier = new(questData.Gid);
         }
 
         this.logger.LogDebug("Using quest multiplier: {@multiplier}", questMultiplier);
 
-        double difficultyMultiplier = Math.Log(questData.Difficulty / 1000);
+        double difficultyCoeff = Math.Max(questData.Difficulty / 1000, Math.E);
+        double difficultyMultiplier = Math.Log(difficultyCoeff);
 
         foreach (AtgenEnemy enemy in enemyList)
         {


### PR DESCRIPTION
A -Infinity quest drop difficulty multiplier could occur when a quest's difficulty was less than 1000. Now the minimum difficulty multiplier will be 1