### PR TITLE
Make DbTimeAttackClear key unique for retries

### DIFF
--- a/DragaliaAPI.Database/DbTimeAttackClear.cs
+++ b/DragaliaAPI.Database/DbTimeAttackClear.cs
@@ -9,7 +9,7 @@ namespace DragaliaAPI.Database;
 public class DbTimeAttackClear
 {
     [Key]
-    public required string RoomName { get; set; }
+    public required string GameId { get; set; }
 
     public int QuestId { get; set; }
 

--- a/DragaliaAPI.Database/Entities/DbTimeAttackClearUnit.cs
+++ b/DragaliaAPI.Database/Entities/DbTimeAttackClearUnit.cs
@@ -5,10 +5,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Entities;
 
-[PrimaryKey(nameof(RoomName), nameof(DeviceAccountId), nameof(UnitNo))]
+[PrimaryKey(nameof(GameId), nameof(DeviceAccountId), nameof(UnitNo))]
 public class DbTimeAttackClearUnit : DbPartyUnitBase
 {
-    public required string RoomName { get; set; }
+    public required string GameId { get; set; }
 
     public required string DeviceAccountId { get; set; }
 
@@ -20,6 +20,6 @@ public class DbTimeAttackClearUnit : DbPartyUnitBase
 
     public int TalismanAbility2 { get; set; }
 
-    [ForeignKey($"{nameof(RoomName)},{nameof(DeviceAccountId)}")]
+    [ForeignKey($"{nameof(GameId)},{nameof(DeviceAccountId)}")]
     public DbTimeAttackPlayer? Player { get; set; }
 }

--- a/DragaliaAPI.Database/Entities/DbTimeAttackPlayer.cs
+++ b/DragaliaAPI.Database/Entities/DbTimeAttackPlayer.cs
@@ -3,11 +3,11 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Entities;
 
-[PrimaryKey(nameof(RoomName), nameof(DeviceAccountId))]
+[PrimaryKey(nameof(GameId), nameof(DeviceAccountId))]
 public class DbTimeAttackPlayer
 {
     [ForeignKey(nameof(Clear))]
-    public required string RoomName { get; set; }
+    public required string GameId { get; set; }
 
     [ForeignKey(nameof(Player))]
     public required string DeviceAccountId { get; set; }

--- a/DragaliaAPI.Database/Migrations/20231006174740_time-attack-fix.Designer.cs
+++ b/DragaliaAPI.Database/Migrations/20231006174740_time-attack-fix.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20231006174740_time-attack-fix")]
+    partial class timeattackfix
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI.Database/Migrations/20231006174740_time-attack-fix.cs
+++ b/DragaliaAPI.Database/Migrations/20231006174740_time-attack-fix.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class timeattackfix : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TimeAttackClearUnits_TimeAttackPlayers_RoomName_DeviceAccou~",
+                table: "TimeAttackClearUnits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TimeAttackPlayers_TimeAttackClears_RoomName",
+                table: "TimeAttackPlayers");
+
+            migrationBuilder.RenameColumn(
+                name: "RoomName",
+                table: "TimeAttackPlayers",
+                newName: "GameId");
+
+            migrationBuilder.RenameColumn(
+                name: "RoomName",
+                table: "TimeAttackClearUnits",
+                newName: "GameId");
+
+            migrationBuilder.RenameColumn(
+                name: "RoomName",
+                table: "TimeAttackClears",
+                newName: "GameId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TimeAttackClearUnits_TimeAttackPlayers_GameId_DeviceAccount~",
+                table: "TimeAttackClearUnits",
+                columns: new[] { "GameId", "DeviceAccountId" },
+                principalTable: "TimeAttackPlayers",
+                principalColumns: new[] { "GameId", "DeviceAccountId" },
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TimeAttackPlayers_TimeAttackClears_GameId",
+                table: "TimeAttackPlayers",
+                column: "GameId",
+                principalTable: "TimeAttackClears",
+                principalColumn: "GameId",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_TimeAttackClearUnits_TimeAttackPlayers_GameId_DeviceAccount~",
+                table: "TimeAttackClearUnits");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_TimeAttackPlayers_TimeAttackClears_GameId",
+                table: "TimeAttackPlayers");
+
+            migrationBuilder.RenameColumn(
+                name: "GameId",
+                table: "TimeAttackPlayers",
+                newName: "RoomName");
+
+            migrationBuilder.RenameColumn(
+                name: "GameId",
+                table: "TimeAttackClearUnits",
+                newName: "RoomName");
+
+            migrationBuilder.RenameColumn(
+                name: "GameId",
+                table: "TimeAttackClears",
+                newName: "RoomName");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TimeAttackClearUnits_TimeAttackPlayers_RoomName_DeviceAccou~",
+                table: "TimeAttackClearUnits",
+                columns: new[] { "RoomName", "DeviceAccountId" },
+                principalTable: "TimeAttackPlayers",
+                principalColumns: new[] { "RoomName", "DeviceAccountId" },
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_TimeAttackPlayers_TimeAttackClears_RoomName",
+                table: "TimeAttackPlayers",
+                column: "RoomName",
+                principalTable: "TimeAttackClears",
+                principalColumn: "RoomName",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -300,8 +300,11 @@ public class DungeonRecordTest : TestFixture
 
         int questId = 227010104; // Volk's Wrath TA Solo
         string roomName = Guid.NewGuid().ToString();
