### PR TITLE
Fix co-op retry bugs

### DIFF
--- a/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
+++ b/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
@@ -31,7 +31,5 @@ namespace DragaliaAPI.Photon.Plugin.Constants
         public const string HeroParamCount = "PLUGIN_HeroParamCount";
 
         public const string MemberCount = "PLUGIN_MemberCount";
-
-        public const string FailQuest = "PLUGIN_FailQuest";
     }
 }

--- a/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
+++ b/DragaliaAPI.Photon.Plugin/Constants/ActorPropertyKeys.cs
@@ -6,6 +6,12 @@ using System.Threading.Tasks;
 
 namespace DragaliaAPI.Photon.Plugin.Constants
 {
+    /// <summary>
+    /// Actor property keys.
+    /// </summary>
+    /// <remarks>
+    /// The PLUGIN_ prefix denotes properties that are used for plugin logic and not by the game.
+    /// </remarks>
     public class ActorPropertyKeys
     {
         public const string PlayerId = "PlayerId";
@@ -16,14 +22,16 @@ namespace DragaliaAPI.Photon.Plugin.Constants
 
         public const string GoToIngameState = "GoToIngameState";
 
-        public const string StartQuest = "StartQuest";
+        public const string StartQuest = "PLUGIN_StartQuest";
 
-        public const string RemovedFromRedis = "RemovedFromRedis";
+        public const string RemovedFromRedis = "PLUGIN_RemovedFromRedis";
 
-        public const string HeroParam = "HeroParam";
+        public const string HeroParam = "PLUGIN_HeroParam";
 
-        public const string HeroParamCount = "HeroParamCount";
+        public const string HeroParamCount = "PLUGIN_HeroParamCount";
 
-        public const string MemberCount = "MemberCount";
+        public const string MemberCount = "PLUGIN_MemberCount";
+
+        public const string FailQuest = "PLUGIN_FailQuest";
     }
 }

