### PR TITLE
Address some performance issues with savefile updates

### DIFF
--- a/DragaliaAPI.Shared/MasterAsset/MasterAsset.cs
+++ b/DragaliaAPI.Shared/MasterAsset/MasterAsset.cs
@@ -265,25 +265,25 @@ public static class MasterAsset
     /// <summary>
     /// Dragon StoryId Arrays indexed by DragonId
     /// </summary>
-    public static MasterAssetData<int, StoryData> DragonStories =>
+    public static MasterAssetData<int, StoryData> DragonStories { get; } =
         new("Story/DragonStories.json", x => x.id);
 
     /// <summary>
     /// Character StoryId Arrays indexed by CharaId
     /// </summary>
-    public static MasterAssetData<int, StoryData> CharaStories =>
+    public static MasterAssetData<int, StoryData> CharaStories { get; } =
         new("Story/CharaStories.json", x => x.id);
 
-    public static MasterAssetData<int, UnitStory> UnitStory =>
+    public static MasterAssetData<int, UnitStory> UnitStory { get; } =
         new("Story/UnitStory.json", x => x.Id);
 
-    public static MasterAssetData<int, QuestStory> QuestStory =>
+    public static MasterAssetData<int, QuestStory> QuestStory { get; } =
         new("Story/QuestStory.json", x => x.Id);
 
-    public static MasterAssetData<int, EventStory> EventStory =>
+    public static MasterAssetData<int, EventStory> EventStory { get; } =
         new("Story/EventStory.json", x => x.Id);
 
-    public static MasterAssetData<int, QuestStoryRewardInfo> QuestStoryRewardInfo =>
+    public static MasterAssetData<int, QuestStoryRewardInfo> QuestStoryRewardInfo { get; } =
         new("Story/QuestStoryRewardInfo.json", x => x.Id);
 
     #endregion

--- a/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
+++ b/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using DragaliaAPI.Shared.Json;
+using Serilog;
 
 namespace DragaliaAPI.Shared.MasterAsset;
 
@@ -84,6 +85,8 @@ public class MasterAssetData<TKey, TItem>
 
     private InternalKeyedCollection DataFactory()
     {
+        Log.Verbose("Initializing MasterAsset {name}", this.jsonFilename);
+
         InternalKeyedCollection result = new(this.keySelector);
         string path = Path.Join(
             Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),

--- a/DragaliaAPI/Extensions/IEnumerableExtensions.cs
+++ b/DragaliaAPI/Extensions/IEnumerableExtensions.cs
@@ -36,15 +36,19 @@ public static class IEnumerableExtensions
         return Enumerable.Repeat(enumerable, count).SelectMany(x => x);
     }
 
-    public static async Task<HashSet<TElement>> ToHashSetAsync<TElement>(this IQueryable<TElement> enumerable,
+    public static async Task<HashSet<TElement>> ToHashSetAsync<TElement>(
+        this IQueryable<TElement> enumerable,
         IEqualityComparer<TElement>? comparer = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default
+    )
         where TElement : struct
     {
         comparer ??= EqualityComparer<TElement>.Default;
-        
+
         HashSet<TElement> set = new(comparer);
-        await foreach (TElement element in enumerable.AsAsyncEnumerable().WithCancellation(cancellationToken))
+        await foreach (
+            TElement element in enumerable.AsAsyncEnumerable().WithCancellation(cancellationToken)
+        )
         {
             set.Add(element);
         }

--- a/DragaliaAPI/Extensions/IEnumerableExtensions.cs
+++ b/DragaliaAPI/Extensions/IEnumerableExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Extensions;
 
@@ -33,5 +34,21 @@ public static class IEnumerableExtensions
             throw new ArgumentOutOfRangeException(nameof(count));
 
         return Enumerable.Repeat(enumerable, count).SelectMany(x => x);
+    }
+
+    public static async Task<HashSet<TElement>> ToHashSetAsync<TElement>(this IQueryable<TElement> enumerable,
+        IEqualityComparer<TElement>? comparer = null,
+        CancellationToken cancellationToken = default)
+        where TElement : struct
+    {
+        comparer ??= EqualityComparer<TElement>.Default;
+        
+        HashSet<TElement> set = new(comparer);
+        await foreach (TElement element in enumerable.AsAsyncEnumerable().WithCancellation(cancellationToken))
+        {
+            set.Add(element);
+        }
+
+        return set;
     }
 }

--- a/DragaliaAPI/Features/SavefileUpdate/SavefileUpdateService.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/SavefileUpdateService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.PlayerDetails;
@@ -43,13 +44,23 @@ public class SavefileUpdateService : ISavefileUpdateService
             return;
         }
 
+        Stopwatch s = new();
+
         foreach (ISavefileUpdate update in this.savefileUpdates.OrderBy(x => x.SavefileVersion))
         {
             if (player.SavefileVersion < update.SavefileVersion)
             {
-                this.logger.LogInformation("Applying savefile update {$update}", update);
+                s.Restart();
                 await update.Apply();
+                s.Stop();
+
                 player.SavefileVersion = update.SavefileVersion;
+
+                this.logger.LogInformation(
+                    "Applied savefile update {$update} (took: {time} ms)",
+                    update,
+                    s.ElapsedMilliseconds
+                );
             }
         }
 

--- a/DragaliaAPI/Features/SavefileUpdate/V14Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V14Update.cs
@@ -1,4 +1,5 @@
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Extensions;
 using DragaliaAPI.Features.Emblem;
 using DragaliaAPI.Features.Reward;
 using DragaliaAPI.Shared.Definitions.Enums;
@@ -30,8 +31,7 @@ public class V14Update(
         int storyCharacterId;
         int[] characterStoryList;
 
-        HashSet<Emblems> ownedEmblems =
-            new(await emblemRepository.Emblems.Select(x => x.EmblemId).ToListAsync());
+        HashSet<Emblems> ownedEmblems = await emblemRepository.Emblems.Select(x => x.EmblemId).ToHashSetAsync();
 
         foreach (int readStoryId in readStoryIdList)
         {

--- a/DragaliaAPI/Features/SavefileUpdate/V14Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V14Update.cs
@@ -31,7 +31,10 @@ public class V14Update(
         int storyCharacterId;
         int[] characterStoryList;
 
-        HashSet<Emblems> ownedEmblems = await emblemRepository.Emblems.Select(x => x.EmblemId).ToHashSetAsync();
+        HashSet<Emblems> ownedEmblems = await emblemRepository
+            .Emblems
+            .Select(x => x.EmblemId)
+            .ToHashSetAsync();
 
         foreach (int readStoryId in readStoryIdList)
         {


### PR DESCRIPTION
- Preload all emblems in v14update for dupe checking
- Stop story masterassets being loaded on every call
- Add more perf diagnostics around savefile updates