+        string roomId = "1234";
+        string gameId = $"{roomName}_{roomId}";
 
         this.Client.DefaultRequestHeaders.Add("RoomName", roomName);
+        this.Client.DefaultRequestHeaders.Add("RoomId", roomId);
 
         await this.AddToDatabase(
             new DbQuest()
@@ -348,14 +351,13 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.TimeAttackClears.Should().ContainSingle(x => x.RoomName == roomName);
+        this.ApiContext.TimeAttackClears.Should().ContainSingle(x => x.GameId == gameId);
 
         DbTimeAttackClear? recordedClear = await this.ApiContext.TimeAttackClears
             .Include(x => x.Players)
             .ThenInclude(x => x.Units)
-            .FirstAsync(x => x.RoomName == roomName);
+            .FirstAsync(x => x.GameId == gameId);
 
-        recordedClear.RoomName.Should().Be(roomName);
         recordedClear.Time.Should().Be(clearTime);
         recordedClear.QuestId.Should().Be(questId);
         recordedClear.Players.Should().ContainSingle(x => x.DeviceAccountId == DeviceAccountId);

--- a/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -4,7 +4,7 @@
 		<TargetFramework>net461</TargetFramework>
 		<PlatformTarget>x64</PlatformTarget>
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-		<AssemblyVersion>2.2.1</AssemblyVersion>
+		<AssemblyVersion>2.2.2</AssemblyVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.Helper.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.Helper.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using DragaliaAPI.Photon.Plugin.Constants;
 using DragaliaAPI.Photon.Plugin.Helpers;
 using DragaliaAPI.Photon.Plugin.Models;
 using MessagePack;
@@ -143,7 +144,11 @@ namespace DragaliaAPI.Photon.Plugin
                 {
                     { "Auth-ViewerId", actor.GetViewerId().ToString() },
                     { "Authorization", $"Bearer {this.config.BearerToken}" },
-                    { "RoomName", this.PluginHost.GameId }
+                    { "RoomName", this.PluginHost.GameId },
+                    {
+                        "RoomId",
+                        this.PluginHost.GameProperties.GetInt(GamePropertyKeys.RoomId).ToString()
+                    }
                 }
             };
 

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.cs
@@ -69,12 +69,15 @@ namespace DragaliaAPI.Photon.Plugin
 #endif
             info.Request.ActorProperties.InitializeViewerId();
 
+            int roomId = this.GenerateRoomId();
+            info.Request.GameProperties.Add(GamePropertyKeys.RoomId, roomId);
+
+            info.Continue();
+
             // https://doc.photonengine.com/server/current/plugins/plugins-faq#how_to_get_the_actor_number_in_plugin_callbacks_
             // This is only invalid if the room is recreated from an inactive state, which Dragalia doesn't do (hopefully!)
             const int actorNr = 1;
             this.actorState[actorNr] = new ActorState();
