### PR TITLE
Fix ability crest upgrade issues

### DIFF
--- a/DragaliaAPI.Shared.Test/Unit/MasterAssetTest.cs
+++ b/DragaliaAPI.Shared.Test/Unit/MasterAssetTest.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Photon.Shared.Enums;
+﻿using System.Collections.Frozen;
+using DragaliaAPI.Photon.Shared.Enums;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
@@ -609,7 +610,7 @@ public class MasterAssetTest
     [Fact]
     public void AbilityCrestBuildupGroup_MaterialMap_ReturnsExpectedDictionary()
     {
-        Dictionary<Materials, int> map = MasterAsset
+        FrozenDictionary<Materials, int> map = MasterAsset
             .MasterAsset
             .AbilityCrestBuildupGroup
             .Get(6020603)
@@ -677,7 +678,7 @@ public class MasterAssetTest
     [Fact]
     public void AbilityCrestBuildupLevel_MaterialMap_ReturnsExpectedDictionary()
     {
-        Dictionary<Materials, int> map = MasterAsset
+        FrozenDictionary<Materials, int> map = MasterAsset
             .MasterAsset
             .AbilityCrestBuildupLevel
             .Get(901010)
@@ -791,7 +792,7 @@ public class MasterAssetTest
     [Fact]
     public void AbilityCrest_DuplicateMaterialMap_ReturnsExpectedDictionary()
     {
-        Dictionary<Materials, int> map = MasterAsset
+        FrozenDictionary<Materials, int> map = MasterAsset
             .MasterAsset
             .AbilityCrest
             .Get(AbilityCrests.TheGeniusTacticianBowsBoon)

--- a/DragaliaAPI.Shared/MasterAsset/MasterAssetUtils.cs
+++ b/DragaliaAPI.Shared/MasterAsset/MasterAssetUtils.cs
@@ -29,7 +29,7 @@ public static class MasterAssetUtils
     /// </summary>
     /// <param name="map">The material map.</param>
     /// <returns>The inverted material map.</returns>
-    public static Dictionary<Materials, int> Invert(this Dictionary<Materials, int> map) =>
+    public static Dictionary<Materials, int> Invert(this IDictionary<Materials, int> map) =>
         map.ToDictionary(x => x.Key, x => -x.Value);
 
     public static FortPlantDetail GetInitialFortPlant(FortPlants id) =>

--- a/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrest.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrest.cs
@@ -1,4 +1,6 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using System.Collections.Immutable;
+using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
 
@@ -31,10 +33,10 @@ public record AbilityCrest(
 
     public int GetBuildupLevelId(int level) => int.Parse($"{this.Rarity}010{level:00}");
 
-    public Dictionary<Materials, int> DuplicateMaterialMap { get; } =
+    public FrozenDictionary<Materials, int> DuplicateMaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>() { new(DuplicateEntityId, DuplicateEntityQuantity) }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 
     public IEnumerable<int> GetAbilities(int level)
     {

--- a/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrestBuildupGroup.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrestBuildupGroup.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
 
@@ -17,7 +18,7 @@ public record AbilityCrestBuildupGroup(
     int UniqueBuildupMaterialCount
 )
 {
-    public Dictionary<Materials, int> MaterialMap { get; } =
+    public FrozenDictionary<Materials, int> MaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(BuildupMaterialId1, BuildupMaterialQuantity1),
@@ -25,7 +26,7 @@ public record AbilityCrestBuildupGroup(
             new(BuildupMaterialId3, BuildupMaterialQuantity3),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 
     public bool IsUseUniqueMaterial => UniqueBuildupMaterialCount != 0;
 

--- a/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrestBuildupLevel.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/AbilityCrestBuildupLevel.cs
@@ -1,4 +1,6 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using System.Collections.Immutable;
+using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
 
@@ -15,7 +17,7 @@ public record AbilityCrestBuildupLevel(
     int UniqueBuildupMaterialCount
 )
 {
-    public Dictionary<Materials, int> MaterialMap { get; } =
+    public FrozenDictionary<Materials, int> MaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(BuildupMaterialId1, BuildupMaterialQuantity1),
@@ -23,7 +25,7 @@ public record AbilityCrestBuildupLevel(
             new(BuildupMaterialId3, BuildupMaterialQuantity3),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 
     public bool IsUseUniqueMaterial => UniqueBuildupMaterialCount != 0;
 };

--- a/DragaliaAPI.Shared/MasterAsset/Models/FortPlantDetail.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/FortPlantDetail.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
 
@@ -70,7 +71,7 @@ public record FortPlantDetail(
     string Odds
 )
 {
-    public Dictionary<Materials, int> CreateMaterialMap { get; } =
+    public FrozenDictionary<Materials, int> CreateMaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(MaterialsId1, MaterialsNum1),
@@ -80,5 +81,5 @@ public record FortPlantDetail(
             new(MaterialsId5, MaterialsNum5),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 }

--- a/DragaliaAPI.Shared/MasterAsset/Models/WeaponBody.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/WeaponBody.cs
@@ -1,4 +1,6 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using System.Collections.Immutable;
+using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
 
@@ -91,7 +93,7 @@ public record WeaponBody(
     int MaxAtk3
 )
 {
-    public Dictionary<Materials, int> CreateMaterialMap { get; } =
+    public FrozenDictionary<Materials, int> CreateMaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(CreateEntityId1, CreateEntityQuantity1),
@@ -101,7 +103,7 @@ public record WeaponBody(
             new(CreateEntityId5, CreateEntityQuantity5),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 
     /// <summary>
     /// Get the row id in the WeaponBodyBuildupGroup table corresponding to a particular operation and step

--- a/DragaliaAPI.Shared/MasterAsset/Models/WeaponBodyBuildupGroup.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/WeaponBodyBuildupGroup.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
@@ -26,7 +27,7 @@ public record WeaponBodyBuildupGroup(
     int BuildupMaterialQuantity7
 )
 {
-    public Dictionary<Materials, int> MaterialMap { get; } =
+    public FrozenDictionary<Materials, int> MaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(BuildupMaterialId1, BuildupMaterialQuantity1),
@@ -38,5 +39,5 @@ public record WeaponBodyBuildupGroup(
             new(BuildupMaterialId7, BuildupMaterialQuantity7),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 };

--- a/DragaliaAPI.Shared/MasterAsset/Models/WeaponBodyBuildupLevel.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/WeaponBodyBuildupLevel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
@@ -14,7 +15,7 @@ public record WeaponBodyBuildupLevel(
     int BuildupMaterialQuantity3
 )
 {
-    public Dictionary<Materials, int> MaterialMap { get; } =
+    public FrozenDictionary<Materials, int> MaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(BuildupMaterialId1, BuildupMaterialQuantity1),
@@ -22,5 +23,5 @@ public record WeaponBodyBuildupLevel(
             new(BuildupMaterialId3, BuildupMaterialQuantity3),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 };

--- a/DragaliaAPI.Shared/MasterAsset/Models/WeaponPassiveAbility.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/WeaponPassiveAbility.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models;
@@ -25,7 +26,7 @@ public record WeaponPassiveAbility(
     int AbilityId
 )
 {
-    public Dictionary<Materials, int> MaterialMap { get; } =
+    public FrozenDictionary<Materials, int> MaterialMap { get; } =
         new List<KeyValuePair<Materials, int>>()
         {
             new(UnlockMaterialId1, UnlockMaterialQuantity1),
@@ -35,5 +36,5 @@ public record WeaponPassiveAbility(
             new(UnlockMaterialId5, UnlockMaterialQuantity5),
         }
             .Where(x => x.Key != Materials.Empty)
-            .ToDictionary(x => x.Key, x => x.Value);
+            .ToFrozenDictionary(x => x.Key, x => x.Value);
 };

--- a/DragaliaAPI.Test/Services/AbilityCrestServiceTest.cs
+++ b/DragaliaAPI.Test/Services/AbilityCrestServiceTest.cs
@@ -8,11 +8,13 @@ using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Test.Utils;
+using Xunit.Abstractions;
 
 namespace DragaliaAPI.Test.Services;
 
 public class AbilityCrestServiceTest
 {
+    private readonly ITestOutputHelper testOutputHelper;
     private readonly Mock<IAbilityCrestRepository> mockAbilityCrestRepository;
     private readonly Mock<IInventoryRepository> mockInventoryRepository;
     private readonly Mock<IUserDataRepository> mockUserDataRepository;
@@ -165,8 +167,9 @@ public class AbilityCrestServiceTest
             new object[] { AbilityCrests.TutelarysDestinyWolfsBoon, Rarity9LevelMap, 4, 30 }
         };
 
-    public AbilityCrestServiceTest()
+    public AbilityCrestServiceTest(ITestOutputHelper testOutputHelper)
     {
+        this.testOutputHelper = testOutputHelper;
         this.mockAbilityCrestRepository = new(MockBehavior.Strict);
         this.mockInventoryRepository = new(MockBehavior.Strict);
         this.mockUserDataRepository = new(MockBehavior.Strict);
@@ -443,15 +446,15 @@ public class AbilityCrestServiceTest
                 step = 2
             };
 
+        Dictionary<Materials, int> expectedMap =
+            new() { { Materials.JadeInsignia, 40 }, { Materials.DyrenellAureus, 5 } };
         this.mockInventoryRepository
             .Setup(
                 x =>
                     x.CheckQuantity(
-                        new Dictionary<Materials, int>()
-                        {
-                            { Materials.JadeInsignia, 40 },
-                            { Materials.DyrenellAureus, 5 }
-                        }
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => y.IsEquivalent(expectedMap, this.testOutputHelper)
+                        )
                     )
             )
             .ReturnsAsync(false);
@@ -650,7 +653,16 @@ public class AbilityCrestServiceTest
                 step = step
             };
 
-        this.mockInventoryRepository.Setup(x => x.CheckQuantity(materialMap)).ReturnsAsync(true);
+        this.mockInventoryRepository
+            .Setup(
+                x =>
+                    x.CheckQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => y.IsEquivalent(materialMap, this.testOutputHelper)
+                        )
+                    )
+            )
+            .ReturnsAsync(true);
         this.mockUserDataRepository.Setup(x => x.CheckDewpoint(dewpoint)).ReturnsAsync(true);
         this.mockAbilityCrestRepository
             .Setup(x => x.FindAsync(abilityCrestId))
@@ -663,7 +675,14 @@ public class AbilityCrestServiceTest
                 }
             );
         this.mockInventoryRepository
-            .Setup(x => x.UpdateQuantity(materialMap.Invert()))
+            .Setup(
+                x =>
+                    x.UpdateQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => y.IsEquivalent(materialMap.Invert(), this.testOutputHelper)
+                        )
+                    )
+            )
             .Returns(Task.CompletedTask);
         this.mockUserDataRepository
             .Setup(x => x.UpdateDewpoint(-dewpoint))
@@ -695,7 +714,16 @@ public class AbilityCrestServiceTest
                 step = 2
             };
 
-        this.mockInventoryRepository.Setup(x => x.CheckQuantity(materialMap)).ReturnsAsync(true);
+        this.mockInventoryRepository
+            .Setup(
+                x =>
+                    x.CheckQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => y.IsEquivalent(materialMap, this.testOutputHelper)
+                        )
+                    )
+            )
+            .ReturnsAsync(true);
         this.mockUserDataRepository.Setup(x => x.CheckDewpoint(dewpoint)).ReturnsAsync(true);
         this.mockAbilityCrestRepository
             .Setup(x => x.FindAsync(abilityCrestId))
@@ -708,7 +736,14 @@ public class AbilityCrestServiceTest
                 }
             );
         this.mockInventoryRepository
-            .Setup(x => x.UpdateQuantity(materialMap.Invert()))
+            .Setup(
+                x =>
+                    x.UpdateQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => y.IsEquivalent(materialMap.Invert(), this.testOutputHelper)
+                        )
+                    )
+            )
             .Returns(Task.CompletedTask);
         this.mockUserDataRepository
             .Setup(x => x.UpdateDewpoint(-dewpoint))