--- a/DragaliaAPI.Photon.Plugin/Constants/GamePropertyKeys.cs
+++ b/DragaliaAPI.Photon.Plugin/Constants/GamePropertyKeys.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 
 namespace DragaliaAPI.Photon.Plugin.Constants
 {
+    /// <summary>
+    /// Game property keys.
+    /// </summary>
     public class GamePropertyKeys
     {
         public const string MatchingCompatibleId = "MatchingCompatibleId";

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -409,9 +409,7 @@ namespace DragaliaAPI.Photon.Plugin
         /// <param name="info">Info from <see cref="OnSetProperties(ISetPropertiesCallInfo)"/>.</param>
         private void OnSetGoToIngameState(ISetPropertiesCallInfo info)
         {
-            int value = info.Request.Properties.GetInt(ActorPropertyKeys.GoToIngameState);
-
-            switch (value)
+            switch (this.minGoToIngameState)
             {
                 case 1:
                     this.SetGoToIngameInfo(info);

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -128,20 +128,7 @@ namespace DragaliaAPI.Photon.Plugin
             );
 #endif
 
-            base.OnLeave(info);
-
-            // It is not critical to update the Redis state, so don't crash the room if we can't find
-            // the actor or certain properties attached to them.
-            if (actor is null)
-            {
-                this.logger.InfoFormat(
-                    "OnLeave: could not find actor {0} -- GameLeave request aborted",
-                    info.ActorNr
-                );
-                return;
-            }
-
-            if (actor.IsHost())
+            if (info.ActorNr == 1)
             {
                 this.RaiseEvent(
                     Event.Codes.RoomBroken,
@@ -153,6 +140,19 @@ namespace DragaliaAPI.Photon.Plugin
                 this.PluginHost.SetGameState(
                     new SerializableGameState() { IsOpen = false, IsVisible = false }
                 );
+            }
+
+            base.OnLeave(info);
+
+            // It is not critical to update the Redis state, so don't crash the room if we can't find
+            // the actor or certain properties attached to them.
+            if (actor is null)
+            {
+                this.logger.InfoFormat(
+                    "OnLeave: could not find actor {0} -- GameLeave request aborted",
+                    info.ActorNr
+                );
+                return;
             }
 
             if (

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -22,12 +22,10 @@ namespace DragaliaAPI.Photon.Plugin
     /// </summary>
     public partial class GluonPlugin : PluginBase
     {
-        private const int DataEventDelayMs = 3000;
-
         private IPluginLogger logger;
         private PluginConfiguration config;
         private Random rdm;
-        private int minGoToIngameState;
+        private int minGoToIngameState = 0;
 
         private static readonly MessagePackSerializerOptions MessagePackOptions =
             MessagePackSerializerOptions.Standard.WithCompression(MessagePackCompression.Lz4Block);
@@ -139,10 +137,6 @@ namespace DragaliaAPI.Photon.Plugin
                 );
 
                 this.SetRoomVisibility(info, false);
-
-                this.PluginHost.SetGameState(
-                    new SerializableGameState() { IsOpen = false, IsVisible = false }
-                );
             }
 
             base.OnLeave(info);

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -58,7 +58,6 @@ namespace DragaliaAPI.Photon.Plugin
             info.Request.ActorProperties.InitializeViewerId();
 
             info.Request.GameProperties.Add(GamePropertyKeys.RoomId, rdm.Next(100_0000, 999_9999));
-            info.Request.GameProperties.Add(GamePropertyKeys.GoToIngameState, 0);
 
 #if DEBUG
             this.logger.DebugFormat(
@@ -241,12 +240,20 @@ namespace DragaliaAPI.Photon.Plugin
 
         private void OnFailQuestRequest(IRaiseEventCallInfo info)
         {
+            this.minGoToIngameState = 0;
+
             // Clear StartQuest so quests don't start instantly next time.
+            // Also clear same HeroParam properties that cause serialization issues.
             this.PluginHost.SetProperties(
                 info.ActorNr,
-                new Hashtable() { { ActorPropertyKeys.StartQuest, false }, },
+                new Hashtable()
+                {
+                    { ActorPropertyKeys.HeroParam, null },
+                    { ActorPropertyKeys.HeroParamCount, null },
+                    { ActorPropertyKeys.StartQuest, false },
+                },
                 null,
-                true
+                false
             );
 
             FailQuestRequest request = info.DeserializeEvent<FailQuestRequest>();
@@ -627,6 +634,8 @@ namespace DragaliaAPI.Photon.Plugin
 
         private void OnClearQuestRequest(IRaiseEventCallInfo info)
         {
+            this.minGoToIngameState = 0;
+
             // These properties must be set for the client to successfully rejoin the room.
             this.PluginHost.SetProperties(
                 0,

--- a/DragaliaAPI/Services/Game/BonusService.cs
+++ b/DragaliaAPI/Services/Game/BonusService.cs
@@ -1,4 +1,7 @@
-﻿//#define CHEATING
+﻿// #define CHEATS
+#if CHEATS && DEBUG
+#define CHEATING
+#endif
 
 using System.Collections.Immutable;
 using DragaliaAPI.Database.Repositories;
@@ -17,9 +20,6 @@ namespace DragaliaAPI.Services.Game;
 /// <summary>
 /// Service for fort, weapon, and album bonuses
 /// </summary>
-#if CHEATING
-#warning Cheats are enabled
-#endif
 public class BonusService(
     IFortRepository fortRepository,
     IWeaponRepository weaponRepository,


### PR DESCRIPTION
Closes #361 and closes #362 

Also move SetGameState call above `base.OnLeave` call to prevent `Plugin GluonPlugin tries to set game state after call to 'Continue'` error.

---
 
The root cause of both issues was the `StartQuest` property not being cleared between quest attempts, causing an early start and the proper data to not be received. This is a plugin-only property we use to decide when all players are loaded and to fire the StartQuest event.

However, when clearing `StartQuest` on a quest retry, the host appears to progress through the `GoToIngameState` values _much_ faster than other players. This leads to other players experiencing an infinite load, as they never receive the required events -- which probably lead to #362 since by not clearing `StartQuest` they would be forced to load into the game without this info.

~~To solve this, the events are now broadcast after a 3-second delay. This is a bit of a hack, maybe it would be better to find some way to only send the `GoToIngameState` progression events on the last player reaching a particular value, but I couldn't find a nice way to do this.~~

Changed approach: uses an instance variable now to track the min GoToIngameState value. No need to use `Interlocked` methods as plugin callbacks are thread-safe.
