### PR TITLE
Use Respawn to clear up databases in tests

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/AbilityCrestTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/AbilityCrestTest.cs
@@ -13,10 +13,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class AbilityCrestTest : TestFixture
 {
-    public AbilityCrestTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public AbilityCrestTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
@@ -7,10 +7,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class CastleStoryTest : TestFixture
 {
-    public CastleStoryTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public CastleStoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyIgnoreOwnerOptions();

--- a/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
@@ -17,7 +17,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class CharaTest : TestFixture
 {
-    public CharaTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public CharaTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.AddCharacter(Charas.Naveed);

--- a/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -16,7 +16,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class DragonTest : TestFixture
 {
-    public DragonTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public DragonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     public record DragonBuildUpTestCase(

--- a/DragaliaAPI.Integration.Test/Dragalia/DungeonTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/DungeonTest.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class DungeonTest : TestFixture
 {
-    public DungeonTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public DungeonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
@@ -8,7 +8,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class EulaTest : TestFixture
 {
-    public EulaTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public EulaTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
@@ -11,7 +11,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class FriendTest : TestFixture
 {
-    public FriendTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public FriendTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
@@ -5,10 +5,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class GetDeployVersionTest : TestFixture
 {
-    public GetDeployVersionTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public GetDeployVersionTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
@@ -37,7 +37,7 @@ public class MatchingTest : TestFixture
                             new()
                             {
                                 ActorNr = 1,
-                                ViewerId = 1,
+                                ViewerId = ViewerId,
                                 PartyNoList = new List<int>() { 1 }
                             }
                         },
@@ -77,7 +77,7 @@ public class MatchingTest : TestFixture
                             status = RoomStatuses.Available,
                             entry_type = 1,
                             entry_guild_id = 0,
-                            host_viewer_id = ViewerId,
+                            host_viewer_id = (ulong)ViewerId,
                             host_name = "Euden",
                             host_level = 250,
                             leader_chara_id = Charas.ThePrince,
@@ -87,7 +87,7 @@ public class MatchingTest : TestFixture
                             quest_type = QuestTypes.Dungeon,
                             room_member_list = new List<AtgenRoomMemberList>()
                             {
-                                new() { viewer_id = 1, }
+                                new() { viewer_id = (ulong)ViewerId, }
                             },
                             start_entry_time = DateTimeOffset.FromUnixTimeSeconds(1662160789),
                             entry_conditions = new()
@@ -123,7 +123,7 @@ public class MatchingTest : TestFixture
                             new()
                             {
                                 ActorNr = 1,
-                                ViewerId = 1,
+                                ViewerId = ViewerId,
                                 PartyNoList = new List<int>() { 1 }
                             }
                         },
@@ -167,7 +167,7 @@ public class MatchingTest : TestFixture
                             status = RoomStatuses.Available,
                             entry_type = 1,
                             entry_guild_id = 0,
-                            host_viewer_id = ViewerId,
+                            host_viewer_id = (ulong)ViewerId,
                             host_name = "Euden",
                             host_level = 250,
                             leader_chara_id = Charas.ThePrince,
@@ -177,7 +177,7 @@ public class MatchingTest : TestFixture
                             quest_type = QuestTypes.Dungeon,
                             room_member_list = new List<AtgenRoomMemberList>()
                             {
-                                new() { viewer_id = 1, }
+                                new() { viewer_id = (ulong)ViewerId, }
                             },
                             start_entry_time = DateTimeOffset.FromUnixTimeSeconds(1662160789),
                             entry_conditions = new()
@@ -211,7 +211,7 @@ public class MatchingTest : TestFixture
                         new()
                         {
                             ActorNr = 1,
-                            ViewerId = 1,
+                            ViewerId = ViewerId,
                             PartyNoList = new List<int>() { 1 }
                         }
                     },
@@ -248,7 +248,7 @@ public class MatchingTest : TestFixture
                         status = RoomStatuses.Available,
                         entry_type = 1,
                         entry_guild_id = 0,
-                        host_viewer_id = ViewerId,
+                        host_viewer_id = (ulong)ViewerId,
                         host_name = "Euden",
                         host_level = 250,
                         leader_chara_id = Charas.ThePrince,
@@ -258,7 +258,7 @@ public class MatchingTest : TestFixture
                         quest_type = QuestTypes.Dungeon,
                         room_member_list = new List<AtgenRoomMemberList>()
                         {
-                            new() { viewer_id = 1, }
+                            new() { viewer_id = (ulong)ViewerId, }
                         },
                         start_entry_time = DateTimeOffset.FromUnixTimeSeconds(1662160789),
                         entry_conditions = new()

--- a/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
@@ -13,10 +13,7 @@ public class MatchingTest : TestFixture
 {
     private const string EndpointGroup = "/matching";
 
-    public MatchingTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public MatchingTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.MockPhotonStateApi.Reset();
@@ -80,7 +77,7 @@ public class MatchingTest : TestFixture
                             status = RoomStatuses.Available,
                             entry_type = 1,
                             entry_guild_id = 0,
-                            host_viewer_id = 1,
+                            host_viewer_id = ViewerId,
                             host_name = "Euden",
                             host_level = 250,
                             leader_chara_id = Charas.ThePrince,
@@ -170,7 +167,7 @@ public class MatchingTest : TestFixture
                             status = RoomStatuses.Available,
                             entry_type = 1,
                             entry_guild_id = 0,
-                            host_viewer_id = 1,
+                            host_viewer_id = ViewerId,
                             host_name = "Euden",
                             host_level = 250,
                             leader_chara_id = Charas.ThePrince,
@@ -251,7 +248,7 @@ public class MatchingTest : TestFixture
                         status = RoomStatuses.Available,
                         entry_type = 1,
                         entry_guild_id = 0,
-                        host_viewer_id = 1,
+                        host_viewer_id = ViewerId,
                         host_name = "Euden",
                         host_level = 250,
                         leader_chara_id = Charas.ThePrince,

--- a/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -13,7 +13,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class PartyTest : TestFixture
 {
-    public PartyTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public PartyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/QuestClearPartyTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/QuestClearPartyTest.cs
@@ -41,7 +41,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
     {
         this.ImportSave();
 
-        await this.AddRangeToDatabase(multiDbEntities);
+        await this.AddRangeToDatabase(MultiDbEntities);
 
         DragaliaResponse<QuestGetQuestClearPartyMultiData> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyMultiData>(
@@ -51,7 +51,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
 
         response.data.quest_multi_clear_party_setting_list
             .Should()
-            .BeEquivalentTo(multiPartySettingLists);
+            .BeEquivalentTo(MultiPartySettingLists);
         response.data.lost_unit_list.Should().BeEmpty();
     }
 
@@ -65,7 +65,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             new QuestSetQuestClearPartyRequest()
             {
                 quest_id = questId,
-                request_party_setting_list = multiPartySettingLists
+                request_party_setting_list = MultiPartySettingLists
             }
         );
 
@@ -83,9 +83,9 @@ public class QuestClearPartyTest : TestFixture, IDisposable
     {
         this.ImportSave();
 
-        int questId = missingItemDbEntities[0].QuestId;
+        int questId = MissingItemDbEntities[0].QuestId;
 
-        await this.AddRangeToDatabase(missingItemDbEntities);
+        await this.AddRangeToDatabase(MissingItemDbEntities);
 
         DragaliaResponse<QuestGetQuestClearPartyData> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyData>(
@@ -187,7 +187,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 new QuestSetQuestClearPartyRequest()
                 {
                     quest_id = 4,
-                    request_party_setting_list = multiPartySettingLists
+                    request_party_setting_list = MultiPartySettingLists
                 }
             );
 
@@ -197,7 +197,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             .Where(x => x.QuestId == 4 && x.DeviceAccountId == DeviceAccountId && x.IsMulti == true)
             .ToListAsync();
 
-        storedList.Should().BeEquivalentTo(multiDbEntities, opts => opts.Excluding(x => x.QuestId));
+        storedList.Should().BeEquivalentTo(MultiDbEntities, opts => opts.Excluding(x => x.QuestId));
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(4));
     }
 
@@ -220,7 +220,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 EquipCrestSlotType2CrestId2 = AbilityCrests.TotheExtreme,
                 EquipCrestSlotType3CrestId1 = AbilityCrests.CrownofLightSerpentsBoon,
                 EquipCrestSlotType3CrestId2 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                EquipTalismanKeyId = 1,
+                EquipTalismanKeyId = GetTalismanKeyId(Talismans.GalaMym),
                 EquipWeaponSkinId = 30129901,
                 EditSkill1CharaId = Charas.Empty,
                 EditSkill2CharaId = Charas.GalaMym,
@@ -243,7 +243,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 EquipCrestSlotType2CrestId2 = AbilityCrests.LuckoftheDraw,
                 EquipCrestSlotType3CrestId1 = AbilityCrests.RavenousFireCrownsBoon,
                 EquipCrestSlotType3CrestId2 = AbilityCrests.PromisedPietyStaffsBoon,
-                EquipTalismanKeyId = 2,
+                EquipTalismanKeyId = GetTalismanKeyId(Talismans.GalaMym),
                 EquipWeaponSkinId = 30129901,
                 EditSkill1CharaId = Charas.TemplarHope,
                 EditSkill2CharaId = Charas.Zena,
@@ -268,7 +268,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 equip_crest_slot_type_2_crest_id_2 = AbilityCrests.TotheExtreme,
                 equip_crest_slot_type_3_crest_id_1 = AbilityCrests.CrownofLightSerpentsBoon,
                 equip_crest_slot_type_3_crest_id_2 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                equip_talisman_key_id = 1,
+                equip_talisman_key_id = (ulong)GetTalismanKeyId(Talismans.GalaMym),
                 equip_weapon_skin_id = 30129901,
                 edit_skill_1_chara_id = Charas.Empty,
                 edit_skill_2_chara_id = Charas.GalaMym,
@@ -286,14 +286,14 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 equip_crest_slot_type_2_crest_id_2 = AbilityCrests.LuckoftheDraw,
                 equip_crest_slot_type_3_crest_id_1 = AbilityCrests.RavenousFireCrownsBoon,
                 equip_crest_slot_type_3_crest_id_2 = AbilityCrests.PromisedPietyStaffsBoon,
-                equip_talisman_key_id = 2,
+                equip_talisman_key_id = (ulong)GetTalismanKeyId(Talismans.GalaMym),
                 equip_weapon_skin_id = 30129901,
                 edit_skill_1_chara_id = Charas.TemplarHope,
                 edit_skill_2_chara_id = Charas.Zena,
             }
         };
 
-    private List<DbQuestClearPartyUnit> multiDbEntities =>
+    private List<DbQuestClearPartyUnit> MultiDbEntities =>
         new()
         {
             new()
@@ -312,7 +312,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 EquipCrestSlotType2CrestId2 = AbilityCrests.DragonsNest,
                 EquipCrestSlotType3CrestId1 = AbilityCrests.TutelarysDestinyWolfsBoon,
                 EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
-                EquipTalismanKeyId = 3,
+                EquipTalismanKeyId = GetTalismanKeyId(Talismans.GalaMym),
                 EquipWeaponSkinId = 0,
                 EditSkill1CharaId = Charas.Empty,
                 EditSkill2CharaId = Charas.GalaMym,
@@ -326,7 +326,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 QuestId = 2,
                 UnitNo = 2,
                 CharaId = Charas.GalaLeif,
-                EquipDragonKeyId = 4,
+                EquipDragonKeyId = GetDragonKeyId(Dragons.Phoenix),
                 EquipWeaponBodyId = WeaponBodies.PrimalTempest,
                 EquipCrestSlotType1CrestId1 = AbilityCrests.AdventureinthePast,
                 EquipCrestSlotType1CrestId2 = AbilityCrests.PrimalCrisis,
@@ -335,7 +335,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 EquipCrestSlotType2CrestId2 = AbilityCrests.ThePlaguebringer,
                 EquipCrestSlotType3CrestId1 = AbilityCrests.AKnightsDreamAxesBoon,
                 EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
-                EquipTalismanKeyId = 4,
+                EquipTalismanKeyId = GetTalismanKeyId(Talismans.GalaMym),
                 EquipWeaponSkinId = 0,
                 EditSkill1CharaId = Charas.ShaWujing,
                 EditSkill2CharaId = Charas.Ranzal,
@@ -344,14 +344,14 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             }
         };
 
-    private readonly List<PartySettingList> multiPartySettingLists =
+    private List<PartySettingList> MultiPartySettingLists =>
         new()
         {
             new()
             {
                 unit_no = 1,
                 chara_id = Charas.GalaNotte,
-                equip_dragon_key_id = 3,
+                equip_dragon_key_id = (ulong)GetDragonKeyId(Dragons.Leviathan),
                 equip_weapon_body_id = WeaponBodies.WindrulersFang,
                 equip_crest_slot_type_1_crest_id_1 = AbilityCrests.BondsBetweenWorlds,
                 equip_crest_slot_type_1_crest_id_2 = AbilityCrests.AManUnchanging,
@@ -360,7 +360,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 equip_crest_slot_type_2_crest_id_2 = AbilityCrests.DragonsNest,
                 equip_crest_slot_type_3_crest_id_1 = AbilityCrests.TutelarysDestinyWolfsBoon,
                 equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
-                equip_talisman_key_id = 3,
+                equip_talisman_key_id = (ulong)GetTalismanKeyId(Talismans.GalaMym),
                 equip_weapon_skin_id = 0,
                 edit_skill_1_chara_id = Charas.Empty,
                 edit_skill_2_chara_id = Charas.GalaMym,
@@ -369,7 +369,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             {
                 unit_no = 2,
                 chara_id = Charas.GalaLeif,
-                equip_dragon_key_id = 4,
+                equip_dragon_key_id = (ulong)GetDragonKeyId(Dragons.Phoenix),
                 equip_weapon_body_id = WeaponBodies.PrimalTempest,
                 equip_crest_slot_type_1_crest_id_1 = AbilityCrests.AdventureinthePast,
                 equip_crest_slot_type_1_crest_id_2 = AbilityCrests.PrimalCrisis,
@@ -378,14 +378,14 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 equip_crest_slot_type_2_crest_id_2 = AbilityCrests.ThePlaguebringer,
                 equip_crest_slot_type_3_crest_id_1 = AbilityCrests.AKnightsDreamAxesBoon,
                 equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
-                equip_talisman_key_id = 4,
+                equip_talisman_key_id = (ulong)GetTalismanKeyId(Talismans.GalaMym),
                 equip_weapon_skin_id = 0,
                 edit_skill_1_chara_id = Charas.ShaWujing,
                 edit_skill_2_chara_id = Charas.Ranzal,
             }
         };
 
-    private List<DbQuestClearPartyUnit> missingItemDbEntities =
+    private List<DbQuestClearPartyUnit> MissingItemDbEntities =>
         new()
         {
             new()

--- a/DragaliaAPI.Integration.Test/Dragalia/QuestClearPartyTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/QuestClearPartyTest.cs
@@ -13,10 +13,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class QuestClearPartyTest : TestFixture, IDisposable
 {
-    public QuestClearPartyTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public QuestClearPartyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyIgnoreOwnerOptions();
@@ -27,7 +24,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
     {
         this.ImportSave();
 
-        await this.AddRangeToDatabase(TestData.SoloDbEntities);
+        await this.AddRangeToDatabase(SoloDbEntities);
 
         DragaliaResponse<QuestGetQuestClearPartyData> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyData>(
@@ -35,9 +32,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 new QuestGetQuestClearPartyRequest() { quest_id = 1 }
             );
 
-        response.data.quest_clear_party_setting_list
-            .Should()
-            .BeEquivalentTo(TestData.SoloPartySettingLists);
+        response.data.quest_clear_party_setting_list.Should().BeEquivalentTo(SoloPartySettingLists);
         response.data.lost_unit_list.Should().BeEmpty();
     }
 
@@ -46,7 +41,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
     {
         this.ImportSave();
 
-        await this.AddRangeToDatabase(TestData.MultiDbEntities);
+        await this.AddRangeToDatabase(multiDbEntities);
 
         DragaliaResponse<QuestGetQuestClearPartyMultiData> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyMultiData>(
@@ -56,7 +51,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
 
         response.data.quest_multi_clear_party_setting_list
             .Should()
-            .BeEquivalentTo(TestData.MultiPartySettingLists);
+            .BeEquivalentTo(multiPartySettingLists);
         response.data.lost_unit_list.Should().BeEmpty();
     }
 
@@ -70,7 +65,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             new QuestSetQuestClearPartyRequest()
             {
                 quest_id = questId,
-                request_party_setting_list = TestData.MultiPartySettingLists
+                request_party_setting_list = multiPartySettingLists
             }
         );
 
@@ -88,9 +83,9 @@ public class QuestClearPartyTest : TestFixture, IDisposable
     {
         this.ImportSave();
 
-        int questId = TestData.MissingItemDbEntities[0].QuestId;
+        int questId = missingItemDbEntities[0].QuestId;
 
-        await this.AddRangeToDatabase(TestData.MissingItemDbEntities);
+        await this.AddRangeToDatabase(missingItemDbEntities);
 
         DragaliaResponse<QuestGetQuestClearPartyData> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyData>(
@@ -165,7 +160,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 new QuestSetQuestClearPartyRequest()
                 {
                     quest_id = 3,
-                    request_party_setting_list = TestData.SoloPartySettingLists
+                    request_party_setting_list = SoloPartySettingLists
                 }
             );
 
@@ -177,9 +172,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             )
             .ToListAsync();
 
-        storedList
-            .Should()
-            .BeEquivalentTo(TestData.SoloDbEntities, opts => opts.Excluding(x => x.QuestId));
+        storedList.Should().BeEquivalentTo(SoloDbEntities, opts => opts.Excluding(x => x.QuestId));
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(3));
     }
 
@@ -194,7 +187,7 @@ public class QuestClearPartyTest : TestFixture, IDisposable
                 new QuestSetQuestClearPartyRequest()
                 {
                     quest_id = 4,
-                    request_party_setting_list = TestData.MultiPartySettingLists
+                    request_party_setting_list = multiPartySettingLists
                 }
             );
 
@@ -204,268 +197,263 @@ public class QuestClearPartyTest : TestFixture, IDisposable
             .Where(x => x.QuestId == 4 && x.DeviceAccountId == DeviceAccountId && x.IsMulti == true)
             .ToListAsync();
 
-        storedList
-            .Should()
-            .BeEquivalentTo(TestData.MultiDbEntities, opts => opts.Excluding(x => x.QuestId));
+        storedList.Should().BeEquivalentTo(multiDbEntities, opts => opts.Excluding(x => x.QuestId));
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(4));
     }
 
-    private static class TestData
-    {
-        public static readonly List<DbQuestClearPartyUnit> SoloDbEntities =
+    private List<DbQuestClearPartyUnit> SoloDbEntities =>
+        new()
+        {
             new()
             {
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    IsMulti = false,
-                    QuestId = 1,
-                    UnitNo = 1,
-                    CharaId = Charas.GalaNedrick,
-                    EquipDragonKeyId = 1,
-                    EquipWeaponBodyId = WeaponBodies.YitianJian,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.PrimalCrisis,
-                    EquipCrestSlotType1CrestId2 = AbilityCrests.WelcometotheOpera,
-                    EquipCrestSlotType1CrestId3 = AbilityCrests.FelyneHospitality,
-                    EquipCrestSlotType2CrestId1 = AbilityCrests.ThePlaguebringer,
-                    EquipCrestSlotType2CrestId2 = AbilityCrests.TotheExtreme,
-                    EquipCrestSlotType3CrestId1 = AbilityCrests.CrownofLightSerpentsBoon,
-                    EquipCrestSlotType3CrestId2 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                    EquipTalismanKeyId = 1,
-                    EquipWeaponSkinId = 30129901,
-                    EditSkill1CharaId = Charas.Empty,
-                    EditSkill2CharaId = Charas.GalaMym,
-                    EquippedDragonEntityId = Dragons.Cerberus,
-                    EquippedTalismanEntityId = Talismans.GalaMym,
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    IsMulti = false,
-                    QuestId = 1,
-                    UnitNo = 2,
-                    CharaId = Charas.Patia,
-                    EquipDragonKeyId = 2,
-                    EquipWeaponBodyId = WeaponBodies.QinglongYanyuedao,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.AHalloweenSpectacular,
-                    EquipCrestSlotType1CrestId2 = AbilityCrests.CastawaysJournal,
-                    EquipCrestSlotType1CrestId3 = AbilityCrests.TheChocolatiers,
-                    EquipCrestSlotType2CrestId1 = AbilityCrests.RoguesBanquet,
-                    EquipCrestSlotType2CrestId2 = AbilityCrests.LuckoftheDraw,
-                    EquipCrestSlotType3CrestId1 = AbilityCrests.RavenousFireCrownsBoon,
-                    EquipCrestSlotType3CrestId2 = AbilityCrests.PromisedPietyStaffsBoon,
-                    EquipTalismanKeyId = 2,
-                    EquipWeaponSkinId = 30129901,
-                    EditSkill1CharaId = Charas.TemplarHope,
-                    EditSkill2CharaId = Charas.Zena,
-                    EquippedDragonEntityId = Dragons.Pazuzu,
-                    EquippedTalismanEntityId = Talismans.GalaMym
-                }
-            };
+                DeviceAccountId = DeviceAccountId,
+                IsMulti = false,
+                QuestId = 1,
+                UnitNo = 1,
+                CharaId = Charas.GalaNedrick,
+                EquipDragonKeyId = GetDragonKeyId(Dragons.Cerberus),
+                EquipWeaponBodyId = WeaponBodies.YitianJian,
+                EquipCrestSlotType1CrestId1 = AbilityCrests.PrimalCrisis,
+                EquipCrestSlotType1CrestId2 = AbilityCrests.WelcometotheOpera,
+                EquipCrestSlotType1CrestId3 = AbilityCrests.FelyneHospitality,
+                EquipCrestSlotType2CrestId1 = AbilityCrests.ThePlaguebringer,
+                EquipCrestSlotType2CrestId2 = AbilityCrests.TotheExtreme,
+                EquipCrestSlotType3CrestId1 = AbilityCrests.CrownofLightSerpentsBoon,
+                EquipCrestSlotType3CrestId2 = AbilityCrests.TutelarysDestinyWolfsBoon,
+                EquipTalismanKeyId = 1,
+                EquipWeaponSkinId = 30129901,
+                EditSkill1CharaId = Charas.Empty,
+                EditSkill2CharaId = Charas.GalaMym,
+                EquippedDragonEntityId = Dragons.Cerberus,
+                EquippedTalismanEntityId = Talismans.GalaMym,
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                IsMulti = false,
+                QuestId = 1,
+                UnitNo = 2,
+                CharaId = Charas.Patia,
+                EquipDragonKeyId = GetDragonKeyId(Dragons.Pazuzu),
+                EquipWeaponBodyId = WeaponBodies.QinglongYanyuedao,
+                EquipCrestSlotType1CrestId1 = AbilityCrests.AHalloweenSpectacular,
+                EquipCrestSlotType1CrestId2 = AbilityCrests.CastawaysJournal,
+                EquipCrestSlotType1CrestId3 = AbilityCrests.TheChocolatiers,
+                EquipCrestSlotType2CrestId1 = AbilityCrests.RoguesBanquet,
+                EquipCrestSlotType2CrestId2 = AbilityCrests.LuckoftheDraw,
+                EquipCrestSlotType3CrestId1 = AbilityCrests.RavenousFireCrownsBoon,
+                EquipCrestSlotType3CrestId2 = AbilityCrests.PromisedPietyStaffsBoon,
+                EquipTalismanKeyId = 2,
+                EquipWeaponSkinId = 30129901,
+                EditSkill1CharaId = Charas.TemplarHope,
+                EditSkill2CharaId = Charas.Zena,
+                EquippedDragonEntityId = Dragons.Pazuzu,
+                EquippedTalismanEntityId = Talismans.GalaMym
+            }
+        };
 
-        public static readonly List<PartySettingList> SoloPartySettingLists =
+    private List<PartySettingList> SoloPartySettingLists =>
+        new()
+        {
             new()
             {
-                new()
-                {
-                    unit_no = 1,
-                    chara_id = Charas.GalaNedrick,
-                    equip_dragon_key_id = 1,
-                    equip_weapon_body_id = WeaponBodies.YitianJian,
-                    equip_crest_slot_type_1_crest_id_1 = AbilityCrests.PrimalCrisis,
-                    equip_crest_slot_type_1_crest_id_2 = AbilityCrests.WelcometotheOpera,
-                    equip_crest_slot_type_1_crest_id_3 = AbilityCrests.FelyneHospitality,
-                    equip_crest_slot_type_2_crest_id_1 = AbilityCrests.ThePlaguebringer,
-                    equip_crest_slot_type_2_crest_id_2 = AbilityCrests.TotheExtreme,
-                    equip_crest_slot_type_3_crest_id_1 = AbilityCrests.CrownofLightSerpentsBoon,
-                    equip_crest_slot_type_3_crest_id_2 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                    equip_talisman_key_id = 1,
-                    equip_weapon_skin_id = 30129901,
-                    edit_skill_1_chara_id = Charas.Empty,
-                    edit_skill_2_chara_id = Charas.GalaMym,
-                },
-                new()
-                {
-                    unit_no = 2,
-                    chara_id = Charas.Patia,
-                    equip_dragon_key_id = 2,
-                    equip_weapon_body_id = WeaponBodies.QinglongYanyuedao,
-                    equip_crest_slot_type_1_crest_id_1 = AbilityCrests.AHalloweenSpectacular,
-                    equip_crest_slot_type_1_crest_id_2 = AbilityCrests.CastawaysJournal,
-                    equip_crest_slot_type_1_crest_id_3 = AbilityCrests.TheChocolatiers,
-                    equip_crest_slot_type_2_crest_id_1 = AbilityCrests.RoguesBanquet,
-                    equip_crest_slot_type_2_crest_id_2 = AbilityCrests.LuckoftheDraw,
-                    equip_crest_slot_type_3_crest_id_1 = AbilityCrests.RavenousFireCrownsBoon,
-                    equip_crest_slot_type_3_crest_id_2 = AbilityCrests.PromisedPietyStaffsBoon,
-                    equip_talisman_key_id = 2,
-                    equip_weapon_skin_id = 30129901,
-                    edit_skill_1_chara_id = Charas.TemplarHope,
-                    edit_skill_2_chara_id = Charas.Zena,
-                }
-            };
+                unit_no = 1,
+                chara_id = Charas.GalaNedrick,
+                equip_dragon_key_id = (ulong)GetDragonKeyId(Dragons.Cerberus),
+                equip_weapon_body_id = WeaponBodies.YitianJian,
+                equip_crest_slot_type_1_crest_id_1 = AbilityCrests.PrimalCrisis,
+                equip_crest_slot_type_1_crest_id_2 = AbilityCrests.WelcometotheOpera,
+                equip_crest_slot_type_1_crest_id_3 = AbilityCrests.FelyneHospitality,
+                equip_crest_slot_type_2_crest_id_1 = AbilityCrests.ThePlaguebringer,
+                equip_crest_slot_type_2_crest_id_2 = AbilityCrests.TotheExtreme,
+                equip_crest_slot_type_3_crest_id_1 = AbilityCrests.CrownofLightSerpentsBoon,
+                equip_crest_slot_type_3_crest_id_2 = AbilityCrests.TutelarysDestinyWolfsBoon,
+                equip_talisman_key_id = 1,
+                equip_weapon_skin_id = 30129901,
+                edit_skill_1_chara_id = Charas.Empty,
+                edit_skill_2_chara_id = Charas.GalaMym,
+            },
+            new()
+            {
+                unit_no = 2,
+                chara_id = Charas.Patia,
+                equip_dragon_key_id = (ulong)GetDragonKeyId(Dragons.Pazuzu),
+                equip_weapon_body_id = WeaponBodies.QinglongYanyuedao,
+                equip_crest_slot_type_1_crest_id_1 = AbilityCrests.AHalloweenSpectacular,
+                equip_crest_slot_type_1_crest_id_2 = AbilityCrests.CastawaysJournal,
+                equip_crest_slot_type_1_crest_id_3 = AbilityCrests.TheChocolatiers,
+                equip_crest_slot_type_2_crest_id_1 = AbilityCrests.RoguesBanquet,
+                equip_crest_slot_type_2_crest_id_2 = AbilityCrests.LuckoftheDraw,
+                equip_crest_slot_type_3_crest_id_1 = AbilityCrests.RavenousFireCrownsBoon,
+                equip_crest_slot_type_3_crest_id_2 = AbilityCrests.PromisedPietyStaffsBoon,
+                equip_talisman_key_id = 2,
+                equip_weapon_skin_id = 30129901,
+                edit_skill_1_chara_id = Charas.TemplarHope,
+                edit_skill_2_chara_id = Charas.Zena,
+            }
+        };
 
