### PR TITLE
Fix hacked character party power exception

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -112,6 +112,29 @@ public class PartyTest : TestFixture
     }
 
     [Fact]
+    public async Task SetPartySetting_IllegalCharacters_Handles()
+    {
+        Charas storyZethia = (Charas)19900001;
+        this.AddCharacter(storyZethia);
+
+        (
+            await this.Client.PostMsgpack<PartySetPartySettingData>(
+                "/party/set_party_setting",
+                new PartySetPartySettingRequest(
+                    1,
+                    new List<PartySettingList>()
+                    {
+                        new() { unit_no = 1, chara_id = storyZethia, }
+                    },
+                    "My New Party",
+                    false,
+                    0
+                )
+            )
+        ).data_headers.result_code.Should().Be(ResultCode.Success);
+    }
+
+    [Fact]
     public async Task SetPartySetting_InvalidRequest_NotOwnedCharacter_ReturnsResultCode()
     {
         PartySetPartySettingRequest request =

--- a/DragaliaAPI/Features/PartyPower/PartyPowerService.cs
+++ b/DragaliaAPI/Features/PartyPower/PartyPowerService.cs
@@ -494,21 +494,18 @@ public class PartyPowerService(
 
     private static int GetExAbilityPower(ref DbPlayerCharaData dbChara, ref CharaData charaData)
     {
-        if (dbChara.ExAbilityLevel == 0)
+        int ability1Id = charaData.ExAbility[dbChara.ExAbilityLevel - 1];
+        if (!MasterAsset.ExAbilityData.TryGetValue(ability1Id, out ExAbilityData? exAbilityData1))
             return 0;
 
-        int power = MasterAsset.ExAbilityData[
-            charaData.ExAbility[dbChara.ExAbilityLevel - 1]
-        ].PartyPowerWeight;
-
-        if (dbChara.ExAbility2Level == 0)
-            return power;
+        int power = exAbilityData1.PartyPowerWeight;
 
         // yes this is intentionally AbilityData
-        return power
-            + MasterAsset.AbilityData[
-                charaData.ExAbility2[dbChara.ExAbility2Level - 1]
-            ].PartyPowerWeight;
+        int ability2Id = charaData.ExAbility2[dbChara.ExAbility2Level - 1];
+        if (!MasterAsset.AbilityData.TryGetValue(ability2Id, out AbilityData? exAbilityData2))
+            return power;
+
+        return power + exAbilityData2.PartyPowerWeight;
     }
 
     private static int GetUnionAbilityPower(IEnumerable<DbAbilityCrest> crests)


### PR DESCRIPTION
- Remove AbilityLevel == 0 check, as this is not a valid value -- both exAbilityLevel(s) start at 1