### PR TITLE
Don't throw on chara / dragon story unlock failure

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
@@ -2,6 +2,7 @@
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Database.Utils;
 using DragaliaAPI.Features.Chara;
+using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
@@ -38,6 +39,7 @@ public class CharaTest : TestFixture
         this.AddCharacter(Charas.GalaZethia);
         this.AddCharacter(Charas.Vida);
         this.AddCharacter(Charas.Delphi);
+        this.AddCharacter(Charas.GalaAudric);
     }
 
     [Fact]
@@ -155,6 +157,32 @@ public class CharaTest : TestFixture
         response.update_data_list.user_data.mana_point
             .Should()
             .Be(manaPointNum - 350 - 450 - 650 - 350 - 450 - 350 - 500 - 450 - 350 - 650);
+    }
+
+    [Fact]
+    public async Task CharaBuildupMana_AllStoriesUnlocked_DoesNotThrow()
+    {
+        foreach (int storyId in MasterAsset.CharaStories[(int)Charas.GalaAudric].storyIds)
+        {
+            await this.AddToDatabase(
+                new DbPlayerStoryState()
+                {
+                    DeviceAccountId = DeviceAccountId,
+                    StoryId = storyId,
+                    State = StoryState.Read,
+                    StoryType = StoryTypes.Chara
+                }
+            );
+        }
+
+        DragaliaResponse<CharaBuildupManaData> response = (
+            await this.Client.PostMsgpack<CharaBuildupManaData>(
+                "chara/buildup_mana",
+                new CharaBuildupManaRequest(Charas.GalaAudric, new List<int>() { 5 }, false)
+            )
+        );
+
+        response.data_headers.result_code.Should().Be(ResultCode.Success);
     }
 
     [Fact]

--- a/DragaliaAPI/Features/Chara/CharaController.cs
+++ b/DragaliaAPI/Features/Chara/CharaController.cs
@@ -663,25 +663,26 @@ public class CharaController(
                     .Get((int)playerCharData.CharaId)
                     .storyIds;
 
-                int nextStoryunlockIndex =
+                int nextStoryUnlockIndex =
                     await storyRepository.Stories
                         .Where(x => charaStories.Contains(x.StoryId))
                         .CountAsync() + unlockedStories.Count;
 
-                if (charaStories.Length - 1 < nextStoryunlockIndex)
+                int nextStoryId = charaStories.ElementAtOrDefault(nextStoryUnlockIndex);
+
+                if (nextStoryId != default)
                 {
-                    throw new DragaliaException(
-                        ResultCode.StoryCountNotEnough,
-                        "Too many story unlocks"
+                    await storyRepository.GetOrCreateStory(StoryTypes.Chara, nextStoryId);
+                    unlockedStories.Add(nextStoryId);
+                }
+                else
+                {
+                    logger.LogWarning(
+                        "Failed to unlock next story for character {char}: index {index} was out of range",
+                        charaData.Id,
+                        nextStoryUnlockIndex
                     );
                 }
-
-                await storyRepository.GetOrCreateStory(
-                    StoryTypes.Chara,
-                    charaStories[nextStoryunlockIndex]
-                );
-
-                unlockedStories.Add(charaStories[nextStoryunlockIndex]);
             }
 
             // they smoked some shit

--- a/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/Services/Game/DragonService.cs
@@ -204,18 +204,22 @@ public class DragonService(
                     int nextStoryUnlockIndex = await storyRepository.Stories
                         .Where(x => dragonStories.Contains(x.StoryId))
                         .CountAsync();
-                    if (nextStoryUnlockIndex > dragonStories.Length - 1)
+
+                    int nextStoryId = dragonStories.ElementAtOrDefault(nextStoryUnlockIndex);
+
+                    if (nextStoryId != default)
                     {
-                        throw new DragaliaException(
-                            ResultCode.StoryCountNotEnough,
-                            "Too many story unlocks"
+                        await storyRepository.GetOrCreateStory(StoryTypes.Chara, nextStoryId);
+                        reward.is_release_story = 1;
+                    }
+                    else
+                    {
+                        logger.LogWarning(
+                            "Failed to unlock next story for dragon: index {index} was out of range",
+                            nextStoryUnlockIndex
                         );
                     }
-                    await storyRepository.GetOrCreateStory(
-                        StoryTypes.Dragon,
-                        dragonStories[nextStoryUnlockIndex]
-                    );
-                    reward.is_release_story = 1;
+
                     return reward;
                 }
                 if (levelIndex == 6)

--- a/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/Services/Game/DragonService.cs
@@ -209,7 +209,7 @@ public class DragonService(
 
                     if (nextStoryId != default)
                     {
-                        await storyRepository.GetOrCreateStory(StoryTypes.Chara, nextStoryId);
+                        await storyRepository.GetOrCreateStory(StoryTypes.Dragon, nextStoryId);
                         reward.is_release_story = 1;
                     }
                     else


### PR DESCRIPTION
Mana node unlocks are regularly failing because players already have all the stories of the character they are trying to unlock. This could be due to a save editor bug which has since been fixed. Change this so that it logs a warning instead of throwing; if the story is already unlocked it is probably fine to do nothing even if it shouldn't happen.