### PR TITLE
Fix failed retry votes on wipe

### DIFF
--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -308,7 +308,7 @@ namespace DragaliaAPI.Photon.Plugin
                     new Hashtable()
                     {
                         { GamePropertyKeys.GoToIngameInfo, null },
-                        // { GamePropertyKeys.RoomId, -1 } TODO: Show 'play again with the same players?' screen on failed retry after wipe
+                        { GamePropertyKeys.RoomId, -1 }
                     },
                     null,
                     true

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -228,10 +228,10 @@ namespace DragaliaAPI.Photon.Plugin
 
 #if DEBUG
             this.logger.DebugFormat(
-                "Actor {0} raised event: 0x{1} ({2})",
+                "Actor {0} raised event: {1} (0x{2})",
                 info.ActorNr,
-                info.Request.EvCode.ToString("X"),
-                info.Request.EvCode
+                (Event)info.Request.EvCode,
+                info.Request.EvCode.ToString("X")
             );
             this.logger.DebugFormat(
                 "Event properties: {0}",
@@ -269,6 +269,13 @@ namespace DragaliaAPI.Photon.Plugin
         private void OnFailQuestRequest(IRaiseEventCallInfo info)
         {
             this.actorState[info.ActorNr].Ready = false;
+
+            this.PluginHost.SetProperties(
+                info.ActorNr,
+                new Hashtable() { { ActorPropertyKeys.GoToIngameState, 0 }, },
+                null,
+                false
+            );
 
             FailQuestRequest request = info.DeserializeEvent<FailQuestRequest>();
 

--- a/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
+++ b/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
@@ -1,6 +1,9 @@
 ﻿using DragaliaAPI.Features.Dungeon;
+using DragaliaAPI.Features.Dungeon.Record;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Services.Photon;
+using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 
 namespace DragaliaAPI.Test.Controllers;
@@ -9,6 +12,8 @@ public class DungeonControllerTest
 {
     private readonly Mock<IDungeonService> mockDungeonService;
     private readonly Mock<IOddsInfoService> mockOddsInfoService;
+    private readonly Mock<IMatchingService> mockMatchingService;
+    private readonly Mock<IDungeonRecordHelperService> mockDungeonRecordHelperService;
 
     private readonly DungeonController dungeonController;
 
@@ -16,35 +21,140 @@ public class DungeonControllerTest
     {
         this.mockDungeonService = new(MockBehavior.Strict);
         this.mockOddsInfoService = new(MockBehavior.Strict);
+        this.mockMatchingService = new(MockBehavior.Strict);
+        this.mockDungeonRecordHelperService = new(MockBehavior.Strict);
 
         this.dungeonController = new(
             this.mockDungeonService.Object,
-            this.mockOddsInfoService.Object
+            this.mockOddsInfoService.Object,
+            this.mockMatchingService.Object,
+            this.mockDungeonRecordHelperService.Object
         );
-
-        dungeonController.SetupMockContext();
     }
 
     [Fact]
-    public async Task Fail_RespondsWithCorrectQuestId()
+    public async Task Fail_IsMultiFalse_ReturnsExpectedResponse()
     {
+        int questId = 227060105;
+
+        List<UserSupportList> userSupportList =
+            new() { new() { support_chara = new() { chara_id = Charas.HalloweenLowen } } };
+
+        List<AtgenHelperDetailList> supportDetailList =
+            new()
+            {
+                new()
+                {
+                    is_friend = false,
+                    viewer_id = 1,
+                    get_mana_point = 50,
+                }
+            };
+
         this.mockDungeonService
             .Setup(x => x.FinishDungeon("my key"))
             .ReturnsAsync(
                 new DungeonSession()
                 {
-                    QuestData = MasterAsset.QuestData.Get(227060105),
-                    Party = new List<PartySettingList>()
+                    QuestData = MasterAsset.QuestData.Get(questId),
+                    Party = new List<PartySettingList>(),
+                    IsMulti = false,
+                    SupportViewerId = 4,
                 }
             );
+
+        this.mockDungeonRecordHelperService
+            .Setup(x => x.ProcessHelperDataSolo(4))
+            .ReturnsAsync((userSupportList, supportDetailList));
 
         DungeonFailData? response = (
             await this.dungeonController.Fail(new DungeonFailRequest() { dungeon_key = "my key" })
         ).GetData<DungeonFailData>();
 
         response.Should().NotBeNull();
-        response!.fail_quest_detail.quest_id.Should().Be(227060105);
+        response!
+            .Should()
+            .BeEquivalentTo(
+                new DungeonFailData()
+                {
+                    result = 1,
+                    fail_helper_list = userSupportList,
+                    fail_helper_detail_list = supportDetailList,
+                    fail_quest_detail = new()
+                    {
+                        wall_id = 0,
+                        wall_level = 0,
+                        is_host = true,
+                        quest_id = questId
+                    }
+                }
+            );
 
         this.mockDungeonService.VerifyAll();
+        this.mockDungeonRecordHelperService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task Fail_IsMultiTrue_RespondsExpectedResponse()
+    {
+        int questId = 227060105;
+
+        List<UserSupportList> userSupportList =
+            new() { new() { support_chara = new() { chara_id = Charas.HalloweenLowen } } };
+
+        List<AtgenHelperDetailList> supportDetailList =
+            new()
+            {
+                new()
+                {
+                    is_friend = false,
+                    viewer_id = 1,
+                    get_mana_point = 50,
+                }
+            };
+
+        this.mockDungeonService
+            .Setup(x => x.FinishDungeon("my key"))
+            .ReturnsAsync(
+                new DungeonSession()
+                {
+                    QuestData = MasterAsset.QuestData.Get(questId),
+                    Party = new List<PartySettingList>(),
+                    IsMulti = true,
+                }
+            );
+
+        this.mockDungeonRecordHelperService
+            .Setup(x => x.ProcessHelperDataMulti())
+            .ReturnsAsync((userSupportList, supportDetailList));
+
+        this.mockMatchingService.Setup(x => x.GetIsHost()).ReturnsAsync(false);
+
+        DungeonFailData? response = (
+            await this.dungeonController.Fail(new DungeonFailRequest() { dungeon_key = "my key" })
+        ).GetData<DungeonFailData>();
+
+        response.Should().NotBeNull();
+        response!
+            .Should()
+            .BeEquivalentTo(
+                new DungeonFailData()
+                {
+                    result = 1,
+                    fail_helper_list = userSupportList,
+                    fail_helper_detail_list = supportDetailList,
+                    fail_quest_detail = new()
+                    {
+                        wall_id = 0,
+                        wall_level = 0,
+                        is_host = false,
+                        quest_id = questId
+                    }
+                }
+            );
+
+        this.mockDungeonService.VerifyAll();
+        this.mockMatchingService.VerifyAll();
+        this.mockDungeonRecordHelperService.VerifyAll();
     }
 }

--- a/DragaliaAPI/Features/Dungeon/DungeonController.cs
+++ b/DragaliaAPI/Features/Dungeon/DungeonController.cs
@@ -1,36 +1,31 @@
 ﻿using DragaliaAPI.Controllers;
+using DragaliaAPI.Features.Dungeon.Record;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
 using DragaliaAPI.Services.Exceptions;
+using DragaliaAPI.Services.Photon;
 using DragaliaAPI.Shared.Definitions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DragaliaAPI.Features.Dungeon;
 
 [Route("dungeon")]
-public class DungeonController : DragaliaControllerBase
+public class DungeonController(
+    IDungeonService dungeonService,
+    IOddsInfoService oddsInfoService,
+    IMatchingService matchingService,
+    IDungeonRecordHelperService dungeonRecordHelperService
+) : DragaliaControllerBase
 {
-    private readonly IDungeonService dungeonService;
-    private readonly IOddsInfoService oddsInfoService;
-
-    public DungeonController(IDungeonService dungeonService, IOddsInfoService oddsInfoService)
-    {
-        this.dungeonService = dungeonService;
-        this.oddsInfoService = oddsInfoService;
-    }
-
     [HttpPost("get_area_odds")]
     public async Task<DragaliaResult> GetAreaOdds(DungeonGetAreaOddsRequest request)
     {
         DungeonSession session = await dungeonService.GetDungeon(request.dungeon_key);
 
-        OddsInfo oddsInfo = this.oddsInfoService.GetOddsInfo(
-            session.QuestData.Id,
-            request.area_idx
-        );
+        OddsInfo oddsInfo = oddsInfoService.GetOddsInfo(session.QuestData.Id, request.area_idx);
 
-        await this.dungeonService.ModifySession(
+        await dungeonService.ModifySession(
             request.dungeon_key,
             session => session.EnemyList[request.area_idx] = oddsInfo.enemy
         );
@@ -43,8 +38,8 @@ public class DungeonController : DragaliaControllerBase
     {
         DungeonSession session = await dungeonService.FinishDungeon(request.dungeon_key);
 
-        return Ok(
-            new DungeonFailData()
+        DungeonFailData response =
+            new()
             {
                 result = 1,
                 fail_helper_list = new List<UserSupportList>(),
@@ -56,7 +51,20 @@ public class DungeonController : DragaliaControllerBase
                     wall_level = 0,
                     is_host = true,
                 }
-            }
-        );
+            };
+
+        if (session.IsMulti)
+        {
+            response.fail_quest_detail.is_host = await matchingService.GetIsHost();
+            (response.fail_helper_list, response.fail_helper_detail_list) =
+                await dungeonRecordHelperService.ProcessHelperDataMulti();
+        }
+        else
+        {
+            (response.fail_helper_list, response.fail_helper_detail_list) =
+                await dungeonRecordHelperService.ProcessHelperDataSolo(session.SupportViewerId);
+        }
+
+        return this.Ok(response);
     }
 }

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordHelperService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordHelperService.cs
@@ -61,6 +61,8 @@ public class DungeonRecordHelperService(
             teammates
         );
 
+        logger.LogDebug("Retrieved teammate support list {@supportList}", teammateSupportLists);
+
         // TODO: Replace with friend system once implemented
         IEnumerable<AtgenHelperDetailList> teammateDetailLists = teammates.Select(
             x =>
@@ -90,7 +92,7 @@ public class DungeonRecordHelperService(
         {
             if (!userDetails.TryGetValue(player.ViewerId, out DbPlayerUserData? userData))
             {
-                logger.LogDebug("No user details returned for player {@player}", player);
+                logger.LogWarning("No user details returned for player {@player}", player);
                 continue;
             }
 
@@ -109,7 +111,7 @@ public class DungeonRecordHelperService(
             }
             catch (Exception e)
             {
-                logger.LogDebug(
+                logger.LogWarning(
                     e,
                     "Failed to populate multiplayer support info for player {@player}",
                     player

--- a/DragaliaAPI/Services/Photon/MatchingService.cs
+++ b/DragaliaAPI/Services/Photon/MatchingService.cs
@@ -103,7 +103,7 @@ public class MatchingService : IMatchingService
 
         if (game is null)
         {
-            this.logger.LogDebug("Failed to retrieve game for ID {viewerId}", viewerId);
+            this.logger.LogWarning("Failed to retrieve game for ID {viewerId}", viewerId);
             return Enumerable.Empty<Player>();
         }
 


### PR DESCRIPTION
Closes #378 

Correctly setting is_host from /dungeon/fail makes only the host call GameSucceed, and then the plugin can use the existing OnGameSucceed logic.

Also sets support info correctly from this endpoint.