### PR TITLE
Use id token from header

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Database.Entities;
+﻿using Antlr4.Runtime;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using NuGet.Common;
@@ -10,6 +11,8 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 /// </summary>
 public class ToolTest : TestFixture
 {
+    private const string IdTokenHeader = "ID-TOKEN";
+
     public ToolTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
@@ -30,126 +33,36 @@ public class ToolTest : TestFixture
         response.service_status.Should().Be(1);
     }
 
-    [Fact]
-    public async Task Signup_CorrectIdToken_ReturnsOKResponse()
+    [Theory]
+    [InlineData("/tool/signup")]
+    [InlineData("/tool/auth")]
+    [InlineData("/tool/reauth")]
+    public async Task Auth_CorrectIdToken_ReturnsOKResponse(string endpoint)
     {
-        ToolSignupData response = (
-            await this.Client.PostMsgpack<ToolSignupData>(
-                "/tool/signup",
-                new ToolSignupRequest()
-                {
-                    id_token = TokenHelper
-                        .GetToken(DateTime.UtcNow + TimeSpan.FromMinutes(5), DeviceAccountId)
-                        .AsString()
-                }
-            )
-        ).data;
-
-        response.viewer_id.Should().Be((ulong)ViewerId);
-    }
-
-    /*[Fact]
-    public async Task Signup_ExpiredIdToken_ReturnsRefreshRequest()
-    {
-        HttpResponseMessage response = await this.Client.PostMsgpackBasic(
-            "/tool/signup",
-            new ToolAuthRequest()
-            {
-                id_token = TestUtils.TokenToString(
-                    TestUtils.GetToken(
-                        DateTime.UtcNow - TimeSpan.FromMinutes(5),
-                        IntegrationTestFixture.DeviceAccountId
-                    )
-                )
-            }
-        );
-
-        response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
-        response.Headers.Should().ContainKey("Is-Required-Refresh-Id-Token");
-        response.Headers
-            .GetValues("Is-Required-Refresh-Id-Token")
-            .Should()
-            .BeEquivalentTo(new List<string>() { "true" });
-    }*/
-
-    [Fact]
-    public async Task Signup_InvalidIdToken_ReturnsIdTokenError()
-    {
-        DragaliaResponse<ResultCodeData> response = await this.Client.PostMsgpack<ResultCodeData>(
-            "/tool/signup",
-            new ToolAuthRequest() { id_token = "im blue dabba dee dabba doo" },
-            ensureSuccessHeader: false
-        );
-
-        response
-            .Should()
-            .BeEquivalentTo(
-                new DragaliaResponse<ResultCodeData>(
-                    new DataHeaders(ResultCode.IdTokenError),
-                    new(ResultCode.IdTokenError)
-                )
-            );
-    }
-
-    [Fact]
-    public async Task Auth_CorrectIdToken_ReturnsOKResponse()
-    {
-        ToolAuthData response = (
-            await this.Client.PostMsgpack<ToolAuthData>(
-                "/tool/auth",
-                new ToolAuthRequest()
-                {
-                    id_token = TokenHelper
-                        .GetToken(DateTimeOffset.UtcNow + TimeSpan.FromMinutes(5), DeviceAccountId)
-                        .AsString()
-                }
-            )
-        ).data;
-
-        response.viewer_id.Should().Be((ulong)ViewerId);
-        Guid.TryParse(response.session_id, out _).Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task Auth_CalledTwice_ReturnsSameSessionId()
-    {
-        ToolAuthRequest data =
-            new()
-            {
-                uuid = "unused",
-                id_token = TokenHelper
-                    .GetToken(DateTime.UtcNow + TimeSpan.FromMinutes(5), DeviceAccountId)
-                    .AsString()
-            };
+        string token = TokenHelper
+            .GetToken(DateTime.UtcNow + TimeSpan.FromMinutes(5), DeviceAccountId)
+            .AsString();
+        this.Client.DefaultRequestHeaders.Add(IdTokenHeader, token);
 
         ToolAuthData response = (
-            await this.Client.PostMsgpack<ToolAuthData>("/tool/auth", data)
-        ).data;
-        ToolAuthData response2 = (
-            await this.Client.PostMsgpack<ToolAuthData>("/tool/auth", data)
+            await this.Client.PostMsgpack<ToolAuthData>(endpoint, new ToolAuthRequest() { })
         ).data;
 
         response.viewer_id.Should().Be((ulong)ViewerId);
-        Guid.TryParse(response.session_id, out _).Should().BeTrue();
-        response2.viewer_id.Should().Be((ulong)ViewerId);
-        Guid.TryParse(response2.session_id, out _).Should().BeTrue();
-        response.session_id.Should().Be(response2.session_id);
     }
 
-    /*[Fact]
+    [Fact]
     public async Task Auth_ExpiredIdToken_ReturnsRefreshRequest()
     {
+        string token = TokenHelper
+            .GetToken(DateTime.UtcNow - TimeSpan.FromHours(5), DeviceAccountId)
+            .AsString();
+        this.Client.DefaultRequestHeaders.Add(IdTokenHeader, token);
+        this.Client.DefaultRequestHeaders.Add("DeviceId", "id");
+
         HttpResponseMessage response = await this.Client.PostMsgpackBasic(
             "/tool/auth",
-            new ToolAuthRequest()
-            {
-                id_token = TestUtils.TokenToString(
-                    TestUtils.GetToken(
-                        DateTime.UtcNow - TimeSpan.FromMinutes(5),
-                        IntegrationTestFixture.DeviceAccountId
-                    )
-                )
-            }
+            new ToolAuthRequest() { }
         );
 
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
@@ -158,14 +71,20 @@ public class ToolTest : TestFixture
             .GetValues("Is-Required-Refresh-Id-Token")
             .Should()
             .BeEquivalentTo(new List<string>() { "true" });
-    }*/
+    }
 