--- a/DragaliaAPI.Test/Services/WeaponServiceTest.cs
+++ b/DragaliaAPI.Test/Services/WeaponServiceTest.cs
@@ -157,7 +157,14 @@ public class WeaponServiceTest
             .ReturnsAsync(true);
 
         this.mockInventoryRepository
-            .Setup(x => x.CheckQuantity(weaponData.CreateMaterialMap))
+            .Setup(
+                x =>
+                    x.CheckQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => ValidateMaterialMap(weaponData.CreateMaterialMap, y)
+                        )
+                    )
+            )
             .ReturnsAsync(false);
 
         (await this.weaponService.ValidateCraft(WeaponBodies.PrimalCrimson)).Should().BeFalse();
@@ -185,7 +192,14 @@ public class WeaponServiceTest
             .ReturnsAsync(true);
 
         this.mockInventoryRepository
-            .Setup(x => x.CheckQuantity(weaponData.CreateMaterialMap))
+            .Setup(
+                x =>
+                    x.CheckQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => ValidateMaterialMap(weaponData.CreateMaterialMap, y)
+                        )
+                    )
+            )
             .ReturnsAsync(true);
 
         this.mockUserDataRepository
@@ -218,7 +232,14 @@ public class WeaponServiceTest
             .ReturnsAsync(true);
 
         this.mockInventoryRepository
