### PR TITLE
More time attack fixes

### DIFF
--- a/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net461</TargetFramework>
 		<PlatformTarget>x64</PlatformTarget>
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-		<AssemblyVersion>2.2.0</AssemblyVersion>
+		<AssemblyVersion>2.2.1</AssemblyVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -701,11 +701,13 @@ namespace DragaliaAPI.Photon.Plugin
             foreach (IActor actor in this.PluginHost.GameActors)
                 this.actorState[actor.ActorNr].MemberCount = memberCountTable[actor.ActorNr];
 
+            int rankingType = QuestHelper.GetIsRanked(this.roomState.QuestId) ? 1 : 0;
+
             PartyEvent evt = new PartyEvent()
             {
                 MemberCountTable = memberCountTable,
                 ReBattleCount = this.config.ReplayTimeoutSeconds,
-                RankingType = 1,
+                RankingType = rankingType,
             };
 
             this.RaiseEvent(Event.Party, evt);

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -16,6 +16,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.env.default = .env.default
 		.gitignore = .gitignore
 		.config\dotnet-tools.json = .config\dotnet-tools.json
+		DragaliaAPI.sln.startup.json = DragaliaAPI.sln.startup.json
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/DragaliaAPI/Features/TimeAttack/Validation/TalismanValidator.cs
+++ b/DragaliaAPI/Features/TimeAttack/Validation/TalismanValidator.cs
@@ -18,7 +18,7 @@ public class TalismanValidator : AbstractValidator<TalismanList>
         );
 
         When(
-            x => x.talisman_ability_id_1 != 0,
+            x => x.talisman_ability_id_2 != 0,
             () => RuleFor(x => x.talisman_ability_id_2).ExclusiveBetween(340000000, 350000000)
         );
 

--- a/DragaliaAPI/RazorComponents/TimeAttack/OwnClear.razor
+++ b/DragaliaAPI/RazorComponents/TimeAttack/OwnClear.razor
@@ -76,7 +76,7 @@
         }
 
         this.ownRank =
-           (await clears.Where(x => x.Time < ownClear.Time).ToListAsync())
+           (await clears.Include(x => x.Players).Where(x => x.Time < ownClear.Time).ToListAsync())
                .DistinctBy(x => x.PlayersHash)
                .Count() + 1;
 


### PR DESCRIPTION
- Actually fix OwnClear ranking -- need to include players to use the players hash
- Fix all quests showing TA ranking message
- Fix single-ability Kaleidoscape prints failing validation