### PR TITLE
Revert "Disable change tracking for big queries"

### DIFF
--- a/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
+++ b/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
@@ -11,7 +11,6 @@ using DragaliaAPI.Features.Dungeon;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.PlayerDetails;
-using DragaliaAPI.Test.Utils;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Test.Features.Dungeon;
@@ -30,8 +29,6 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             this.ApiContext,
             this.mockPlayerIdentityService.Object
         );
-
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/Features/Dungeon/DungeonRepository.cs
+++ b/DragaliaAPI/Features/Dungeon/DungeonRepository.cs
@@ -8,7 +8,6 @@ using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.PlayerDetails;
-using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Features.Dungeon;
 
@@ -27,8 +26,7 @@ public class DungeonRepository : IDungeonRepository
         IQueryable<DbQuestClearPartyUnit> input
     )
     {
-        return (
-            from unit in input
+        return from unit in input
             from chara in this.apiContext.PlayerCharaData
                 .Where(x => x.CharaId == unit.CharaId && x.DeviceAccountId == unit.DeviceAccountId)
                 .DefaultIfEmpty()
@@ -158,8 +156,7 @@ public class DungeonRepository : IDungeonRepository
                         ),
                 TalismanData = talisman,
                 WeaponSkinData = skin
-            }
-        ).AsNoTracking();
+            };
     }
 
     public IQueryable<DbDetailedPartyUnit> BuildDetailedPartyUnit(
@@ -167,8 +164,7 @@ public class DungeonRepository : IDungeonRepository
         int firstPartyNo
     )
     {
-        return (
-            from unit in input
+        return from unit in input
             join chara in this.apiContext.PlayerCharaData
                 on new { unit.DeviceAccountId, unit.CharaId } equals new
                 {
@@ -307,8 +303,7 @@ public class DungeonRepository : IDungeonRepository
                         ),
                 TalismanData = talisman,
                 WeaponSkinData = skin
-            }
-        ).AsNoTracking();
+            };
     }
 
     public IEnumerable<IQueryable<DbDetailedPartyUnit>> BuildDetailedPartyUnit(
@@ -325,7 +320,7 @@ public class DungeonRepository : IDungeonRepository
 
         foreach (PartySettingList unit in party)
         {
-            IQueryable<DbDetailedPartyUnit> detailQuery = (
+            IQueryable<DbDetailedPartyUnit> detailQuery =
                 from chara in this.apiContext.PlayerCharaData
                     .Where(
                         x =>
@@ -468,8 +463,7 @@ public class DungeonRepository : IDungeonRepository
                             ),
                     TalismanData = talisman,
                     WeaponSkinData = skin
-                }
-            ).AsNoTracking();
+                };
 
             queries.Add(detailQuery);
         }

--- a/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/Features/Fort/FortService.cs
@@ -37,9 +37,7 @@ public class FortService(
 
     public async Task<IEnumerable<BuildList>> GetBuildList()
     {
-        return (await fortRepository.Builds.AsNoTracking().ToListAsync()).Select(
-            mapper.Map<BuildList>
-        );
+        return (await fortRepository.Builds.ToListAsync()).Select(mapper.Map<BuildList>);
     }
 
     public async Task<FortDetail> AddCarpenter(PaymentTypes paymentType)

--- a/DragaliaAPI/Services/Game/BonusService.cs
+++ b/DragaliaAPI/Services/Game/BonusService.cs
@@ -30,14 +30,12 @@ public class BonusService(
     {
         IEnumerable<int> buildIds = (
             await fortRepository.Builds
-                .AsNoTracking()
                 .Where(x => x.Level != 0)
                 .Select(x => new { x.PlantId, x.Level })
                 .ToListAsync()
         ).Select(x => MasterAssetUtils.GetPlantDetailId(x.PlantId, x.Level));
 
         IEnumerable<WeaponBodies> weaponIds = await weaponRepository.WeaponBodies
-            .AsNoTracking()
             .Where(x => x.FortPassiveCharaWeaponBuildupCount != 0)
             .Select(x => x.WeaponBodyId)
             .ToListAsync();

--- a/DragaliaAPI/Services/Game/LoadService.cs
+++ b/DragaliaAPI/Services/Game/LoadService.cs
@@ -1,7 +1,9 @@
 ﻿using System.Diagnostics;
 using AutoMapper;
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Missions;
+using DragaliaAPI.Features.PartyPower;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.Present;
 using DragaliaAPI.Features.Shop;
@@ -36,7 +38,7 @@ public class LoadService(
         Stopwatch stopwatch = new();
         stopwatch.Start();
 
-        DbPlayer savefile = await savefileService.Load().AsNoTracking().FirstAsync();
+        DbPlayer savefile = await savefileService.Load().SingleAsync();
 
         logger.LogInformation("{time} ms: Load query complete", stopwatch.ElapsedMilliseconds);
 


### PR DESCRIPTION
Reverts SapiensAnatis/Dawnshard#444

There have been a bunch of errors in the logs today about players being short of materials which I've never seen before. In other words, the client is out of sync with the backend about what materials it owns.

I'm not quite clear yet on why disabling change tracking might cause this, but it seems the most likely candidate. The only one that seems relevant is LoadService, and that query is after a SaveChangesAsync. Best to revert the changes and investigate the cause before re-applying. Performance benefit was not immediately apparent anyway.