-        public static readonly List<DbQuestClearPartyUnit> MultiDbEntities =
+    private List<DbQuestClearPartyUnit> multiDbEntities =>
+        new()
+        {
             new()
             {
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    IsMulti = true,
-                    QuestId = 2,
-                    UnitNo = 1,
-                    CharaId = Charas.GalaNotte,
-                    EquipDragonKeyId = 3,
-                    EquipWeaponBodyId = WeaponBodies.WindrulersFang,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.BondsBetweenWorlds,
-                    EquipCrestSlotType1CrestId2 = AbilityCrests.AManUnchanging,
-                    EquipCrestSlotType1CrestId3 = AbilityCrests.GoingUndercover,
-                    EquipCrestSlotType2CrestId1 = AbilityCrests.APassionforProduce,
-                    EquipCrestSlotType2CrestId2 = AbilityCrests.DragonsNest,
-                    EquipCrestSlotType3CrestId1 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                    EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
-                    EquipTalismanKeyId = 3,
-                    EquipWeaponSkinId = 0,
-                    EditSkill1CharaId = Charas.Empty,
-                    EditSkill2CharaId = Charas.GalaMym,
-                    EquippedDragonEntityId = Dragons.Leviathan,
-                    EquippedTalismanEntityId = Talismans.GalaMym
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    IsMulti = true,
-                    QuestId = 2,
-                    UnitNo = 2,
-                    CharaId = Charas.GalaLeif,
-                    EquipDragonKeyId = 4,
-                    EquipWeaponBodyId = WeaponBodies.PrimalTempest,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.AdventureinthePast,
-                    EquipCrestSlotType1CrestId2 = AbilityCrests.PrimalCrisis,
-                    EquipCrestSlotType1CrestId3 = AbilityCrests.GoingUndercover,
-                    EquipCrestSlotType2CrestId1 = AbilityCrests.DragonsNest,
-                    EquipCrestSlotType2CrestId2 = AbilityCrests.ThePlaguebringer,
-                    EquipCrestSlotType3CrestId1 = AbilityCrests.AKnightsDreamAxesBoon,
-                    EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
-                    EquipTalismanKeyId = 4,
-                    EquipWeaponSkinId = 0,
-                    EditSkill1CharaId = Charas.ShaWujing,
-                    EditSkill2CharaId = Charas.Ranzal,
-                    EquippedDragonEntityId = Dragons.Phoenix,
-                    EquippedTalismanEntityId = Talismans.GalaMym
-                }
-            };
+                DeviceAccountId = DeviceAccountId,
+                IsMulti = true,
+                QuestId = 2,
+                UnitNo = 1,
+                CharaId = Charas.GalaNotte,
+                EquipDragonKeyId = GetDragonKeyId(Dragons.Leviathan),
+                EquipWeaponBodyId = WeaponBodies.WindrulersFang,
+                EquipCrestSlotType1CrestId1 = AbilityCrests.BondsBetweenWorlds,
+                EquipCrestSlotType1CrestId2 = AbilityCrests.AManUnchanging,
+                EquipCrestSlotType1CrestId3 = AbilityCrests.GoingUndercover,
+                EquipCrestSlotType2CrestId1 = AbilityCrests.APassionforProduce,
+                EquipCrestSlotType2CrestId2 = AbilityCrests.DragonsNest,
+                EquipCrestSlotType3CrestId1 = AbilityCrests.TutelarysDestinyWolfsBoon,
+                EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
+                EquipTalismanKeyId = 3,
+                EquipWeaponSkinId = 0,
+                EditSkill1CharaId = Charas.Empty,
+                EditSkill2CharaId = Charas.GalaMym,
+                EquippedDragonEntityId = Dragons.Leviathan,
+                EquippedTalismanEntityId = Talismans.GalaMym
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                IsMulti = true,
+                QuestId = 2,
+                UnitNo = 2,
+                CharaId = Charas.GalaLeif,
+                EquipDragonKeyId = 4,
+                EquipWeaponBodyId = WeaponBodies.PrimalTempest,
+                EquipCrestSlotType1CrestId1 = AbilityCrests.AdventureinthePast,
+                EquipCrestSlotType1CrestId2 = AbilityCrests.PrimalCrisis,
+                EquipCrestSlotType1CrestId3 = AbilityCrests.GoingUndercover,
+                EquipCrestSlotType2CrestId1 = AbilityCrests.DragonsNest,
+                EquipCrestSlotType2CrestId2 = AbilityCrests.ThePlaguebringer,
+                EquipCrestSlotType3CrestId1 = AbilityCrests.AKnightsDreamAxesBoon,
+                EquipCrestSlotType3CrestId2 = AbilityCrests.CrownofLightSerpentsBoon,
+                EquipTalismanKeyId = 4,
+                EquipWeaponSkinId = 0,
+                EditSkill1CharaId = Charas.ShaWujing,
+                EditSkill2CharaId = Charas.Ranzal,
+                EquippedDragonEntityId = Dragons.Phoenix,
+                EquippedTalismanEntityId = Talismans.GalaMym
+            }
+        };
 
