### PR TITLE
Don't remove kscape or emblems on save import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ appsettings.Development.json
 test_coverage.json
 .run
 PhotonServer
+global.json
 
 # CMake
 cmake-build-*/

--- a/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/Services/Game/SavefileService.cs
@@ -12,6 +12,7 @@ using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.EntityFrameworkCore.Storage;
 using Microsoft.Extensions.Caching.Distributed;
 
@@ -147,7 +148,7 @@ public class SavefileService : ISavefileService
                 new DbPlayer
                 {
                     AccountId = this.playerIdentityService.AccountId,
-                    SavefileVersion = this.maxSavefileVersion
+                    SavefileVersion = 0,
                 }
             );
 
@@ -457,7 +458,13 @@ public class SavefileService : ISavefileService
                 stopwatch.Elapsed.TotalMilliseconds
             );
 
-            if (savefile.user_data.emblem_id != Emblems.DragonbloodPrince)
+            if (
+                savefile.user_data.emblem_id != Emblems.DragonbloodPrince
+                && this.apiContext.Emblems.Local.FindEntry(
+                    nameof(DbEmblem.EmblemId),
+                    savefile.user_data.emblem_id
+                ) == null
+            )
             {
                 this.apiContext.Emblems.Add(
                     new DbEmblem
@@ -525,6 +532,10 @@ public class SavefileService : ISavefileService
 
     private void Delete()
     {
+        // Options commented out have been excluded from save import deletion process.
+        // They will still be deleted by cascade delete when a player is actually deleted
+        // without being re-added as they are in save imports.
+
         string deviceAccountId = this.playerIdentityService.AccountId;
 
         this.apiContext.Players.RemoveRange(
@@ -602,32 +613,32 @@ public class SavefileService : ISavefileService
         this.apiContext.PlayerEventPassives.RemoveRange(
             this.apiContext.PlayerEventPassives.Where(x => x.DeviceAccountId == deviceAccountId)
         );
-        this.apiContext.PlayerDmodeInfos.RemoveRange(
-            this.apiContext.PlayerDmodeInfos.Where(x => x.DeviceAccountId == deviceAccountId)
-        );
-        this.apiContext.PlayerDmodeCharas.RemoveRange(
-            this.apiContext.PlayerDmodeCharas.Where(x => x.DeviceAccountId == deviceAccountId)
-        );
-        this.apiContext.PlayerDmodeDungeons.RemoveRange(
-            this.apiContext.PlayerDmodeDungeons.Where(x => x.DeviceAccountId == deviceAccountId)
-        );
-        this.apiContext.PlayerDmodeServitorPassives.RemoveRange(
-            this.apiContext.PlayerDmodeServitorPassives.Where(
-                x => x.DeviceAccountId == deviceAccountId
-            )
-        );
-        this.apiContext.PlayerDmodeExpeditions.RemoveRange(
-            this.apiContext.PlayerDmodeExpeditions.Where(x => x.DeviceAccountId == deviceAccountId)
-        );
+        // this.apiContext.PlayerDmodeInfos.RemoveRange(
+        //     this.apiContext.PlayerDmodeInfos.Where(x => x.DeviceAccountId == deviceAccountId)
+        // );
+        // this.apiContext.PlayerDmodeCharas.RemoveRange(
+        //     this.apiContext.PlayerDmodeCharas.Where(x => x.DeviceAccountId == deviceAccountId)
+        // );
+        // this.apiContext.PlayerDmodeDungeons.RemoveRange(
+        //     this.apiContext.PlayerDmodeDungeons.Where(x => x.DeviceAccountId == deviceAccountId)
+        // );
+        // this.apiContext.PlayerDmodeServitorPassives.RemoveRange(
+        //     this.apiContext.PlayerDmodeServitorPassives.Where(
+        //         x => x.DeviceAccountId == deviceAccountId
+        //     )
+        // );
+        // this.apiContext.PlayerDmodeExpeditions.RemoveRange(
+        //     this.apiContext.PlayerDmodeExpeditions.Where(x => x.DeviceAccountId == deviceAccountId)
+        // );
         this.apiContext.PlayerUseItems.RemoveRange(
             this.apiContext.PlayerUseItems.Where(x => x.DeviceAccountId == deviceAccountId)
         );
         this.apiContext.PlayerSummonTickets.RemoveRange(
             this.apiContext.PlayerSummonTickets.Where(x => x.DeviceAccountId == deviceAccountId)
         );
-        this.apiContext.Emblems.RemoveRange(
-            this.apiContext.Emblems.Where(x => x.DeviceAccountId == deviceAccountId)
-        );
+        // this.apiContext.Emblems.RemoveRange(
+        //     this.apiContext.Emblems.Where(x => x.DeviceAccountId == deviceAccountId)
+        // );
         this.apiContext.QuestEvents.RemoveRange(
             this.apiContext.QuestEvents.Where(x => x.DeviceAccountId == deviceAccountId)
         );

--- a/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/Services/Game/SavefileService.cs
@@ -460,8 +460,8 @@ public class SavefileService : ISavefileService
 
             if (
                 savefile.user_data.emblem_id != Emblems.DragonbloodPrince
-                && this.apiContext.Emblems.Local.FindEntry(
-                    nameof(DbEmblem.EmblemId),
+                && await this.apiContext.Emblems.FindAsync(
+                    deviceAccountId,
                     savefile.user_data.emblem_id
                 ) == null
             )


### PR DESCRIPTION
- Stop clearing these tables as players became frustrated at losing significant progress when editing their save
- Could consider keeping event compendium tables too