-
-            info.Continue();
 
             if (
                 info.Request.GameProperties.TryGetValue(
@@ -88,9 +91,6 @@ namespace DragaliaAPI.Photon.Plugin
             }
 
             this.roomState.QuestId = info.Request.GameProperties.GetInt(GamePropertyKeys.QuestId);
-
-            int roomId = this.GenerateRoomId();
-            info.Request.GameProperties.Add(GamePropertyKeys.RoomId, roomId);
 
             this.logger.InfoFormat(
                 "Viewer ID {0} created room {1} with room ID {2}",
@@ -770,18 +770,6 @@ namespace DragaliaAPI.Photon.Plugin
         /// <param name="info">Event call info.</param>
         private void OnClearQuestRequest(IRaiseEventCallInfo info)
         {
-            // These properties must be set for the client to successfully rejoin the room.
-            this.PluginHost.SetProperties(
-                0,
-                new Hashtable()
-                {
-                    { GamePropertyKeys.GoToIngameInfo, null },
-                    { GamePropertyKeys.RoomId, -1 }
-                },
-                null,
-                true
-            );
-
             this.actorState[info.ActorNr] = new ActorState();
 
             ClearQuestRequest evt = info.DeserializeEvent<ClearQuestRequest>();
@@ -806,6 +794,18 @@ namespace DragaliaAPI.Photon.Plugin
                     callAsync: true
                 );
             }
+
+            // These properties must be set for the client to successfully rejoin the room.
+            this.PluginHost.SetProperties(
+                0,
+                new Hashtable()
+                {
+                    { GamePropertyKeys.GoToIngameInfo, null },
+                    { GamePropertyKeys.RoomId, -1 }
+                },
+                null,
+                true
+            );
         }
 
         private bool ShouldRegisterTimeAttack()

