### PR TITLE
Fix incorrect parameter reference

### DIFF
--- a/DragaliaAPI/Features/Missions/MissionInitialProgressionService.cs
+++ b/DragaliaAPI/Features/Missions/MissionInitialProgressionService.cs
@@ -309,9 +309,9 @@ public class MissionInitialProgressionService(
 
     private async Task<int> GetCharacterBuildupCount(MissionProgressionInfo requirement)
     {
-        Debug.Assert(requirement.Parameter2 != null, "requirement.Parameter2 != null");
+        Debug.Assert(requirement.Parameter3 != null, "requirement.Parameter3 != null");
 
-        PlusCountType type = (PlusCountType)requirement.Parameter2;
+        PlusCountType type = (PlusCountType)requirement.Parameter3;
 
         if (requirement.Parameter != null)
         {


### PR DESCRIPTION
```
System.InvalidOperationException: Nullable object must have a value.
   at System.Nullable`1.get_Value()
   at DragaliaAPI.Features.Missions.MissionInitialProgressionService.GetCharacterBuildupCount(MissionProgressionInfo requirement) in /src/DragaliaAPI/Features/Missions/MissionInitialProgressionService.cs:line 314
   at DragaliaAPI.Features.Missions.MissionInitialProgressionService.GetInitialMissionProgress(DbPlayerMission mission) in /src/DragaliaAPI/Features/Missions
```


```csharp
/// <summary>
/// Charas charaId, UnitElement element, PlusCountType type
/// </summary>
CharacterBuildupPlusCount,
```

`PlusCountType` should be Parameter3 and this is what the progression info has it as.