### PR TITLE
Update TalismanValidator.cs

### DIFF
--- a/DragaliaAPI.Test/Features/TimeAttack/PartyInfoValidatorTest.cs
+++ b/DragaliaAPI.Test/Features/TimeAttack/PartyInfoValidatorTest.cs
@@ -330,8 +330,8 @@ public class PartyInfoValidatorTest
                         talisman_data = new()
                         {
                             talisman_id = Talismans.GalaLuca,
-                            additional_attack = 51,
-                            additional_hp = 51
+                            additional_attack = 101,
+                            additional_hp = 101
                         }
                     }
                 }

--- a/DragaliaAPI/Features/TimeAttack/Validation/TalismanValidator.cs
+++ b/DragaliaAPI/Features/TimeAttack/Validation/TalismanValidator.cs
@@ -7,8 +7,8 @@ public class TalismanValidator : AbstractValidator<TalismanList>
 {
     public TalismanValidator()
     {
-        RuleFor(x => x.additional_attack).InclusiveBetween(0, 50);
-        RuleFor(x => x.additional_hp).InclusiveBetween(0, 50);
+        RuleFor(x => x.additional_attack).InclusiveBetween(0, 100);
+        RuleFor(x => x.additional_hp).InclusiveBetween(0, 100);
 
         RuleFor(x => x.talisman_id).IsInEnum();
 


### PR DESCRIPTION
The portrait wyrmprints without abilities can actually reach up to 100 bonus attack and hp! It should be wrong to exclude such wyrmprints even if they arent optimal! Though the correct hack check should be 0 abilities -> 0-100, 1 ability -> 0-50 , 2 abilities 0 !