-        public static readonly List<PartySettingList> MultiPartySettingLists =
+    private readonly List<PartySettingList> multiPartySettingLists =
+        new()
+        {
             new()
             {
-                new()
-                {
-                    unit_no = 1,
-                    chara_id = Charas.GalaNotte,
-                    equip_dragon_key_id = 3,
-                    equip_weapon_body_id = WeaponBodies.WindrulersFang,
-                    equip_crest_slot_type_1_crest_id_1 = AbilityCrests.BondsBetweenWorlds,
-                    equip_crest_slot_type_1_crest_id_2 = AbilityCrests.AManUnchanging,
-                    equip_crest_slot_type_1_crest_id_3 = AbilityCrests.GoingUndercover,
-                    equip_crest_slot_type_2_crest_id_1 = AbilityCrests.APassionforProduce,
-                    equip_crest_slot_type_2_crest_id_2 = AbilityCrests.DragonsNest,
-                    equip_crest_slot_type_3_crest_id_1 = AbilityCrests.TutelarysDestinyWolfsBoon,
-                    equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
-                    equip_talisman_key_id = 3,
-                    equip_weapon_skin_id = 0,
-                    edit_skill_1_chara_id = Charas.Empty,
-                    edit_skill_2_chara_id = Charas.GalaMym,
-                },
-                new()
-                {
-                    unit_no = 2,
-                    chara_id = Charas.GalaLeif,
-                    equip_dragon_key_id = 4,
-                    equip_weapon_body_id = WeaponBodies.PrimalTempest,
-                    equip_crest_slot_type_1_crest_id_1 = AbilityCrests.AdventureinthePast,
-                    equip_crest_slot_type_1_crest_id_2 = AbilityCrests.PrimalCrisis,
-                    equip_crest_slot_type_1_crest_id_3 = AbilityCrests.GoingUndercover,
-                    equip_crest_slot_type_2_crest_id_1 = AbilityCrests.DragonsNest,
-                    equip_crest_slot_type_2_crest_id_2 = AbilityCrests.ThePlaguebringer,
-                    equip_crest_slot_type_3_crest_id_1 = AbilityCrests.AKnightsDreamAxesBoon,
-                    equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
-                    equip_talisman_key_id = 4,
-                    equip_weapon_skin_id = 0,
-                    edit_skill_1_chara_id = Charas.ShaWujing,
-                    edit_skill_2_chara_id = Charas.Ranzal,
-                }
-            };
+                unit_no = 1,
+                chara_id = Charas.GalaNotte,
+                equip_dragon_key_id = 3,
+                equip_weapon_body_id = WeaponBodies.WindrulersFang,
+                equip_crest_slot_type_1_crest_id_1 = AbilityCrests.BondsBetweenWorlds,
+                equip_crest_slot_type_1_crest_id_2 = AbilityCrests.AManUnchanging,
+                equip_crest_slot_type_1_crest_id_3 = AbilityCrests.GoingUndercover,
+                equip_crest_slot_type_2_crest_id_1 = AbilityCrests.APassionforProduce,
+                equip_crest_slot_type_2_crest_id_2 = AbilityCrests.DragonsNest,
+                equip_crest_slot_type_3_crest_id_1 = AbilityCrests.TutelarysDestinyWolfsBoon,
+                equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
+                equip_talisman_key_id = 3,
+                equip_weapon_skin_id = 0,
+                edit_skill_1_chara_id = Charas.Empty,
+                edit_skill_2_chara_id = Charas.GalaMym,
+            },
+            new()
+            {
+                unit_no = 2,
+                chara_id = Charas.GalaLeif,
+                equip_dragon_key_id = 4,
+                equip_weapon_body_id = WeaponBodies.PrimalTempest,
+                equip_crest_slot_type_1_crest_id_1 = AbilityCrests.AdventureinthePast,
+                equip_crest_slot_type_1_crest_id_2 = AbilityCrests.PrimalCrisis,
+                equip_crest_slot_type_1_crest_id_3 = AbilityCrests.GoingUndercover,
+                equip_crest_slot_type_2_crest_id_1 = AbilityCrests.DragonsNest,
+                equip_crest_slot_type_2_crest_id_2 = AbilityCrests.ThePlaguebringer,
+                equip_crest_slot_type_3_crest_id_1 = AbilityCrests.AKnightsDreamAxesBoon,
+                equip_crest_slot_type_3_crest_id_2 = AbilityCrests.CrownofLightSerpentsBoon,
+                equip_talisman_key_id = 4,
+                equip_weapon_skin_id = 0,
+                edit_skill_1_chara_id = Charas.ShaWujing,
+                edit_skill_2_chara_id = Charas.Ranzal,
+            }
+        };
 