-    [Fact]
-    public async Task Auth_InvalidIdToken_ReturnsIdTokenError()
+    [Theory]
+    [InlineData("/tool/signup")]
+    [InlineData("/tool/auth")]
+    [InlineData("/tool/reauth")]
+    public async Task Auth_InvalidIdToken_ReturnsIdTokenError(string endpoint)
     {
+        string token = "im blue dabba dee dabba doo";
+        this.Client.DefaultRequestHeaders.Add(IdTokenHeader, token);
+
         DragaliaResponse<ResultCodeData> response = await this.Client.PostMsgpack<ResultCodeData>(
-            "/tool/auth",
-            new ToolAuthRequest() { id_token = "im blue dabba dee dabba doo" },
+            endpoint,
+            new ToolAuthRequest() { },
             ensureSuccessHeader: false
         );
 
@@ -178,98 +97,4 @@ public class ToolTest : TestFixture
                 )
             );
     }
-
-    [Fact]
-    public async Task Auth_ValidIdToken_PendingSavefile_ImportsSavefile()
-    {
-        string deviceAccountId = "save import id";
-
-        this.ApiContext.PlayerUserData.Find(DeviceAccountId)!.LastSaveImportTime =
-            DateTimeOffset.MinValue;
-        await this.ApiContext.SaveChangesAsync();
-
-        string token = TokenHelper
-            .GetToken(
-                DateTime.UtcNow + TimeSpan.FromMinutes(5),
-                deviceAccountId,
-                savefileAvailable: true,
-                savefileTime: DateTime.UtcNow - TimeSpan.FromDays(1)
-            )
-            .AsString();
-
-        ToolAuthRequest data = new() { uuid = "unused", id_token = token };
-
-        await this.Client.PostMsgpack<ToolAuthData>("/tool/auth", data);
-
-        DbPlayerUserData userData = this.ApiContext.PlayerUserData.Find(deviceAccountId)!;
-        await this.ApiContext.Entry(userData).ReloadAsync();
-        userData.Name.Should().Be("Jay");
-    }
-
-    [Fact]
-    public async Task Auth_ValidIdToken_OldSavefile_DoesNotImportSavefile()
-    {
-        this.ApiContext.PlayerUserData.Find(DeviceAccountId)!.LastSaveImportTime = DateTime.UtcNow;
-        await this.ApiContext.SaveChangesAsync();
-
-        string token = TokenHelper
-            .GetToken(
-                DateTime.UtcNow + TimeSpan.FromMinutes(5),
-                DeviceAccountId,
-                savefileAvailable: true,
-                savefileTime: DateTime.UtcNow - TimeSpan.FromDays(1)
-            )
-            .AsString();
-        ToolAuthRequest data = new() { uuid = "unused", id_token = token };
-
-        await this.Client.PostMsgpack<ToolAuthData>("/tool/auth", data);
-
-        this.MockBaasApi.Verify(x => x.GetSavefile(token), Times.Never);
-
-        DbPlayerUserData userData = this.ApiContext.PlayerUserData.Find(DeviceAccountId)!;
-        this.ApiContext.Entry(userData).Reload();
-        userData.Name.Should().Be("Euden");
-    }
-
-    /*[Fact]
-     public async Task Auth_SaveImport_CalledTwice_DoesNotError()
-     {
-         // This test is useless because it passes without the thread safety mechanism.
-         // Possibly because of the SQLite DB being fast.
-         // Perhaps this should be revisited with proper end-to-end tests.
-         string deviceAccountId = "save import id";
-
-         this.ApiContext.PlayerUserData
-             .Find(this.IntegrationTestFixture.DeviceAccountId)!
-             .LastSaveImportTime = DateTime.MinValue;
-         await this.ApiContext.SaveChangesAsync();
-
-         string token = TestUtils.TokenToString(
-             TestUtils.GetToken(
-                 DateTime.UtcNow + TimeSpan.FromMinutes(5),
-                 deviceAccountId,
-                 savefileAvailable: true,
-                 savefileTime: DateTime.UtcNow - TimeSpan.FromDays(1)
-             )
-         );
-
-         Task<DragaliaResponse<ToolAuthData>> response1 = this.Client.PostMsgpack<ToolAuthData>(
-             "/tool/auth",
-             new ToolAuthRequest() { uuid = "unused", id_token = token },
-             ensureSuccessHeader: false
-         );
-
-         await Task.Delay(100);
-
-         Task<DragaliaResponse<ToolAuthData>> response2 = this.Client.PostMsgpack<ToolAuthData>(
-             "/tool/auth",
-             new ToolAuthRequest() { uuid = "unused", id_token = token },
-             ensureSuccessHeader: false
-         );
-
-         DragaliaResponse<ToolAuthData>[] result = await Task.WhenAll(response1, response2);
-
-         result[0].data_headers.result_code.Should().Be(ResultCode.Success);
-         result[1].data_headers.result_code.Should().Be(ResultCode.Success);
-     }*/
 }

