### PR TITLE
Use ExecuteDeleteAsync over RemoveRange in save import

### DIFF
--- a/DragaliaAPI.Database/DatabaseConfiguration.cs
+++ b/DragaliaAPI.Database/DatabaseConfiguration.cs
@@ -23,7 +23,6 @@ public static class DatabaseConfiguration
     )
     {
         string connectionString = GetConnectionString(host);
-        // logger.Debug("Connecting to database using host {host}...", host);
 
         services = services
             .AddDbContext<ApiContext>(
@@ -80,12 +79,6 @@ public static class DatabaseConfiguration
             .ServiceProvider
             .GetRequiredService<ILoggerFactory>()
             .CreateLogger("DatabaseConfiguration");
-
-        logger.LogInformation(
-            "Connecting to database using username {username} and database {database}",
-            Environment.GetEnvironmentVariable("POSTGRES_PASSWORD"),
-            Environment.GetEnvironmentVariable("POSTGRES_DB")
-        );
 
         if (!context.Database.IsRelational())
             return;

--- a/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.Json;
 using Microsoft.EntityFrameworkCore;
 
@@ -177,6 +178,25 @@ public class SavefileImportTest : TestFixture
             .StoryType
             .Should()
             .Be(StoryTypes.Dragon);
+    }
+
+    [Fact]
+    public async Task Import_DoesNotDeleteEmblems()
+    {
+        await this.AddToDatabase(
+            new DbEmblem() { ViewerId = ViewerId, EmblemId = Emblems.IsolationSpeedslayer_1 }
+        );
+
+        this.ApiContext.ChangeTracker.Clear();
+
+        HttpContent content = PrepareSavefileRequest();
+        await this.Client.PostAsync($"savefile/import/{ViewerId}", content);
+
+        this.ApiContext
+            .Emblems
+            .AsNoTracking()
+            .Should()
+            .Contain(x => x.ViewerId == ViewerId && x.EmblemId == Emblems.IsolationSpeedslayer_1);
     }
 
     [Fact]

--- a/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/Services/Game/SavefileService.cs
@@ -138,7 +138,7 @@ public class SavefileService : ISavefileService
                 .Database
                 .BeginTransactionAsync();
 
-            this.Delete();
+            await this.Delete();
 
             this.logger.LogDebug(
                 "Deleting savedata step done after {t} ms",
@@ -457,90 +457,98 @@ public class SavefileService : ISavefileService
         }
     }
 
-    private void Delete() => this.Delete(this.playerIdentityService.ViewerId);
+    private Task Delete() => this.Delete(this.playerIdentityService.ViewerId);
 
-    private void Delete(long viewerId)
+    private async Task Delete(long viewerId)
     {
         // Options commented out have been excluded from save import deletion process.
         // They will still be deleted by cascade delete when a player is actually deleted
         // without being re-added as they are in save imports.
-        this.apiContext
-            .Players
-            .RemoveRange(this.apiContext.Players.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+        await this.apiContext.Players.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerUserData
-            .RemoveRange(this.apiContext.PlayerUserData.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerCharaData
-            .RemoveRange(this.apiContext.PlayerCharaData.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerDragonReliability
-            .RemoveRange(
-                this.apiContext.PlayerDragonReliability.Where(x => x.ViewerId == viewerId)
-            );
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerDragonData
-            .RemoveRange(this.apiContext.PlayerDragonData.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerAbilityCrests
-            .RemoveRange(this.apiContext.PlayerAbilityCrests.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerStoryState
-            .RemoveRange(this.apiContext.PlayerStoryState.Where(x => x.ViewerId == viewerId));
-        this.apiContext
-            .PlayerQuests
-            .RemoveRange(this.apiContext.PlayerQuests.Where(x => x.ViewerId == viewerId));
-        this.apiContext
-            .PlayerParties
-            .RemoveRange(this.apiContext.PlayerParties.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext.PlayerQuests.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext.PlayerParties.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerPartyUnits
-            .RemoveRange(this.apiContext.PlayerPartyUnits.Where(x => x.ViewerId == viewerId));
-        this.apiContext
-            .PlayerWeapons
-            .RemoveRange(this.apiContext.PlayerWeapons.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext.PlayerWeapons.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerMaterials
-            .RemoveRange(this.apiContext.PlayerMaterials.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerTalismans
-            .RemoveRange(this.apiContext.PlayerTalismans.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerFortBuilds
-            .RemoveRange(this.apiContext.PlayerFortBuilds.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerWeaponSkins
-            .RemoveRange(this.apiContext.PlayerWeaponSkins.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerPassiveAbilities
-            .RemoveRange(this.apiContext.PlayerPassiveAbilities.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerDragonGifts
-            .RemoveRange(this.apiContext.PlayerDragonGifts.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerMissions
-            .RemoveRange(this.apiContext.PlayerMissions.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .EquippedStamps
-            .RemoveRange(this.apiContext.EquippedStamps.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerShopInfos
-            .RemoveRange(this.apiContext.PlayerShopInfos.Where(x => x.ViewerId == viewerId));
-        this.apiContext
-            .PlayerTrades
-            .RemoveRange(this.apiContext.PlayerTrades.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext.PlayerTrades.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerEventData
-            .RemoveRange(this.apiContext.PlayerEventData.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerEventItems
-            .RemoveRange(this.apiContext.PlayerEventItems.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerEventRewards
-            .RemoveRange(this.apiContext.PlayerEventRewards.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerEventPassives
-            .RemoveRange(this.apiContext.PlayerEventPassives.Where(x => x.ViewerId == viewerId));
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
         // this.apiContext.PlayerDmodeInfos.RemoveRange(
         //     this.apiContext.PlayerDmodeInfos.Where(x => x.ViewerId == viewerId)
         // );
@@ -558,27 +566,27 @@ public class SavefileService : ISavefileService
         // this.apiContext.PlayerDmodeExpeditions.RemoveRange(
         //     this.apiContext.PlayerDmodeExpeditions.Where(x => x.ViewerId == viewerId)
         // );
-        this.apiContext
+        await this.apiContext
             .PlayerUseItems
-            .RemoveRange(this.apiContext.PlayerUseItems.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerSummonTickets
-            .RemoveRange(this.apiContext.PlayerSummonTickets.Where(x => x.ViewerId == viewerId));
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
         // this.apiContext.Emblems.RemoveRange(
         //     this.apiContext.Emblems.Where(x => x.ViewerId == viewerId)
         // );
-        this.apiContext
-            .QuestEvents
-            .RemoveRange(this.apiContext.QuestEvents.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+        await this.apiContext.QuestEvents.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .QuestTreasureList
-            .RemoveRange(this.apiContext.QuestTreasureList.Where(x => x.ViewerId == viewerId));
-        this.apiContext
-            .PartyPowers
-            .RemoveRange(this.apiContext.PartyPowers.Where(x => x.ViewerId == viewerId));
-        this.apiContext
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await this.apiContext.PartyPowers.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
+        await this.apiContext
             .PlayerQuestWalls
-            .RemoveRange(this.apiContext.PlayerQuestWalls.Where(x => x.ViewerId == viewerId));
+            .Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
     }
 
     public async Task Reset()


### PR DESCRIPTION
It turns out that `RemoveRange(IQueryable<TEntity>)` enumerates the query synchronously then tracks all of those as deleted.

We are in a transaction so should be faster and equally as safe to use ExecuteDeleteAsync.