### PR TITLE
Fix off-by-one error in levelup calculation

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
@@ -37,6 +37,7 @@ public class CharaTest : TestFixture
         this.AddCharacter(Charas.Vida);
         this.AddCharacter(Charas.Delphi);
         this.AddCharacter(Charas.GalaAudric);
+        this.AddCharacter(Charas.Gauld);
     }
 
     [Fact]
@@ -123,6 +124,40 @@ public class CharaTest : TestFixture
             .quantity
             .Should()
             .Be(matQuantity - 300);
+    }
+
+    [Fact]
+    public async Task CharaBuildup_NotEnoughForLevel_DoesNotLevelUp()
+    {
+        await this.Client.PostMsgpack(
+            "chara/buildup",
+            new CharaBuildupRequest(
+                Charas.Gauld,
+                [new AtgenEnemyPiece() { id = Materials.GoldCrystal, quantity = 10 }]
+            )
+        );
+
+        byte currentLevel = this.ApiContext
+            .PlayerCharaData
+            .AsNoTracking()
+            .First(x => x.CharaId == Charas.Gauld)
+            .Level;
+
+        await this.Client.PostMsgpack(
+            "chara/buildup",
+            new CharaBuildupRequest(
+                Charas.Gauld,
+                [new AtgenEnemyPiece() { id = Materials.BronzeCrystal, quantity = 1 }]
+            )
+        );
+
+        this.ApiContext
+            .PlayerCharaData
+            .AsNoTracking()
+            .First(x => x.CharaId == Charas.Gauld)
+            .Level
+            .Should()
+            .Be(currentLevel);
     }
 
     [Fact]

--- a/DragaliaAPI/Features/Chara/CharaService.cs
+++ b/DragaliaAPI/Features/Chara/CharaService.cs
@@ -40,7 +40,7 @@ public class CharaService(
 
             while (
                 maxLevel > playerCharaData.Level
-                && playerCharaData.Exp > CharaConstants.XpLimits[playerCharaData.Level - 1]
+                && playerCharaData.Exp >= CharaConstants.XpLimits[playerCharaData.Level]
             )
             {
                 playerCharaData.Level++;


### PR DESCRIPTION
This while loop was checking `playerCharaData.Exp` against the XP required for the character's _current_ level rather than the next one.

This resulted in always levelling up a character even when using 1 crystal.