### PR TITLE
Modify statemanager logic around leaving and closing rooms

### DIFF
--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -170,8 +170,6 @@ namespace DragaliaAPI.Photon.Plugin
                     Event.RoomBroken,
                     new RoomBroken() { Reason = RoomBroken.RoomBrokenType.HostDisconnected }
                 );
-
-                this.SetRoomVisibility(info, false);
             }
 
             if (!this.actorState.Remove(info.ActorNr))
@@ -195,40 +193,39 @@ namespace DragaliaAPI.Photon.Plugin
                 return;
             }
 
-            if (
-                actor.TryGetViewerId(out int viewerId)
-                && this.actorState.TryGetValue(info.ActorNr, out ActorState actorState)
-                && !actorState.RemovedFromRedis
-            )
+            if (!actor.TryGetViewerId(out int viewerId))
             {
-                this.logger.InfoFormat(
-                    "Actor {0} with viewer ID {1} left game {2}",
-                    info.ActorNr,
-                    viewerId,
-                    this.PluginHost.GameId
+                this.logger.WarnFormat(
+                    "OnLeave: failed to acquire viewer ID of actor {0}",
+                    info.ActorNr
                 );
-
-                this.PostStateManagerRequest(
-                    GameLeaveEndpoint,
-                    new GameModifyRequest
-                    {
-                        GameName = this.PluginHost.GameId,
-                        Player = new Player() { ViewerId = viewerId }
-                    },
-                    info,
-                    true
-                );
-
-                // For some strange reason on completing a quest this appears to be raised twice for each actor.
-                // Prevent duplicate requests by setting a flag.
-                actorState.RemovedFromRedis = true;
+                return;
             }
+
+            this.logger.InfoFormat(
+                "Actor {0} with viewer ID {1} left game {2}",
+                info.ActorNr,
+                viewerId,
+                this.PluginHost.GameId
+            );
+
+            this.PostStateManagerRequest(
+                GameLeaveEndpoint,
+                new GameModifyRequest
+                {
+                    GameName = this.PluginHost.GameId,
+                    Player = new Player() { ViewerId = viewerId }
+                },
+                info,
+                true
+            );
 
             if (this.roomState.MinGoToIngameState > 0)
             {
                 int newMinGoToIngameState = this.PluginHost.GameActors
                     .Where(x => x.ActorNr != info.ActorNr)
                     .Select(x => x.Properties.GetIntOrDefault(ActorPropertyKeys.GoToIngameState))
+                    .DefaultIfEmpty()
                     .Min();
 
                 this.roomState.MinGoToIngameState = newMinGoToIngameState;

--- a/DragaliaAPI.Photon.Plugin/Models/ActorState.cs
+++ b/DragaliaAPI.Photon.Plugin/Models/ActorState.cs
@@ -19,7 +19,5 @@ namespace DragaliaAPI.Photon.Plugin.Models
         public bool Dead { get; set; }
 
         public bool Ready { get; set; }
-
-        public bool RemovedFromRedis { get; set; }
     }
 }

--- a/DragaliaAPI.Photon.StateManager/Authentication/PhotonAuthenticationHandler.cs
+++ b/DragaliaAPI.Photon.StateManager/Authentication/PhotonAuthenticationHandler.cs
@@ -20,16 +20,14 @@ public class PhotonAuthenticationHandler : AuthenticationHandler<AuthenticationS
 
     protected override Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        AuthenticationHeaderValue authenticationHeader;
-        try
+        if (
+            !AuthenticationHeaderValue.TryParse(
+                this.Request.Headers.Authorization,
+                out AuthenticationHeaderValue? authenticationHeader
+            )
+        )
         {
-            authenticationHeader = AuthenticationHeaderValue.Parse(
-                this.Request.Headers.Authorization
-            );
-        }
-        catch (Exception ex)
-        {
-            this.Logger.LogDebug("Failed to parse Authorization header: {reason}", ex.Message);
+            Logger.LogDebug("Failed to parse Authorization header.");
             return Task.FromResult(AuthenticateResult.NoResult());
         }
 

--- a/DragaliaAPI/Middleware/PhotonAuthenticationHandler.cs
+++ b/DragaliaAPI/Middleware/PhotonAuthenticationHandler.cs
@@ -30,14 +30,14 @@ public class PhotonAuthenticationHandler : AuthenticationHandler<AuthenticationS
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        AuthenticationHeaderValue authenticationHeader;
-        try
+        if (
+            !AuthenticationHeaderValue.TryParse(
+                this.Request.Headers.Authorization,
+                out AuthenticationHeaderValue? authenticationHeader
+            )
+        )
         {
-            authenticationHeader = AuthenticationHeaderValue.Parse(Request.Headers.Authorization);
-        }
-        catch (Exception ex)
-        {
-            Logger.LogDebug("Failed to parse Authorization header: {reason}", ex.Message);
+            Logger.LogDebug("Failed to parse Authorization header.");
             return AuthenticateResult.NoResult();
         }
 


### PR DESCRIPTION
- Don't call to set room visibility to false on RoomBroken. Requesting visibility changes when the room is about to tear down seems to cause a fair few errors about the game not existing. Delegate this responsibility to the StateManager.
- Remove RemovedFromRedis flag in actor state. This was causing rooms to be perpetually full as the actor state was removed before this was checked
- Set EmptyRoomTTL to 500ms (previously 30 seconds!). It's not 0 to accomodate any outgoing GameLeave etc requests.

Also:
- Fix some debug logging
- Use TryParse in auth handlers over try/catch