### PR TITLE
Royal regimen fixes

### DIFF
--- a/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -1332,7 +1332,7 @@
     "_MissionId": 303000,
     "_CompleteType": "QuestCleared",
     "_UseTotalValue": 1,
-    "_Parameter": 210010101,
+    "_Parameter": 210011101,
     "_Parameter3": 2
   },
   {

--- a/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -1216,7 +1216,7 @@
     "_Id": 30170008,
     "_MissionType": "Drill",
     "_MissionId": 301700,
-    "_CompleteType": "AbilityCrestTotalPlusCountUp",
+    "_CompleteType": "AbilityCrestLevelUp",
     "_UseTotalValue": 1
   },
   {


### PR DESCRIPTION
- Fix 'Clear High Midgardsormr's Trial: Standard on Solo' counting the co-op version
- Fix 'Upgrade a Wyrmprint's HP & Strength 15 Times' counting augment usage instead of water usage
- Fix 'Obtain Glorious Tempest from the Treasure Trade' not being able to be completed for pre-2.0 saves
- Fix existing GraphQL mutations
- Add new GraphQL 'reset all' mutation when fixes are applied to a particular mission