### PR TITLE
Fix quest cache lookup failure on claiming partial bonus

### DIFF
--- a/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/Features/Quest/QuestService.cs
@@ -260,11 +260,8 @@ public class QuestService(
             count = questEvent.QuestBonusReserveCount;
         }
 
-        questEvent.QuestBonusReserveCount -= count;
-        questEvent.QuestBonusReserveTime =
-            questEvent.QuestBonusReserveCount == 0
-                ? DateTimeOffset.UnixEpoch
-                : dateTimeProvider.UtcNow;
+        questEvent.QuestBonusReserveCount = 0;
+        questEvent.QuestBonusReserveTime = DateTimeOffset.UnixEpoch;
 
         questEvent.QuestBonusReceiveCount += count;
 

--- a/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/Features/Quest/QuestService.cs
@@ -227,21 +227,18 @@ public class QuestService(
     {
         DbQuestEvent questEvent = await questRepository.GetQuestEventAsync(eventGroupId);
 
-        int questId =
-            await questCacheService.GetQuestGroupQuestIdAsync(eventGroupId)
-            ?? throw new DragaliaException(
-                ResultCode.CommonDbError,
-                $"Could not find latest quest clear id for group {eventGroupId} in cache."
-            );
+        int? questId = await questCacheService.GetQuestGroupQuestIdAsync(eventGroupId);
 
-        if (!isReceive)
+        if (!isReceive || questId == null)
         {
+            logger.LogInformation("Cancelling receipt of quest bonus");
+
             questEvent.QuestBonusReserveCount = 0;
             questEvent.QuestBonusReserveTime = DateTimeOffset.UnixEpoch;
 
             await questCacheService.RemoveQuestGroupQuestIdAsync(eventGroupId);
 
-            return new AtgenReceiveQuestBonus() { target_quest_id = questId };
+            return new AtgenReceiveQuestBonus() { target_quest_id = questId ?? 0 };
         }
 
         if (count > questEvent.QuestBonusReserveCount + questEvent.QuestBonusStackCount)
@@ -273,13 +270,13 @@ public class QuestService(
 
         // TODO: bonus factor?
         IEnumerable<AtgenBuildEventRewardEntityList> bonusRewards = (
-            await GenerateBonusDrops(questId, count)
+            await GenerateBonusDrops(questId.Value, count)
         ).Select(x => x.ToBuildEventRewardEntityList());
 
         // Remove at the end so it doesn't get messed up when erroring
         await questCacheService.RemoveQuestGroupQuestIdAsync(eventGroupId);
 
-        return new AtgenReceiveQuestBonus(questId, count, 1, bonusRewards);
+        return new AtgenReceiveQuestBonus(questId.Value, count, 1, bonusRewards);
     }
 
     private void ResetQuestEventBonus(DbQuestEvent questEvent, QuestEvent questEventData)


### PR DESCRIPTION
When a player skip tickets a quest and claims e.g. 1/3 bonuses, we need to clear the QuestBonusReserveCount, otherwise they will be asked to claim the remaining bonuses when they next login, but the cache entry will be gone.

Also allow the function to return on cache lookup failure, so that a missing cache entry doesn't block players from logging in.

Closes #447 