### PR TITLE
Add user impersonation

### DIFF
--- a/DragaliaAPI.Test/Services/SessionServiceTest.cs
+++ b/DragaliaAPI.Test/Services/SessionServiceTest.cs
@@ -5,6 +5,7 @@ using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services;
 using DragaliaAPI.Services.Game;
 using DragaliaAPI.Shared;
+using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -18,6 +19,7 @@ public class SessionServiceTest
     private readonly Mock<ILogger<SessionService>> mockLogger;
     private readonly Mock<IOptionsMonitor<RedisOptions>> mockOptions;
     private readonly Mock<IDateTimeProvider> mockDateTimeProvider;
+    private readonly Mock<IPlayerIdentityService> mockPlayerIdentityService;
     private readonly SessionService sessionService;
 
     [Obsolete(ObsoleteReasons.BaaS)]
@@ -33,6 +35,7 @@ public class SessionServiceTest
         this.mockLogger = new(MockBehavior.Loose);
         this.mockOptions = new(MockBehavior.Strict);
         this.mockDateTimeProvider = new(MockBehavior.Strict);
+        this.mockPlayerIdentityService = new(MockBehavior.Strict);
 
         IOptions<MemoryDistributedCacheOptions> opts = Options.Create(
             new MemoryDistributedCacheOptions()
@@ -44,10 +47,11 @@ public class SessionServiceTest
             .Returns(new RedisOptions() { SessionExpiryTimeMinutes = 1 });
 
         sessionService = new(
-            testCache,
-            mockOptions.Object,
-            mockLogger.Object,
-            mockDateTimeProvider.Object
+            this.testCache,
+            this.mockOptions.Object,
+            this.mockLogger.Object,
+            this.mockDateTimeProvider.Object,
+            this.mockPlayerIdentityService.Object
         );
 
         this.mockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(DateTimeOffset.UnixEpoch);

--- a/DragaliaAPI/Features/GraphQL/ImpersionationMutations.cs
+++ b/DragaliaAPI/Features/GraphQL/ImpersionationMutations.cs
@@ -1,0 +1,55 @@
+using System.Linq.Expressions;
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Services;
+using DragaliaAPI.Shared.PlayerDetails;
+using EntityGraphQL.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.GraphQL;
+
+public class ImpersionationMutations : MutationBase
+{
+    private readonly ISessionService sessionService;
+    private readonly ApiContext apiContext;
+
+    public ImpersionationMutations(
+        ISessionService sessionService,
+        ApiContext apiContext,
+        IPlayerIdentityService identityService
+    )
+        : base(apiContext, identityService)
+    {
+        this.sessionService = sessionService;
+        this.apiContext = apiContext;
+    }
+
+    [GraphQLMutation]
+    public async Task<Expression<Func<ApiContext, DbPlayer>>> StartImpersonation(
+        long viewerId,
+        long targetViewerId
+    )
+    {
+        DbPlayer player = this.GetPlayer(viewerId);
+        string targetAccountId = this.apiContext.Players
+            .Include(x => x.UserData)
+            .Where(x => x.UserData!.ViewerId == targetViewerId)
+            .Select(x => x.AccountId)
+            .First();
+
+        await this.sessionService.StartUserImpersonation(targetAccountId, targetViewerId);
+
+        return context => context.Players.First(x => x.AccountId == targetAccountId);
+    }
+
+    [GraphQLMutation]
+    public async Task<Expression<Func<ApiContext, DbPlayer>>> ClearImpersonation(long viewerId)
+    {
+        DbPlayer player = this.GetPlayer(viewerId);
+
+        await this.sessionService.ClearUserImpersonation();
+
+        return context => context.Players.First(x => x.AccountId == player.AccountId);
+    }
+}

--- a/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
+++ b/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
@@ -8,13 +8,18 @@ using Microsoft.Extensions.Options;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authorization;
 using System.Security.Claims;
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Middleware;
 
 public class SessionAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
     private readonly ISessionService sessionService;
+    private readonly IWebHostEnvironment webHostEnvironment;
+    private readonly ApiContext apiContext;
 
     private const string SessionExpired = "Session-Expired";
     private const string True = "true";
@@ -26,11 +31,15 @@ public class SessionAuthenticationHandler : AuthenticationHandler<Authentication
         ILoggerFactory logger,
         UrlEncoder encoder,
         ISystemClock clock,
-        ISessionService sessionService
+        ISessionService sessionService,
+        IWebHostEnvironment webHostEnvironment,
+        ApiContext apiContext
     )
         : base(options, logger, encoder, clock)
     {
         this.sessionService = sessionService;
+        this.webHostEnvironment = webHostEnvironment;
+        this.apiContext = apiContext;
     }
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -46,14 +55,15 @@ public class SessionAuthenticationHandler : AuthenticationHandler<Authentication
         if (sid is null)
             return AuthenticateResult.Fail("Invalid SID header: value was null");
 
-        List<Claim> claims = new();
+        string deviceAccountId;
+        string viewerId;
 
         try
         {
             Session session = await this.sessionService.LoadSessionSessionId(sid);
 
-            claims.Add(new(CustomClaimType.AccountId, session.DeviceAccountId));
-            claims.Add(new(CustomClaimType.ViewerId, session.ViewerId.ToString()));
+            deviceAccountId = session.DeviceAccountId;
+            viewerId = session.ViewerId.ToString();
 
             this.Context.Items[LastLoginTime] = session.LoginTime;
         }
@@ -61,6 +71,28 @@ public class SessionAuthenticationHandler : AuthenticationHandler<Authentication
         {
             return AuthenticateResult.Fail($"Failed to look up SID {sid}");
         }
+
+        Session? impersonatedSession = await this.sessionService.LoadImpersonationSession(
+            deviceAccountId
+        );
+
+        if (impersonatedSession != null)
+        {
+            this.Logger.LogInformation(
+                "User impersonation activated: {@impersonation}",
+                new { impersonatedSession.DeviceAccountId, impersonatedSession.ViewerId }
+            );
+
+            deviceAccountId = impersonatedSession.DeviceAccountId;
+            viewerId = impersonatedSession.ViewerId.ToString();
+        }
+
+        List<Claim> claims =
+            new()
+            {
+                new(CustomClaimType.AccountId, deviceAccountId),
+                new(CustomClaimType.ViewerId, viewerId)
+            };
 
         ClaimsIdentity identity = new(claims, this.Scheme.Name);
         ClaimsPrincipal principal = new(identity);

--- a/DragaliaAPI/Services/ISessionService.cs
+++ b/DragaliaAPI/Services/ISessionService.cs
@@ -52,4 +52,7 @@ public interface ISessionService
     /// <returns>The session object.</returns>
     /// <exception cref="Exceptions.SessionException">A matching key was not found in the cache.</exception>
     Task<Session> LoadSessionIdToken(string idToken);
+    Task StartUserImpersonation(string targetAccountId, long targetViewerId);
+    Task ClearUserImpersonation();
+    Task<Session?> LoadImpersonationSession(string deviceAccountId);
 }


### PR DESCRIPTION

Allows developers to log in as another user.

Adds GraphQL mutations to set a flag in redis to override the account ID returned from authentication