-            .Setup(x => x.CheckQuantity(weaponData.CreateMaterialMap))
+            .Setup(
+                x =>
+                    x.CheckQuantity(
+                        It.Is<IEnumerable<KeyValuePair<Materials, int>>>(
+                            y => ValidateMaterialMap(weaponData.CreateMaterialMap, y)
+                        )
+                    )
+            )
             .ReturnsAsync(true);
 
         this.mockUserDataRepository
@@ -1057,21 +1078,16 @@ public class WeaponServiceTest
     /// <param name="input"></param>
     /// <returns></returns>
     private bool ValidateMaterialMap(
-        Dictionary<Materials, int> expected,
+        IDictionary<Materials, int> expected,
         IEnumerable<KeyValuePair<Materials, int>> input
     )
     {
         if (input.Count() != expected.Count())
             return false;
 
-        foreach (
-            (
-                KeyValuePair<Materials, int> inputKv,
-                KeyValuePair<Materials, int> actualKv
-            ) in input.Zip(expected)
-        )
+        foreach ((Materials material, int quantity) in input)
         {
-            if (!(inputKv.Key == actualKv.Key && inputKv.Value == actualKv.Value))
+            if (expected[material] != quantity)
                 return false;
         }
 

--- a/DragaliaAPI.Test/UnitTestUtils.cs
+++ b/DragaliaAPI.Test/UnitTestUtils.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using MockQueryable.Moq;
 using Moq.Language.Flow;
+using Xunit.Abstractions;
 
 namespace DragaliaAPI.Test;
 
@@ -113,4 +114,18 @@ public static class UnitTestUtils
                     .AsQueryable()
                     .BuildMock()
             );
