### PR TITLE
Fix single-enemy quests throwing errors on start

### DIFF
--- a/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -4,7 +4,7 @@ using JetBrains.Annotations;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
 
-public record QuestDropInfo(int QuestId, [NoEnumeration] IEnumerable<DropEntity> Drops);
+public record QuestDropInfo(int QuestId, DropEntity[] Drops);
 
 public record DropEntity(
     int Id,

--- a/DragaliaAPI/Features/Dungeon/SingleValuePicker.cs
+++ b/DragaliaAPI/Features/Dungeon/SingleValuePicker.cs
@@ -1,0 +1,19 @@
+using FluentRandomPicker.FluentInterfaces.General;
+
+namespace DragaliaAPI.Features.Dungeon.Start;
+
+public class SingleValuePicker<T> : IPick<T>
+{
+    private readonly T singleElement;
+
+    public SingleValuePicker(T singleElement)
+    {
+        this.singleElement = singleElement;
+    }
+
+    public IEnumerable<T> Pick(int n) => Enumerable.Repeat(this.singleElement, n);
+
+    public T PickOne() => this.singleElement;
+
+    public IEnumerable<T> PickDistinct(int n) => throw new NotSupportedException();
+}


### PR DESCRIPTION
FluentRandomPicker throws NotEnoughValuesToPickException when calling .WithPrioritizedElements with a collection that has fewer than 2 values. This is a problem since many boss quests only have 1 enemy. Some quests may only have 1 drop as well.

This commit implements an alternative implementation of IPick<T> that handles the single-element case and create a factory method to handle constructing either FluentRandomPicker's implementation or the custom implementation depending on the array length..