### PR TITLE
Fix treasure chests not appearing at the end of quests

### DIFF
--- a/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -206,7 +206,6 @@ public class QuestEnemyService : IQuestEnemyService
         }
 
         return enemyParamList
-            .OrderBy(x => x.Id)
             .Where(x => x.Tough != Toughness.RareEnemy)
             .Select(
                 (x, idx) =>


### PR DESCRIPTION
A change was made in #527 to order the enemy list by param_id, but it seems other quests strongly dislike this and will start reporting inaccurate information about which enemies were killed, leading to no drops being granted in /dungeon_record/record.