### PR TITLE
Fix smithy and weapon upgrades being locked incorrectly

### DIFF
--- a/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
@@ -283,15 +283,7 @@ public class FortControllerTest
         mockFortService
             .Setup(x => x.LevelupAtOnce(PaymentTypes.HalidomHustleHammer, 8))
             .Returns(Task.CompletedTask);
-        mockFortService
-            .Setup(x => x.GetBuildList())
-            .ReturnsAsync(
-                new List<BuildList>()
-                {
-                    new() { plant_id = FortPlants.Smithy, level = 2, },
-                    new() { plant_id = FortPlants.TheHalidom, level = 3, }
-                }
-            );
+        mockFortService.Setup(x => x.GetCoreLevels()).ReturnsAsync((3, 2));
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
@@ -367,15 +359,7 @@ public class FortControllerTest
 
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
         mockFortService.Setup(x => x.EndLevelup(8)).Returns(Task.CompletedTask);
-        mockFortService
-            .Setup(x => x.GetBuildList())
-            .ReturnsAsync(
-                new List<BuildList>()
-                {
-                    new() { plant_id = FortPlants.Smithy, level = 2, },
-                    new() { plant_id = FortPlants.TheHalidom, level = 3, }
-                }
-            );
+        mockFortService.Setup(x => x.GetCoreLevels()).ReturnsAsync((3, 2));
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
@@ -392,72 +376,6 @@ public class FortControllerTest
         data.fort_bonus_list.Should().BeEquivalentTo(bonusList);
         data.fort_detail.Should().BeEquivalentTo(detail);
         data.update_data_list.Should().BeEquivalentTo(updateDataList);
-
-        mockFortService.VerifyAll();
-        mockBonusService.VerifyAll();
-        mockUpdateDataService.VerifyAll();
-    }
-
-    [Fact]
-    public async Task LevelupEnd_NoSmithy_UsesDefaultValues()
-    {
-        UpdateDataList updateDataList = new() { build_list = new List<BuildList>() };
-        FortBonusList bonusList = new() { all_bonus = new(2, 3) };
-        FortDetail detail = new() { working_carpenter_num = 4 };
-
-        mockFortService
-            .Setup(x => x.GetRupieProduction())
-            .ReturnsAsync(new AtgenProductionRp(0, 0));
-
-        mockFortService
-            .Setup(x => x.GetDragonfruitProduction())
-            .ReturnsAsync(new AtgenProductionRp(0, 0));
-
-        mockFortService
-            .Setup(x => x.GetStaminaProduction())
-            .ReturnsAsync(new AtgenProductionRp(0, 0));
-
-        mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
-        mockFortService.Setup(x => x.EndLevelup(8)).Returns(Task.CompletedTask);
-        mockFortService
-            .Setup(x => x.GetBuildList())
-            .ReturnsAsync(
-                new List<BuildList>()
-                {
-                    new() { plant_id = FortPlants.TheHalidom, level = 3, }
-                }
-            );
-
-        mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
-
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync()).ReturnsAsync(updateDataList);
-
-        FortLevelupEndData data = (
-            await fortController.LevelupEnd(new FortLevelupEndRequest() { build_id = 8 })
-        ).GetData<FortLevelupEndData>()!;
-
-        data.result.Should().Be(1);
-        data.build_id.Should().Be(8);
-        data.current_fort_level.Should().Be(3);
-        data.current_fort_craft_level.Should().Be(0);
-        data.fort_bonus_list.Should().BeEquivalentTo(bonusList);
-        data.fort_detail.Should().BeEquivalentTo(detail);
-        data.update_data_list.Should().BeEquivalentTo(updateDataList);
-
-        mockFortService.VerifyAll();
-        mockBonusService.VerifyAll();
-        mockUpdateDataService.VerifyAll();
-    }
-
-    [Fact]
-    public async Task LevelupEnd_NoHalidom_ThrowsInvalidOperationException()
-    {
-        mockFortService.Setup(x => x.GetBuildList()).ReturnsAsync(new List<BuildList>() { });
-
-        await fortController
-            .Invoking(x => x.LevelupEnd(new FortLevelupEndRequest() { build_id = 8 }))
-            .Should()
-            .ThrowExactlyAsync<InvalidOperationException>();
 
         mockFortService.VerifyAll();
         mockBonusService.VerifyAll();

--- a/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/Features/Fort/FortService.cs
@@ -602,4 +602,20 @@ public class FortService(
             detail.StaminaMax
         );
     }
+
+    public async Task<(int HalidomLevel, int SmithyLevel)> GetCoreLevels()
+    {
+        IEnumerable<(FortPlants PlantId, int Level)> queryResult = await fortRepository.Builds
+            .Where(x => x.PlantId == FortPlants.TheHalidom || x.PlantId == FortPlants.Smithy)
+            .Select(x => new ValueTuple<FortPlants, int>(x.PlantId, x.Level))
+            .ToListAsync();
+
+        // We will get level = 0 if FirstOrDefault does not find a match.
+        int halidomLevel = queryResult
+            .FirstOrDefault(x => x.PlantId == FortPlants.TheHalidom)
+            .Level;
+        int smithyLevel = queryResult.FirstOrDefault(x => x.PlantId == FortPlants.Smithy).Level;
+
+        return (halidomLevel, smithyLevel);
+    }
 }

--- a/DragaliaAPI/Features/Fort/IFortService.cs
+++ b/DragaliaAPI/Features/Fort/IFortService.cs
@@ -32,4 +32,5 @@ public interface IFortService
     Task<AtgenProductionRp> GetRupieProduction();
     Task<AtgenProductionRp> GetDragonfruitProduction();
     Task<AtgenProductionRp> GetStaminaProduction();
+    Task<(int HalidomLevel, int SmithyLevel)> GetCoreLevels();
 }


### PR DESCRIPTION
- Move determination of smithy and halidom level to after SaveChangesAsync in LevelupAtOnce and LevelupEnd. This should cause the levels to be up to date if the building being levelled up is the halidom or smithy.
- Write new method to get these core levels instead of querying all builds