### PR TITLE
Fix Wyrmite payment calculation for finishing fort builds

### DIFF
--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -615,7 +615,7 @@ public class FortServiceTest
                             840 - wyrmiteDifference,
                             842 - wyrmiteDifference,
                             Range.Inclusive
-                            )
+                        )
                     )
             )
             .Returns(Task.CompletedTask);

--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -599,7 +599,7 @@ public class FortServiceTest
                 Level = 5,
                 PlantId = FortPlants.Smithy,
                 BuildStartDate = FixedTime - TimeSpan.FromDays(1),
-                BuildEndDate = FixedTime + TimeSpan.FromDays(7)
+                BuildEndDate = FixedTime + TimeSpan.FromDays(6)
             };
 
         const int wyrmiteDifference = 24 * 60 / 12;
@@ -614,7 +614,8 @@ public class FortServiceTest
                         It.IsInRange(
                             840 - wyrmiteDifference,
                             842 - wyrmiteDifference,
-                            Range.Inclusive)
+                            Range.Inclusive
+                            )
                     )
             )
             .Returns(Task.CompletedTask);

--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -611,7 +611,10 @@ public class FortServiceTest
                     x.ProcessPayment(
                         PaymentTypes.Wyrmite,
                         null,
-                        It.IsInRange(840 - wyrmiteDifference, 842 - wyrmiteDifference, Range.Inclusive)
+                        It.IsInRange(
+                            840 - wyrmiteDifference,
+                            842 - wyrmiteDifference,
+                            Range.Inclusive)
                     )
             )
             .Returns(Task.CompletedTask);

--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -619,6 +619,5 @@ public class FortServiceTest
         mockFortMissionProgressionService.VerifyAll();
         mockPaymentService.VerifyAll();
         mockDateTimeProvider.VerifyAll();
-        mockDateTimeProvider.VerifyAll();
     }
 }

--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -6,6 +6,7 @@ using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.Reward;
 using DragaliaAPI.Features.Shop;
+using DragaliaAPI.Helpers;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Services.Exceptions;
@@ -31,6 +32,9 @@ public class FortServiceTest
     private readonly Mock<IRewardService> mockRewardService;
     private readonly Mock<IOptionsMonitor<DragonfruitConfig>> mockConfig;
     private readonly Mock<IUserService> mockUserService;
+    private readonly Mock<IDateTimeProvider> mockDateTimeProvider;
+
+    private readonly DateTimeOffset FixedTime = DateTimeOffset.UtcNow;
 
     private readonly IFortService fortService;
 
@@ -47,6 +51,7 @@ public class FortServiceTest
         this.mockRewardService = new(MockBehavior.Strict);
         this.mockConfig = new(MockBehavior.Strict);
         this.mockUserService = new(MockBehavior.Strict);
+        this.mockDateTimeProvider = new(MockBehavior.Strict);
 
         this.mockConfig
             .SetupGet(x => x.CurrentValue)
@@ -97,8 +102,11 @@ public class FortServiceTest
             mockPaymentService.Object,
             mockRewardService.Object,
             mockConfig.Object,
-            mockUserService.Object
+            mockUserService.Object,
+            mockDateTimeProvider.Object
         );
+
+        mockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(FixedTime);
 
         UnitTestUtils.ApplyDateTimeAssertionOptions();
     }
@@ -223,8 +231,8 @@ public class FortServiceTest
             {
                 ViewerId = 1,
                 Level = 2,
-                BuildStartDate = DateTimeOffset.UtcNow,
-                BuildEndDate = DateTimeOffset.UtcNow + TimeSpan.FromSeconds(5)
+                BuildStartDate = FixedTime,
+                BuildEndDate = FixedTime + TimeSpan.FromSeconds(5)
             };
 
         mockFortMissionProgressionService
@@ -242,6 +250,7 @@ public class FortServiceTest
         mockPaymentService.VerifyAll();
         mockFortMissionProgressionService.VerifyAll();
         mockFortRepository.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 
     [Fact]
@@ -252,8 +261,8 @@ public class FortServiceTest
             {
                 BuildId = 1,
                 ViewerId = 1,
-                BuildStartDate = DateTimeOffset.UtcNow,
-                BuildEndDate = DateTimeOffset.UtcNow + TimeSpan.FromDays(1),
+                BuildStartDate = FixedTime,
+                BuildEndDate = FixedTime + TimeSpan.FromDays(1),
                 Level = 2,
             };
         mockFortRepository.Setup(x => x.GetBuilding(1)).ReturnsAsync(build);
