### PR TITLE
Weapon passive ability fix + refactoring

### DIFF
--- a/DragaliaAPI.Database/Entities/DbWeaponBody.cs
+++ b/DragaliaAPI.Database/Entities/DbWeaponBody.cs
@@ -62,20 +62,10 @@ public class DbWeaponBody : DbPlayerData
     [NotMapped]
     public int AdditionalEffectCount { get; }
 
-    public string UnlockWeaponPassiveAbilityNoString { get; private set; } =
-        "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0";
-
     /// <summary>
     /// Gets or sets a list of passive abilities that are unlocked on the weapon.
     /// </summary>
-    [NotMapped]
-    public IEnumerable<int> UnlockWeaponPassiveAbilityNoList
-    {
-        // I will consider replacing this with a bitmask if we generate a unified helper for them
-        // Currently opposed to having another util class
-        get => this.UnlockWeaponPassiveAbilityNoString.Split(",").Select(int.Parse);
-        set => this.UnlockWeaponPassiveAbilityNoString = string.Join(",", value);
-    }
+    public int[] UnlockWeaponPassiveAbilityNoList { get; set; } = new int[15];
 
     /// <summary>
     /// Gets or sets a value indicating whether the weapon bonus has been unlocked.

--- a/DragaliaAPI.Database/Migrations/20231204191101_WeaponPassives.Designer.cs
+++ b/DragaliaAPI.Database/Migrations/20231204191101_WeaponPassives.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20231204191101_WeaponPassives")]
+    partial class WeaponPassives
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI.Database/Migrations/20231204191101_WeaponPassives.cs
+++ b/DragaliaAPI.Database/Migrations/20231204191101_WeaponPassives.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class WeaponPassives : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            
+            migrationBuilder.AddColumn<int[]>(
+                name: "UnlockWeaponPassiveAbilityNoList",
+                table: "PlayerWeapons",
+                type: "integer[]",
+                nullable: false,
+                defaultValue: new int[0]);
+
+            migrationBuilder.Sql(
+                """
+                UPDATE "PlayerWeapons" w SET "UnlockWeaponPassiveAbilityNoList" = string_to_array("UnlockWeaponPassiveAbilityNoString", ',')::int[];
+                """);
+            
+            migrationBuilder.DropColumn(
+                name: "UnlockWeaponPassiveAbilityNoString",
+                table: "PlayerWeapons");
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "UnlockWeaponPassiveAbilityNoList",
+                table: "PlayerWeapons");
+
+            migrationBuilder.AddColumn<string>(
+                name: "UnlockWeaponPassiveAbilityNoString",
+                table: "PlayerWeapons",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/DragaliaAPI.Database/Repositories/WeaponRepository.cs
+++ b/DragaliaAPI.Database/Repositories/WeaponRepository.cs
@@ -129,6 +129,11 @@ public class WeaponRepository : IWeaponRepository
     {
         this.logger.LogDebug("Unlocking passive ability {@ability}", passiveAbility);
 
+        DbWeaponBody? entity = await this.FindAsync(id);
+        ArgumentNullException.ThrowIfNull(entity);
+
+        entity.UnlockWeaponPassiveAbilityNoList[passiveAbility.WeaponPassiveAbilityNo - 1] = 1;
+
         if (
             await this.WeaponPassiveAbilities.AnyAsync(
                 x => x.WeaponPassiveAbilityId == passiveAbility.Id
@@ -138,13 +143,6 @@ public class WeaponRepository : IWeaponRepository
             this.logger.LogDebug("Passive was already owned.");
             return;
         }
-
-        DbWeaponBody? entity = await this.FindAsync(id);
-        ArgumentNullException.ThrowIfNull(entity);
-
-        List<int> passiveList = entity.UnlockWeaponPassiveAbilityNoList.ToList();
-        passiveList[passiveAbility.WeaponPassiveAbilityNo - 1] = 1;
-        entity.UnlockWeaponPassiveAbilityNoList = passiveList;
 
         await this.apiContext
             .PlayerPassiveAbilities

--- a/DragaliaAPI/AutoMapper/Profiles/UnitReverseMapProfile.cs
+++ b/DragaliaAPI/AutoMapper/Profiles/UnitReverseMapProfile.cs
@@ -28,9 +28,8 @@ public class UnitReverseMapProfile : Profile
             .ForMember(x => x.Exp, opts => opts.MapFrom(src => src.reliability_total_exp));
 
         this.CreateMap<AbilityCrestList, DbAbilityCrest>();
-
-        this.CreateMap<WeaponBodyList, DbWeaponBody>()
-            .ForMember(x => x.UnlockWeaponPassiveAbilityNoString, opts => opts.Ignore());
+        
+        this.CreateMap<WeaponBodyList, DbWeaponBody>();
 
         this.CreateMap<PartyList, DbParty>()
             .ForMember(x => x.Units, opts => opts.MapFrom(src => src.party_setting_list));

--- a/DragaliaAPI/AutoMapper/Profiles/UnitReverseMapProfile.cs
+++ b/DragaliaAPI/AutoMapper/Profiles/UnitReverseMapProfile.cs
@@ -28,7 +28,7 @@ public class UnitReverseMapProfile : Profile
             .ForMember(x => x.Exp, opts => opts.MapFrom(src => src.reliability_total_exp));
 
         this.CreateMap<AbilityCrestList, DbAbilityCrest>();
-        
+
         this.CreateMap<WeaponBodyList, DbWeaponBody>();
 
         this.CreateMap<PartyList, DbParty>()


### PR DESCRIPTION
- Fix weapon_passive_ability_no_list never getting updated if the duplicate weapon passive ability check is hit. This would mean the passive would always show as able to be unlocked + would always consume materials
- Use an int array for the DB model instead of a formatted string. Uses postgres's int array type. https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-8.0/whatsnew#primitive-collections