-        public static List<DbQuestClearPartyUnit> MissingItemDbEntities =
+    private List<DbQuestClearPartyUnit> missingItemDbEntities =
+        new()
+        {
             new()
             {
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 1,
-                    QuestId = 6,
-                    IsMulti = false,
-                    CharaId = Charas.Basileus,
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 2,
-                    QuestId = 6,
-                    IsMulti = false,
-                    CharaId = Charas.Cecile,
-                    EquipCrestSlotType1CrestId1 = AbilityCrests.InanUnendingWorld
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 3,
-                    QuestId = 6,
-                    IsMulti = false,
-                    CharaId = Charas.Durant,
-                    EquipWeaponBodyId = WeaponBodies.PrimalAqua,
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 4,
-                    QuestId = 6,
-                    IsMulti = false,
-                    CharaId = Charas.Elias,
-                    EquipWeaponSkinId = 1000,
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 5,
-                    QuestId = 6,
-                    IsMulti = false,
-                    EquipDragonKeyId = 2000,
-                    CharaId = Charas.Emma,
-                    EquippedDragonEntityId = Dragons.Ifrit,
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 6,
-                    QuestId = 6,
-                    IsMulti = false,
-                    EquipTalismanKeyId = 3000,
-                    CharaId = Charas.Raemond,
-                    EquippedTalismanEntityId = Talismans.Raemond
-                },
-                new()
-                {
-                    DeviceAccountId = DeviceAccountId,
-                    UnitNo = 7,
-                    QuestId = 6,
-                    IsMulti = false,
-                    CharaId = Charas.Edward,
-                    EditSkill1CharaId = Charas.Yue,
-                    EditSkill2CharaId = Charas.Marty
-                }
-            };
-    }
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 1,
+                QuestId = 6,
+                IsMulti = false,
+                CharaId = Charas.Basileus,
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 2,
+                QuestId = 6,
+                IsMulti = false,
+                CharaId = Charas.Cecile,
+                EquipCrestSlotType1CrestId1 = AbilityCrests.InanUnendingWorld
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 3,
+                QuestId = 6,
+                IsMulti = false,
+                CharaId = Charas.Durant,
+                EquipWeaponBodyId = WeaponBodies.PrimalAqua,
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 4,
+                QuestId = 6,
+                IsMulti = false,
+                CharaId = Charas.Elias,
+                EquipWeaponSkinId = 1000,
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 5,
+                QuestId = 6,
+                IsMulti = false,
+                EquipDragonKeyId = 2000,
+                CharaId = Charas.Emma,
+                EquippedDragonEntityId = Dragons.Ifrit,
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 6,
+                QuestId = 6,
+                IsMulti = false,
+                EquipTalismanKeyId = 3000,
+                CharaId = Charas.Raemond,
+                EquippedTalismanEntityId = Talismans.Raemond
+            },
+            new()
+            {
+                DeviceAccountId = DeviceAccountId,
+                UnitNo = 7,
+                QuestId = 6,
+                IsMulti = false,
+                CharaId = Charas.Edward,
+                EditSkill1CharaId = Charas.Yue,
+                EditSkill2CharaId = Charas.Marty
+            }
+        };
 
     public void Dispose()
     {

--- a/DragaliaAPI.Integration.Test/Dragalia/QuestReadStoryTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/QuestReadStoryTest.cs
@@ -7,10 +7,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class QuestReadStoryTest : TestFixture
 {
-    public QuestReadStoryTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public QuestReadStoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/RedoableSummonTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/RedoableSummonTest.cs
@@ -7,10 +7,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class RedoableSummonTest : TestFixture
 {
-    public RedoableSummonTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public RedoableSummonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/StoryTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/StoryTest.cs
@@ -7,7 +7,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class StoryTest : TestFixture
 {
-    public StoryTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public StoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
@@ -12,7 +12,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class SummonTest : TestFixture
 {
-    public SummonTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public SummonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
@@ -45,7 +45,7 @@ public class ToolTest : TestFixture
             )
         ).data;
 
-        response.viewer_id.Should().Be(1);
+        response.viewer_id.Should().Be((ulong)ViewerId);
     }
 
     /*[Fact]
@@ -106,7 +106,7 @@ public class ToolTest : TestFixture
             )
         ).data;
 
-        response.viewer_id.Should().Be(1);
+        response.viewer_id.Should().Be((ulong)ViewerId);
         Guid.TryParse(response.session_id, out _).Should().BeTrue();
     }
 
@@ -129,9 +129,9 @@ public class ToolTest : TestFixture
             await this.Client.PostMsgpack<ToolAuthData>("/tool/auth", data)
         ).data;
 
-        response.viewer_id.Should().Be(1);
+        response.viewer_id.Should().Be((ulong)ViewerId);
         Guid.TryParse(response.session_id, out _).Should().BeTrue();
-        response2.viewer_id.Should().Be(1);
+        response2.viewer_id.Should().Be((ulong)ViewerId);
         Guid.TryParse(response2.session_id, out _).Should().BeTrue();
         response.session_id.Should().Be(response2.session_id);
     }

--- a/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
@@ -10,7 +10,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class ToolTest : TestFixture
 {
-    public ToolTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public ToolTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.Client.DefaultRequestHeaders.Remove("SID");

--- a/DragaliaAPI.Integration.Test/Dragalia/TutorialTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/TutorialTest.cs
@@ -15,10 +15,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class TutorialTest : TestFixture
 {
-    public TutorialTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public TutorialTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Dragalia/UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/UpdateTest.cs
@@ -10,7 +10,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class UpdateTest : TestFixture
 {
-    public UpdateTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/UrlListTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/UrlListTest.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class UrlListTest : TestFixture
 {
-    public UrlListTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public UrlListTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 
 public class UserTest : TestFixture
 {
-    public UserTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public UserTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Dragalia/VersionTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/VersionTest.cs
@@ -8,7 +8,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class VersionTest : TestFixture
 {
-    public VersionTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public VersionTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Theory]

--- a/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -12,10 +12,7 @@ public class WeaponBodyTest : TestFixture
 {
     private const string EndpointGroup = "/weapon_body";
 
-    public WeaponBodyTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public WeaponBodyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 5);

--- a/DragaliaAPI.Integration.Test/DragaliaAPI.Integration.Test.csproj
+++ b/DragaliaAPI.Integration.Test/DragaliaAPI.Integration.Test.csproj
@@ -21,6 +21,7 @@
         <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.5" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
         <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="Respawn" Version="6.1.0" />
         <PackageReference Include="Snapshooter.Xunit" Version="0.13.0" />
         <PackageReference Include="Testcontainers" Version="3.0.0" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="3.0.0" />

--- a/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -9,7 +9,7 @@ namespace DragaliaAPI.Integration.Test.Features.Dmode;
 
 public class DmodeTest : TestFixture
 {
-    public DmodeTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public DmodeTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
@@ -14,10 +14,7 @@ namespace DragaliaAPI.Integration.Test.Features.DmodeDungeon;
 
 public class DmodeDungeonTest : TestFixture
 {
-    public DmodeDungeonTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DmodeDungeonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -11,10 +11,7 @@ namespace DragaliaAPI.Integration.Test.Features.Dungeon;
 
 public class DungeonRecordTest : TestFixture
 {
-    public DungeonRecordTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions(2);

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -14,10 +14,7 @@ public class DungeonSkipTest : TestFixture
 {
     private const string Endpoint = "/dungeon_skip";
 
-    public DungeonSkipTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DungeonSkipTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -11,10 +11,7 @@ namespace DragaliaAPI.Integration.Test.Features.Dungeon;
 /// </summary>
 public class DungeonStartTest : TestFixture
 {
-    public DungeonStartTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DungeonStartTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         ImportSave();

--- a/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
@@ -9,10 +9,7 @@ namespace DragaliaAPI.Integration.Test.Features.Event;
 
 public class BuildEventTest : TestFixture
 {
-    public BuildEventTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public BuildEventTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         _ = Client

--- a/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
@@ -9,10 +9,7 @@ namespace DragaliaAPI.Integration.Test.Features.Event;
 
 public class Clb01EventTest : TestFixture
 {
-    public Clb01EventTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public Clb01EventTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         _ = Client

--- a/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
@@ -8,10 +8,7 @@ namespace DragaliaAPI.Integration.Test.Features.Event;
 
 public class CombatEventTest : TestFixture
 {
-    public CombatEventTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public CombatEventTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         _ = Client

--- a/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -8,10 +8,7 @@ namespace DragaliaAPI.Integration.Test.Features.Event;
 
 public class RaidEventTest : TestFixture
 {
-    public RaidEventTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public RaidEventTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         _ = Client

--- a/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -8,7 +8,7 @@ namespace DragaliaAPI.Integration.Test.Features.Fort;
 
 public class FortTest : TestFixture
 {
-    public FortTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public FortTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
@@ -15,7 +15,7 @@ public class GraphQlTest : GraphQlTestFixture
 {
     private const string Endpoint = "savefile/graphql";
 
-    public GraphQlTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public GraphQlTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         Environment.SetEnvironmentVariable("DEVELOPER_TOKEN", "supersecrettoken");

--- a/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
@@ -40,9 +40,9 @@ public class GraphQlTest : GraphQlTestFixture
         GraphQLResponse<Response> response = await this.GraphQlHttpClient.SendQueryAsync<Response>(
             new GraphQLRequest
             {
-                Query = """
+                Query = $$"""
                 query {
-                    player(viewerId: 1) {
+                    player(viewerId: {{ViewerId}}) {
                         charaList {
                             charaId
                         }
@@ -73,9 +73,9 @@ public class GraphQlTest : GraphQlTestFixture
         GraphQLResponse<object> response = await this.GraphQlHttpClient.SendQueryAsync<object>(
             new GraphQLRequest
             {
-                Query = """
+                Query = $$"""
                 mutation {
-                    resetCharacter(viewerId: 1, charaId: ThePrince) {
+                    resetCharacter(viewerId: {{ViewerId}}, charaId: ThePrince) {
                         level
                     }
                 }
@@ -103,9 +103,9 @@ public class GraphQlTest : GraphQlTestFixture
             await this.GraphQlHttpClient.SendQueryAsync<JsonDocument>(
                 new GraphQLRequest
                 {
-                    Query = """
+                    Query = $$"""
                     mutation {
-                        givePresent(viewerId: 1, entityType: Dragon, entityId: 20050525) {
+                        givePresent(viewerId: {{ViewerId}}, entityType: Dragon, entityId: 20050525) {
                             presentId
                         }
                     }
@@ -145,9 +145,9 @@ public class GraphQlTest : GraphQlTestFixture
             await this.GraphQlHttpClient.SendQueryAsync<JsonDocument>(
                 new GraphQLRequest
                 {
-                    Query = """
+                    Query = $$"""
                     mutation {
-                        updateTutorialStatus(viewerId: 1, newStatus: 60999) {
+                        updateTutorialStatus(viewerId: {{ViewerId}}, newStatus: 60999) {
                             tutorialStatus
                         }
                     }

--- a/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTestFixture.cs
+++ b/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTestFixture.cs
@@ -8,10 +8,7 @@ public class GraphQlTestFixture : TestFixture
 {
     public GraphQLHttpClient GraphQlHttpClient { get; init; }
 
-    public GraphQlTestFixture(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public GraphQlTestFixture(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         Uri endpoint = new Uri(this.Client.BaseAddress!, "savefile/graphql");

--- a/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
@@ -8,7 +8,7 @@ namespace DragaliaAPI.Integration.Test.Features.Item;
 
 public class ItemTest : TestFixture
 {
-    public ItemTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public ItemTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         ApiContext.PlayerUseItems.Where(x => x.DeviceAccountId == DeviceAccountId).ExecuteDelete();

--- a/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -10,7 +10,7 @@ namespace DragaliaAPI.Integration.Test.Features.Login;
 
 public class LoginTest : TestFixture
 {
-    public LoginTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public LoginTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.ResetLastLoginTime();

--- a/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Integration.Test.Features.Missions;
 
 public class MissionTest : TestFixture
 {
-    public MissionTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public MissionTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -12,7 +12,7 @@ public class PresentTest : TestFixture
 {
     private const string Controller = "/present";
 
-    public PresentTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public PresentTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 3);

--- a/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -21,10 +21,7 @@ public class QuestBonusTest : TestFixture
      * JOIN TextLabel t ON _QuestViewName = t._Id
      */
 
-    public QuestBonusTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public QuestBonusTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         CommonAssertionOptions.ApplyTimeOptions();

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
@@ -8,10 +8,7 @@ public class ISavefileUpdateTest : TestFixture
 {
     private readonly IEnumerable<ISavefileUpdate> updates;
 
-    public ISavefileUpdateTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public ISavefileUpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         updates = this.Services.GetServices<ISavefileUpdate>();

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -9,7 +9,7 @@ public abstract class SavefileUpdateTestFixture : TestFixture
     protected int MaxVersion { get; }
 
     public SavefileUpdateTestFixture(
-        CustomWebApplicationFactory<Program> factory,
+        CustomWebApplicationFactory factory,
         ITestOutputHelper outputHelper
     )
         : base(factory, outputHelper)

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -8,10 +8,7 @@ namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
 
 public class V1UpdateTest : SavefileUpdateTestFixture
 {
-    public V1UpdateTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public V1UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.ApiContext.PlayerFortBuilds.ExecuteDelete();

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
@@ -6,10 +6,7 @@ namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
 
 public class V2UpdateTest : SavefileUpdateTestFixture
 {
-    public V2UpdateTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public V2UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         this.ApiContext.EquippedStamps.ExecuteDelete();

--- a/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
@@ -7,7 +7,7 @@ namespace DragaliaAPI.Integration.Test.Features.Shop;
 
 public class ShopTest : TestFixture
 {
-    public ShopTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public ShopTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
@@ -7,7 +7,7 @@ public class StampTest : TestFixture
 {
     private const string Controller = "/stamp";
 
-    public StampTest(CustomWebApplicationFactory<Program> factory, ITestOutputHelper outputHelper)
+    public StampTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Trade/AbilityCrestTradeTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Trade/AbilityCrestTradeTest.cs
@@ -9,10 +9,7 @@ namespace DragaliaAPI.Integration.Test.Features.Trade;
 /// </summary>
 public class AbilityCrestTradeTest : TestFixture
 {
-    public AbilityCrestTradeTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper output
-    )
+    public AbilityCrestTradeTest(CustomWebApplicationFactory factory, ITestOutputHelper output)
         : base(factory, output) { }
 
     [Theory]

--- a/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -11,10 +11,7 @@ namespace DragaliaAPI.Integration.Test.Features.Trade;
 
 public class TreasureTradeTest : TestFixture
 {
-    public TreasureTradeTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public TreasureTradeTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
@@ -7,7 +7,7 @@ public class AuthorizationMiddlewareTest : TestFixture
     private const string Endpoint = "test";
 
     public AuthorizationMiddlewareTest(
-        CustomWebApplicationFactory<Program> factory,
+        CustomWebApplicationFactory factory,
         ITestOutputHelper outputHelper
     )
         : base(factory, outputHelper) { }

--- a/DragaliaAPI.Integration.Test/Other/DeleteSavefileTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/DeleteSavefileTest.cs
@@ -8,10 +8,7 @@ namespace DragaliaAPI.Integration.Test.Other;
 
 public class DeleteSavefileTest : TestFixture
 {
-    public DeleteSavefileTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DeleteSavefileTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         Environment.SetEnvironmentVariable("DEVELOPER_TOKEN", "supersecrettoken");

--- a/DragaliaAPI.Integration.Test/Other/DragalipatchTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/DragalipatchTest.cs
@@ -6,10 +6,7 @@ namespace DragaliaAPI.Integration.Test.Other;
 
 public class DragalipatchTest : TestFixture
 {
-    public DragalipatchTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public DragalipatchTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
@@ -10,7 +10,7 @@ public class ExceptionHandlerMiddlewareTest : TestFixture
     public const string Controller = "test";
 
     public ExceptionHandlerMiddlewareTest(
-        CustomWebApplicationFactory<Program> factory,
+        CustomWebApplicationFactory factory,
         ITestOutputHelper outputHelper
     )
         : base(factory, outputHelper) { }

--- a/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
@@ -14,10 +14,7 @@ namespace DragaliaAPI.Integration.Test.Other;
 
 public class HeroParamTest : TestFixture
 {
-    public HeroParamTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public HeroParamTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
@@ -22,7 +22,7 @@ public class HeroParamTest : TestFixture
     {
         this.ImportSave();
 
-        HttpResponseMessage httpResponse = await this.Client.GetAsync("heroparam/1/1");
+        HttpResponseMessage httpResponse = await this.Client.GetAsync($"heroparam/{ViewerId}/1");
 
         httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 

--- a/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -13,10 +13,7 @@ namespace DragaliaAPI.Integration.Test.Other;
 /// </summary>
 public class SavefileImportTest : TestFixture
 {
-    public SavefileImportTest(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    public SavefileImportTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
         Environment.SetEnvironmentVariable("DEVELOPER_TOKEN", "supersecrettoken");

--- a/DragaliaAPI.Integration.Test/TestContainers.cs
+++ b/DragaliaAPI.Integration.Test/TestContainers.cs
@@ -1,6 +1,7 @@
 using DotNet.Testcontainers.Builders;
 using DotNet.Testcontainers.Containers;
 using Serilog;
+using Testcontainers.PostgreSql;
 
 namespace DragaliaAPI.Integration.Test;
 
@@ -11,6 +12,7 @@ static class TestContainers
 
     public static string PostgresUser { get; private set; }
     public static string PostgresPassword { get; private set; }
+    public static string PostgresDatabase { get; private set; }
     public static string PostgresHost { get; private set; }
     public static int PostgresPort { get; private set; }
 
@@ -28,6 +30,7 @@ static class TestContainers
         {
             PostgresUser = "testing";
             PostgresPassword = "aVerystrong(!)password123";
+            PostgresDatabase = "testing";
 
             CreateContainers(out IContainer postgresContainer, out IContainer redisContainer);
 
@@ -41,6 +44,7 @@ static class TestContainers
         {
             PostgresUser = Environment.GetEnvironmentVariable("POSTGRES_USER")!;
             PostgresPassword = Environment.GetEnvironmentVariable("POSTGRES_PASSWORD")!;
+            PostgresDatabase = PostgresUser;
             PostgresHost = "localhost";
             PostgresPort = PostgresContainerPort;
 
@@ -54,16 +58,10 @@ static class TestContainers
         out IContainer redisContainer
     )
     {
-        postgresContainer = new ContainerBuilder()
-            .WithImage("postgres")
-            .WithEnvironment(
-                new Dictionary<string, string>()
-                {
-                    { "POSTGRES_USER", PostgresUser },
-                    { "POSTGRES_PASSWORD", PostgresPassword }
-                }
-            )
-            .WithWaitStrategy(Wait.ForUnixContainer().UntilCommandIsCompleted("pg_isready"))
+        postgresContainer = new PostgreSqlBuilder()
+            .WithDatabase(PostgresDatabase)
+            .WithUsername(PostgresUser)
+            .WithPassword(PostgresPassword)
             .WithPortBinding(PostgresContainerPort, true)
             .Build();
 

--- a/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -48,10 +48,9 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory>
 
         this.MockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(() => DateTimeOffset.UtcNow);
 
-        this.ViewerId = (ulong)
-            this.ApiContext.PlayerUserData
-                .First(x => x.DeviceAccountId == DeviceAccountId)
-                .ViewerId;
+        this.ViewerId = this.ApiContext.PlayerUserData
+            .First(x => x.DeviceAccountId == DeviceAccountId)
+            .ViewerId;
     }
 
     protected Mock<IBaasApi> MockBaasApi { get; }
@@ -67,7 +66,7 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory>
     /// </summary>
     public const string DeviceAccountId = "logged_in_id";
 
-    protected ulong ViewerId { get; private set; }
+    protected long ViewerId { get; private set; }
 
     public const string SessionId = "session_id";
 
@@ -138,6 +137,15 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory>
         return this.ApiContext.PlayerDragonData
             .Where(x => x.DragonId == dragon)
             .Select(x => x.DragonKeyId)
+            .DefaultIfEmpty()
+            .First();
+    }
+
+    protected long GetTalismanKeyId(Talismans talisman)
+    {
+        return this.ApiContext.PlayerTalismans
+            .Where(x => x.TalismanId == talisman)
+            .Select(x => x.TalismanKeyId)
             .DefaultIfEmpty()
             .First();
     }

--- a/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -16,12 +16,9 @@ using Microsoft.Extensions.Logging;
 namespace DragaliaAPI.Integration.Test;
 
 [Collection("DragaliaIntegration")]
-public class TestFixture : IClassFixture<CustomWebApplicationFactory<Program>>
+public class TestFixture : IClassFixture<CustomWebApplicationFactory>
 {
-    protected TestFixture(
-        CustomWebApplicationFactory<Program> factory,
-        ITestOutputHelper outputHelper
-    )
+    protected TestFixture(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
     {
         this.Client = factory
             .WithWebHostBuilder(
@@ -50,6 +47,11 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory<Program>>
         this.MockDateTimeProvider = factory.MockDateTimeProvider;
 
         this.MockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(() => DateTimeOffset.UtcNow);
+
+        this.ViewerId = (ulong)
+            this.ApiContext.PlayerUserData
+                .First(x => x.DeviceAccountId == DeviceAccountId)
+                .ViewerId;
     }
 
     protected Mock<IBaasApi> MockBaasApi { get; }
@@ -64,6 +66,8 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory<Program>>
     /// The device account ID which links to the seeded savefiles <see cref="SeedDatabase"/>
     /// </summary>
     public const string DeviceAccountId = "logged_in_id";
+
+    protected ulong ViewerId { get; private set; }
 
     public const string SessionId = "session_id";
 
@@ -109,14 +113,6 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory<Program>>
         this.MockBaasApi.Setup(x => x.GetSavefile(It.IsAny<string>())).ReturnsAsync(GetSavefile());
     }
 
-    private static LoadIndexData GetSavefile() =>
-        JsonSerializer
-            .Deserialize<DragaliaResponse<LoadIndexData>>(
-                File.ReadAllText(Path.Join("Data", "endgame_savefile.json")),
-                ApiJsonOptions.Instance
-            )!
-            .data;
-
     protected void ImportSave()
     {
         if (
@@ -136,4 +132,22 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory<Program>>
         using IDisposable ctx = playerIdentityService.StartUserImpersonation(DeviceAccountId);
         savefileService.Import(GetSavefile()).Wait();
     }
+
+    protected ulong GetDragonKeyId(Dragons dragon)
+    {
+        return (ulong)
+            this.ApiContext.PlayerDragonData
+                .Where(x => x.DragonId == dragon)
+                .Select(x => x.DragonKeyId)
+                .DefaultIfEmpty()
+                .First();
+    }
+
+    private static LoadIndexData GetSavefile() =>
+        JsonSerializer
+            .Deserialize<DragaliaResponse<LoadIndexData>>(
+                File.ReadAllText(Path.Join("Data", "endgame_savefile.json")),
+                ApiJsonOptions.Instance
+            )!
+            .data;
 }

--- a/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -133,14 +133,13 @@ public class TestFixture : IClassFixture<CustomWebApplicationFactory>
         savefileService.Import(GetSavefile()).Wait();
     }
 
-    protected ulong GetDragonKeyId(Dragons dragon)
+    protected long GetDragonKeyId(Dragons dragon)
     {
-        return (ulong)
-            this.ApiContext.PlayerDragonData
-                .Where(x => x.DragonId == dragon)
-                .Select(x => x.DragonKeyId)
-                .DefaultIfEmpty()
-                .First();
+        return this.ApiContext.PlayerDragonData
+            .Where(x => x.DragonId == dragon)
+            .Select(x => x.DragonKeyId)
+            .DefaultIfEmpty()
+            .First();
     }
 
     private static LoadIndexData GetSavefile() =>


### PR DESCRIPTION
[Respawn](https://github.com/jbogard/Respawn) should be faster than `EnsureCreated()`/`EnsureDeleted()`. 

Some tests have been updated due to relying on specific values of identity columns (e.g. viewer id, key id) which now are dynamic, as tables are not deleted between test classes