+
+    public static bool IsEquivalent(this object input, object comparison, ITestOutputHelper? output)
+    {
+        try
+        {
+            input.Should().BeEquivalentTo(comparison);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            output?.WriteLine(ex.Message);
+            return false;
+        }
+    }
 }

--- a/DragaliaAPI/Services/Game/AbilityCrestService.cs
+++ b/DragaliaAPI/Services/Game/AbilityCrestService.cs
@@ -111,7 +111,7 @@ public class AbilityCrestService : IAbilityCrestService
             return ResultCode.AbilityCrestBuildupPieceUnablePiece;
         }
 
-        Dictionary<Materials, int> materialMap = buildupInfo.MaterialMap;
+        Dictionary<Materials, int> materialMap = buildupInfo.MaterialMap.ToDictionary();
         int dewpoint = buildupInfo.BuildupDewPoint;
 
         if (buildupInfo.IsUseUniqueMaterial)
@@ -172,7 +172,7 @@ public class AbilityCrestService : IAbilityCrestService
         }
 
         CheckDedicated(buildup);
-        Dictionary<Materials, int> materialMap = levelInfo.MaterialMap;
+        Dictionary<Materials, int> materialMap = levelInfo.MaterialMap.ToDictionary();
 
         if (levelInfo.IsUseUniqueMaterial)
         {

--- a/DragaliaAPI/Services/Game/WeaponService.cs
+++ b/DragaliaAPI/Services/Game/WeaponService.cs
@@ -167,7 +167,7 @@ public class WeaponService : IWeaponService
             return ResultCode.WeaponBodyBuildupPieceUnablePiece;
         }
 
-        Dictionary<Materials, int> materialMap = buildupGroup.MaterialMap;
+        Dictionary<Materials, int> materialMap = buildupGroup.MaterialMap.ToDictionary();
         long coin = buildupGroup.BuildupCoin;
 
         if (
@@ -280,7 +280,7 @@ public class WeaponService : IWeaponService
             return ResultCode.WeaponBodyBuildupPieceUnablePiece;
         }
 
-        Dictionary<Materials, int> materialMap = passiveAbility.MaterialMap;
+        Dictionary<Materials, int> materialMap = passiveAbility.MaterialMap.ToDictionary();
         long coin = passiveAbility.UnlockCoin;
 
         if (!await this.ValidateCost(materialMap, coin))
@@ -331,7 +331,7 @@ public class WeaponService : IWeaponService
             return ResultCode.WeaponBodyBuildupPieceUnablePiece;
         }
 
-        Dictionary<Materials, int> materialMap = buildupLevel.MaterialMap;
+        Dictionary<Materials, int> materialMap = buildupLevel.MaterialMap.ToDictionary();
 
         if (!await this.ValidateCost(materialMap))
             return ResultCode.CommonMaterialShort;


### PR DESCRIPTION
Closes #505 and #295 

The root cause of both issues was that certain code in the `AbilityCrestService` was permanently updating a `Dictionary<Materials, int>` material map in instances of `MasterAsset`. These effects would persist until server restart.

@Nightmerp this is 100% my fault for exposing a `Dictionary` publicly rather than the ability crest code

Fix this by using `FrozenDictionary<Materials, int>` instead, and having callers call `ToDictionary` when a copy is needed.