--- a/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -66,7 +66,7 @@ public static class HttpClientExtensions
     {
         HttpContent content = CreateMsgpackContent(request);
 
-        return await client.PostAsync(endpoint, content);
+        return await client.PostAsync(endpoint.TrimStart('/'), content);
     }
 
     public static HttpContent CreateMsgpackContent(object content)

--- a/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
@@ -36,7 +36,7 @@ public class ExceptionHandlerMiddlewareTest : TestFixture
     [Fact]
     public async Task SecurityTokenExpiredException_ReturnsRefreshRequest_ThenSerializedException()
     {
-        this.Client.DefaultRequestHeaders.Add("DeviceId", "id");
+        this.Client.DefaultRequestHeaders.Add("DeviceId", "id 2");
 
         HttpResponseMessage response = await this.Client.PostMsgpackBasic(
             $"{Controller}/securitytokenexpired",

--- a/DragaliaAPI.Photon.Plugin.Test/DragaliaAPI.Photon.Plugin.Test.csproj
+++ b/DragaliaAPI.Photon.Plugin.Test/DragaliaAPI.Photon.Plugin.Test.csproj
@@ -3,6 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net462</TargetFramework>
 		<IsPackable>false</IsPackable>
+		<PlatformTarget>x64</PlatformTarget>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DragaliaAPI.Test/Controllers/ToolControllerTest.cs
+++ b/DragaliaAPI.Test/Controllers/ToolControllerTest.cs
@@ -21,11 +21,7 @@ public class ToolControllerTest
     {
         this.mockAuthService.Setup(x => x.DoAuth("id token")).ReturnsAsync((1, "session_id"));
 
-        (
-            await this.toolController.Auth(
-                new ToolAuthRequest() { id_token = "id token", uuid = "uuid" }
-            )
-        )
+        (await this.toolController.Auth("id token"))
             .GetData<ToolAuthData>()
             .Should()
             .BeEquivalentTo(
@@ -43,11 +39,7 @@ public class ToolControllerTest
     {
         this.mockAuthService.Setup(x => x.DoAuth("id token")).ReturnsAsync((1, "session_id"));
 
-        (
-            await this.toolController.Signup(
-                new ToolSignupRequest() { id_token = "id token", uuid = "uuid" }
-            )
-        )
+        (await this.toolController.Signup("id token"))
             .GetData<ToolSignupData>()
             .Should()
             .BeEquivalentTo(

--- a/DragaliaAPI/Controllers/Dragalia/ToolController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/ToolController.cs
@@ -32,9 +32,9 @@ public class ToolController : DragaliaControllerBase
 
     [HttpPost]
     [Route("signup")]
-    public async Task<DragaliaResult> Signup(ToolSignupRequest request)
+    public async Task<DragaliaResult> Signup([FromHeader(Name = "ID-TOKEN")] string idToken)
     {
-        (long viewerId, _) = await this.authService.DoAuth(request.id_token);
+        (long viewerId, _) = await this.authService.DoAuth(idToken);
 
         return this.Ok(
             new ToolSignupData()
@@ -54,9 +54,12 @@ public class ToolController : DragaliaControllerBase
 
     [HttpPost]
     [Route("auth")]
-    public async Task<DragaliaResult> Auth(ToolAuthRequest request)
+    public async Task<DragaliaResult> Auth([FromHeader(Name = "ID-TOKEN")] string idToken)
     {
-        (long viewerId, string sessionId) = await this.authService.DoAuth(request.id_token);
+        // For some reason, the id_token in the ToolAuthRequest does not update with refreshes,
+        // but the one in the header does.
+
+        (long viewerId, string sessionId) = await this.authService.DoAuth(idToken);
 
         return this.Ok(
             new ToolAuthData()
@@ -69,9 +72,9 @@ public class ToolController : DragaliaControllerBase
     }
 
     [HttpPost("reauth")]
-    public async Task<DragaliaResult> Reauth(ToolReauthRequest request)
+    public async Task<DragaliaResult> Reauth([FromHeader(Name = "ID-TOKEN")] string idToken)
     {
-        (long viewerId, string sessionId) = await this.authService.DoAuth(request.id_token);
+        (long viewerId, string sessionId) = await this.authService.DoAuth(idToken);
 
         return this.Ok(
             new ToolReauthData()


### PR DESCRIPTION
For some reason, when sending the `Is-Required-Refresh-Id-Token` error, the client:

- goes back to the BaaS as expected
- changes the `ID-TOKEN` header
- but doesn't change the `id_token` property in the request body??

Maybe the request body property was deprecated internally. Should hopefully fix #115 