### PR TITLE
Fix event user data always returning null for events with no items

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -59,4 +59,23 @@ public class RaidEventTest : TestFixture
         evtResp.data.update_data_list.Should().NotBeNull();
         evtResp.data.update_data_list.raid_event_user_list.Should().HaveCount(1); // Reward is a raid event item so we test this
     }
+
+    [Fact]
+    public async Task Entry_EventHasNoItems_InitializesUserData()
+    {
+        const int fracturedFuturesId = 20427;
+
+        await this.Client.PostMsgpack(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(fracturedFuturesId)
+        );
+
+        DragaliaResponse<RaidEventGetEventDataData> response =
+            await this.Client.PostMsgpack<RaidEventGetEventDataData>(
+                "raid_event/get_event_data",
+                new RaidEventGetEventDataRequest(fracturedFuturesId)
+            );
+
+        response.data.raid_event_user_data.Should().NotBeNull();
+    }
 }

--- a/DragaliaAPI/Features/Event/EventRepository.cs
+++ b/DragaliaAPI/Features/Event/EventRepository.cs
@@ -26,6 +26,9 @@ public class EventRepository(ApiContext apiContext, IPlayerIdentityService playe
         return await apiContext.PlayerEventData.FindAsync(playerIdentityService.ViewerId, eventId);
     }
 
+    public async Task<bool> HasEventDataAsync(int eventId) =>
+        await this.EventData.Where(x => x.EventId == eventId).AnyAsync();
+
     public async Task<IEnumerable<DbPlayerEventReward>> GetEventRewardsAsync(
         int eventId,
         bool isLocationReward = false

--- a/DragaliaAPI/Features/Event/EventService.cs
+++ b/DragaliaAPI/Features/Event/EventService.cs
@@ -333,13 +333,13 @@ public class EventService(
 
     public async Task<RaidEventUserList?> GetRaidEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
         {
             // Send client to /entry
             return null;
         }
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new RaidEventUserList(
             eventId,
@@ -357,10 +357,10 @@ public class EventService(
 
     public async Task<Clb01EventUserList?> GetClb01EventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new Clb01EventUserList(
             eventId,
@@ -370,10 +370,10 @@ public class EventService(
 
     public async Task<CollectEventUserList?> GetCollectEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new CollectEventUserList(
             eventId,
@@ -383,10 +383,10 @@ public class EventService(
 
     public async Task<CombatEventUserList?> GetCombatEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new CombatEventUserList(
             eventId,
@@ -400,10 +400,10 @@ public class EventService(
 
     public async Task<EarnEventUserList?> GetEarnEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new EarnEventUserList(
             eventId,
@@ -416,10 +416,10 @@ public class EventService(
 
     public async Task<ExHunterEventUserList?> GetExHunterEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new ExHunterEventUserList(
             eventId,
@@ -437,10 +437,10 @@ public class EventService(
 
     public async Task<ExRushEventUserList?> GetExRushEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new ExRushEventUserList(
             eventId,
@@ -451,10 +451,10 @@ public class EventService(
 
     public async Task<MazeEventUserList?> GetMazeEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new MazeEventUserList(
             eventId,
@@ -464,10 +464,10 @@ public class EventService(
 
     public async Task<SimpleEventUserList?> GetSimpleEventUserData(int eventId)
     {
-        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
-
-        if (itemDict.Count == 0)
+        if (!await eventRepository.HasEventDataAsync(eventId))
             return null;
+
+        Dictionary<int, int> itemDict = await GetEventItemDictionary(eventId);
 
         return new SimpleEventUserList(
             eventId,

--- a/DragaliaAPI/Features/Event/IEventRepository.cs
+++ b/DragaliaAPI/Features/Event/IEventRepository.cs
@@ -37,4 +37,5 @@ public interface IEventRepository
     Task RemoveItemQuantityAsync(int itemId, int quantity);
 
     Task AddEventPassiveProgressAsync(int eventId, int passiveId, int progress);
+    Task<bool> HasEventDataAsync(int eventId);
 }


### PR DESCRIPTION
A check was implemented in #526 to return null for event user data if the event item dictionary was empty. This was so that the client could be redirected to the appropriate /entry endpoint. However, this would lead to infinite loops of calling /entry when the event was meant to have 0 event items such as Fractured Futures does.

Change the check to be against PlayerEventData which all events are guaranteed to initialize.