### PR TITLE
Disable change tracking for big queries

### DIFF
--- a/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
+++ b/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
@@ -11,6 +11,7 @@ using DragaliaAPI.Features.Dungeon;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.PlayerDetails;
+using DragaliaAPI.Test.Utils;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Test.Features.Dungeon;
@@ -29,6 +30,8 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             this.ApiContext,
             this.mockPlayerIdentityService.Object
         );
+
+        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/Features/Dungeon/DungeonRepository.cs
+++ b/DragaliaAPI/Features/Dungeon/DungeonRepository.cs
@@ -8,6 +8,7 @@ using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Features.Dungeon;
 
@@ -26,7 +27,8 @@ public class DungeonRepository : IDungeonRepository
         IQueryable<DbQuestClearPartyUnit> input
     )
     {
-        return from unit in input
+        return (
+            from unit in input
             from chara in this.apiContext.PlayerCharaData
                 .Where(x => x.CharaId == unit.CharaId && x.DeviceAccountId == unit.DeviceAccountId)
                 .DefaultIfEmpty()
@@ -156,7 +158,8 @@ public class DungeonRepository : IDungeonRepository
                         ),
                 TalismanData = talisman,
                 WeaponSkinData = skin
-            };
+            }
+        ).AsNoTracking();
     }
 
     public IQueryable<DbDetailedPartyUnit> BuildDetailedPartyUnit(
@@ -164,7 +167,8 @@ public class DungeonRepository : IDungeonRepository
         int firstPartyNo
     )
     {
-        return from unit in input
+        return (
+            from unit in input
             join chara in this.apiContext.PlayerCharaData
                 on new { unit.DeviceAccountId, unit.CharaId } equals new
                 {
@@ -303,7 +307,8 @@ public class DungeonRepository : IDungeonRepository
                         ),
                 TalismanData = talisman,
                 WeaponSkinData = skin
-            };
+            }
+        ).AsNoTracking();
     }
 
     public IEnumerable<IQueryable<DbDetailedPartyUnit>> BuildDetailedPartyUnit(
@@ -320,7 +325,7 @@ public class DungeonRepository : IDungeonRepository
 
         foreach (PartySettingList unit in party)
         {
-            IQueryable<DbDetailedPartyUnit> detailQuery =
+            IQueryable<DbDetailedPartyUnit> detailQuery = (
                 from chara in this.apiContext.PlayerCharaData
                     .Where(
                         x =>
@@ -463,7 +468,8 @@ public class DungeonRepository : IDungeonRepository
                             ),
                     TalismanData = talisman,
                     WeaponSkinData = skin
-                };
+                }
+            ).AsNoTracking();
 
             queries.Add(detailQuery);
         }

--- a/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/Features/Fort/FortService.cs
@@ -37,7 +37,9 @@ public class FortService(
 
     public async Task<IEnumerable<BuildList>> GetBuildList()
     {
-        return (await fortRepository.Builds.ToListAsync()).Select(mapper.Map<BuildList>);
+        return (await fortRepository.Builds.AsNoTracking().ToListAsync()).Select(
+            mapper.Map<BuildList>
+        );
     }
 
     public async Task<FortDetail> AddCarpenter(PaymentTypes paymentType)

--- a/DragaliaAPI/Services/Game/BonusService.cs
+++ b/DragaliaAPI/Services/Game/BonusService.cs
@@ -30,12 +30,14 @@ public class BonusService(
     {
         IEnumerable<int> buildIds = (
             await fortRepository.Builds
+                .AsNoTracking()
                 .Where(x => x.Level != 0)
                 .Select(x => new { x.PlantId, x.Level })
                 .ToListAsync()
         ).Select(x => MasterAssetUtils.GetPlantDetailId(x.PlantId, x.Level));
 
         IEnumerable<WeaponBodies> weaponIds = await weaponRepository.WeaponBodies
+            .AsNoTracking()
             .Where(x => x.FortPassiveCharaWeaponBuildupCount != 0)
             .Select(x => x.WeaponBodyId)
             .ToListAsync();

--- a/DragaliaAPI/Services/Game/LoadService.cs
+++ b/DragaliaAPI/Services/Game/LoadService.cs
@@ -1,9 +1,7 @@
 ﻿using System.Diagnostics;
 using AutoMapper;
 using DragaliaAPI.Database.Entities;
-using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Missions;
-using DragaliaAPI.Features.PartyPower;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.Present;
 using DragaliaAPI.Features.Shop;
@@ -38,7 +36,7 @@ public class LoadService(
         Stopwatch stopwatch = new();
         stopwatch.Start();
 
-        DbPlayer savefile = await savefileService.Load().SingleAsync();
+        DbPlayer savefile = await savefileService.Load().AsNoTracking().FirstAsync();
 
         logger.LogInformation("{time} ms: Load query complete", stopwatch.ElapsedMilliseconds);
 


### PR DESCRIPTION
Currently targeting hot queries that load a lot of data:
 - fort bonus list
 - /load/index
 - building party units for dungeon start / hero param

First implemented in #444 and then reverted by #445 due to errors in the logs -- however these errors have continued so doubt there is any relation