@@ -275,8 +284,8 @@ public class FortServiceTest
             {
                 BuildId = 1,
                 ViewerId = 1,
-                BuildStartDate = DateTimeOffset.UtcNow,
-                BuildEndDate = DateTimeOffset.UtcNow + TimeSpan.FromDays(1),
+                BuildStartDate = FixedTime,
+                BuildEndDate = FixedTime + TimeSpan.FromDays(1),
                 Level = 0,
             };
         mockFortRepository.Setup(x => x.GetBuilding(1)).ReturnsAsync(build);
@@ -322,7 +331,7 @@ public class FortServiceTest
                 BuildId = 1,
                 ViewerId = 1,
                 BuildStartDate = DateTimeOffset.UnixEpoch,
-                BuildEndDate = DateTimeOffset.UtcNow - TimeSpan.FromMinutes(1),
+                BuildEndDate = FixedTime - TimeSpan.FromMinutes(1),
                 Level = 2,
             };
         mockFortRepository.Setup(x => x.GetBuilding(1)).ReturnsAsync(build);
@@ -338,6 +347,7 @@ public class FortServiceTest
         build.BuildEndDate.Should().Be(DateTimeOffset.UnixEpoch);
 
         mockFortRepository.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 
     [Fact]
@@ -364,6 +374,7 @@ public class FortServiceTest
         build.BuildEndDate.Should().Be(DateTimeOffset.MaxValue);
 
         mockFortRepository.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 
     [Fact]
@@ -473,18 +484,19 @@ public class FortServiceTest
         await fortService.LevelupStart(1);
 
         build.Level.Should().Be(20);
-        build.BuildStartDate.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromSeconds(1));
+        build.BuildStartDate.Should().BeCloseTo(FixedTime, TimeSpan.FromSeconds(1));
         build
             .BuildEndDate
             .Should()
             .BeCloseTo(
-                DateTimeOffset.UtcNow + TimeSpan.FromSeconds(21600),
+                FixedTime + TimeSpan.FromSeconds(21600),
                 TimeSpan.FromSeconds(1)
             );
 
         mockFortRepository.VerifyAll();
         mockInventoryRepository.VerifyAll();
         mockUserDataRepository.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 
     [Fact]
@@ -551,8 +563,8 @@ public class FortServiceTest
                 BuildId = 444,
                 Level = 5,
                 PlantId = FortPlants.Smithy,
-                BuildStartDate = DateTimeOffset.UtcNow,
-                BuildEndDate = DateTimeOffset.UtcNow + TimeSpan.FromDays(7)
+                BuildStartDate = FixedTime,
+                BuildEndDate = FixedTime + TimeSpan.FromDays(7)
             };
 
         mockFortRepository.Setup(x => x.GetBuilding(444)).ReturnsAsync(build);
@@ -576,6 +588,7 @@ public class FortServiceTest
         mockFortMissionProgressionService.VerifyAll();
         mockPaymentService.VerifyAll();
         mockPlayerIdentityService.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 
     [Fact]
@@ -588,8 +601,8 @@ public class FortServiceTest
                 BuildId = 445,
                 Level = 5,
                 PlantId = FortPlants.Smithy,
-                BuildStartDate = DateTimeOffset.UtcNow,
-                BuildEndDate = DateTimeOffset.UtcNow + TimeSpan.FromDays(7)
+                BuildStartDate = FixedTime,
+                BuildEndDate = FixedTime + TimeSpan.FromDays(7)
             };
 
         mockFortRepository.Setup(x => x.GetBuilding(445)).ReturnsAsync(build);
@@ -605,5 +618,7 @@ public class FortServiceTest
 
         mockFortMissionProgressionService.VerifyAll();
         mockPaymentService.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
+        mockDateTimeProvider.VerifyAll();
     }
 }

--- a/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -488,10 +488,7 @@ public class FortServiceTest
         build
             .BuildEndDate
             .Should()
-            .BeCloseTo(
-                FixedTime + TimeSpan.FromSeconds(21600),
-                TimeSpan.FromSeconds(1)
-            );
+            .BeCloseTo(FixedTime + TimeSpan.FromSeconds(21600), TimeSpan.FromSeconds(1));
 
         mockFortRepository.VerifyAll();
         mockInventoryRepository.VerifyAll();


### PR DESCRIPTION
Until now this was based on the buildStartTime, but it should actually be calculated based on the current time.