--- a/DragaliaAPI.Test/Features/TimeAttack/TimeAttackRepositoryTest.cs
+++ b/DragaliaAPI.Test/Features/TimeAttack/TimeAttackRepositoryTest.cs
@@ -28,18 +28,18 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
     [Fact]
     public async Task CreateOrUpdateClear_CreatesNew()
     {
-        string roomName = Guid.NewGuid().ToString();
+        string gameId = Guid.NewGuid().ToString();
 
         DbTimeAttackClear clear =
             new()
             {
-                RoomName = roomName,
+                GameId = gameId,
                 QuestId = 1,
                 Players = new List<DbTimeAttackPlayer>()
                 {
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = "id",
                         PartyInfo = "{}"
                     }
@@ -55,18 +55,18 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
     [Fact]
     public async Task CreateOrUpdateClear_UpdatesExisting()
     {
-        string roomName = Guid.NewGuid().ToString();
+        string gameId = Guid.NewGuid().ToString();
 
         await this.timeAttackRepository.CreateOrUpdateClear(
             new()
             {
-                RoomName = roomName,
+                GameId = gameId,
                 QuestId = 1,
                 Players = new List<DbTimeAttackPlayer>()
                 {
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = "id 2",
                         PartyInfo = "{}"
                     }
@@ -79,13 +79,13 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
         await this.timeAttackRepository.CreateOrUpdateClear(
             new()
             {
-                RoomName = roomName,
+                GameId = gameId,
                 QuestId = 1,
                 Players = new List<DbTimeAttackPlayer>()
                 {
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = "id 3",
                         PartyInfo = "{}"
                     }
@@ -95,22 +95,22 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
 
         await this.ApiContext.SaveChangesAsync();
 
-        this.ApiContext.TimeAttackClears.Should().Contain(x => x.RoomName == roomName);
+        this.ApiContext.TimeAttackClears.Should().Contain(x => x.GameId == gameId);
         this.ApiContext.TimeAttackClears
-            .First(x => x.RoomName == roomName)
+            .First(x => x.GameId == gameId)
             .Players.Should()
             .BeEquivalentTo(
                 new List<DbTimeAttackPlayer>()
                 {
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = "id 2",
                         PartyInfo = "{}"
                     },
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = "id 3",
                         PartyInfo = "{}"
                     }

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordController.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordController.cs
@@ -100,10 +100,13 @@ public class DungeonRecordController(
     )]
     public async Task<DragaliaResult> RecordTimeAttack(
         [FromHeader(Name = "RoomName")] string roomName,
+        [FromHeader(Name = "RoomId")] int roomId,
         [FromBody] DungeonRecordRecordMultiRequest request
     )
     {
-        await timeAttackService.RegisterRankedClear(roomName, request.play_record.time);
+        string gameId = $"{roomName}_{roomId}";
+
+        await timeAttackService.RegisterRankedClear(gameId, request.play_record.time);
         await updateDataService.SaveChangesAsync();
 
         return this.Ok(new ResultCodeData(ResultCode.Success));

--- a/DragaliaAPI/Features/TimeAttack/ITimeAttackService.cs
+++ b/DragaliaAPI/Features/TimeAttack/ITimeAttackService.cs
@@ -8,6 +8,6 @@ public interface ITimeAttackService
     bool GetIsRankedQuest(int questId);
     IEnumerable<RankingTierReward> GetRewards();
     Task<IEnumerable<RankingTierReward>> ReceiveTierReward(int questId);
-    Task RegisterRankedClear(string roomName, float clearTime);
+    Task RegisterRankedClear(string gameId, float clearTime);
     Task<bool> SetupRankedClear(int questId, PartyInfo partyInfo);
 }

--- a/DragaliaAPI/Features/TimeAttack/TimeAttackRepository.cs
+++ b/DragaliaAPI/Features/TimeAttack/TimeAttackRepository.cs
@@ -16,7 +16,7 @@ public class TimeAttackRepository(
 
     public async Task CreateOrUpdateClear(DbTimeAttackClear clear)
     {
-        if (await apiContext.TimeAttackClears.FindAsync(clear.RoomName) is { } existingClear)
+        if (await apiContext.TimeAttackClears.FindAsync(clear.GameId) is { } existingClear)
         {
             existingClear.Players.AddRange(clear.Players);
         }

--- a/DragaliaAPI/Features/TimeAttack/TimeAttackService.cs
+++ b/DragaliaAPI/Features/TimeAttack/TimeAttackService.cs
@@ -55,7 +55,7 @@ public class TimeAttackService(
         return true;
     }
 
-    public async Task RegisterRankedClear(string roomName, float clearTime)
+    public async Task RegisterRankedClear(string gameId, float clearTime)
     {
         if (await timeAttackCacheService.Get() is not { } entry)
         {
@@ -64,20 +64,20 @@ public class TimeAttackService(
         }
 
         List<DbTimeAttackClearUnit> clearUnits = entry.PartyInfo.party_unit_list
-            .Select(x => MapTimeAttackUnit(x, roomName))
+            .Select(x => MapTimeAttackUnit(x, gameId))
             .ToList();
 
         await timeAttackRepository.CreateOrUpdateClear(
             new DbTimeAttackClear()
             {
-                RoomName = roomName,
+                GameId = gameId,
                 QuestId = entry.QuestId,
                 Time = clearTime,
                 Players = new()
                 {
                     new()
                     {
-                        RoomName = roomName,
+                        GameId = gameId,
                         DeviceAccountId = playerIdentityService.AccountId,
                         PartyInfo = JsonSerializer.Serialize(entry.PartyInfo),
                         Units = clearUnits
@@ -88,7 +88,7 @@ public class TimeAttackService(
 
         logger.LogDebug(
             "Registered time attack clear for room {room} and quest {questId}",
-            roomName,
+            gameId,
             entry.QuestId
         );
     }
@@ -148,7 +148,7 @@ public class TimeAttackService(
             {
                 UnitNo = x.position,
                 DeviceAccountId = playerIdentityService.AccountId,
-                RoomName = roomId
+                GameId = roomId
             };
 
         if (x.chara_data is not null)


### PR DESCRIPTION
On a retry in a co-op room, a time attack record request would be submitted with the same RoomName. The API would think this was the same room name as a previous clear and fail to register it as a new clear, instead attempting to update the units. Fix that by incorporating the room ID -- which is regenerated on retries and clears -- into the unique ID.