### PR TITLE
Fix One Starry Dragonyule endeavour conditions

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -392,6 +392,67 @@ public class DungeonRecordTest : TestFixture
     }
 
     [Fact]
+    public async Task Record_Event_ChallengeBattle_Coop_CompletesMissions()
+    {
+        int questId = 229030201; // Repelling the Frosty Fiends: Standard (Co-Op)
+        int eventId = 22903; // One Starry Dragonyule
+
+        await Client.PostMsgpack(
+            "/earn_event/entry",
+            new EarnEventEntryRequest() { event_id = eventId }
+        );
+
+        DungeonSession mockSession =
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { chara_id = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
+                {
+                    { 1, Enumerable.Empty<AtgenEnemy>() }
+                }
+            };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordData response = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = key,
+                    play_record = new PlayRecord
+                    {
+                        time = 10,
+                        treasure_record =
+                        [
+                            new()
+                            {
+                                area_idx = 0,
+                                enemy = [],
+                                enemy_smash = []
+                            }
+                        ],
+                        live_unit_no_list = new List<int>(),
+                        damage_record = new List<AtgenDamageRecord>(),
+                        dragon_damage_record = new List<AtgenDamageRecord>(),
+                        battle_royal_record = new AtgenBattleRoyalRecord(),
+                        wave = 2
+                    }
+                }
+            )
+        ).data;
+
+        AtgenNormalMissionNotice? missionNotice = response
+            .update_data_list
+            .mission_notice
+            ?.period_mission_notice;
+
+        missionNotice.Should().NotBeNull();
+        missionNotice!.new_complete_mission_id_list.Should().Contain(11650501); // Clear an Invasion on Standard
+    }
+
+    [Fact]
     public async Task Record_Event_Trial_CompletesMissions()
     {
         int questId = 208450702; // Wrath of Leviathan: Expert
@@ -442,6 +503,68 @@ public class DungeonRecordTest : TestFixture
             .new_complete_mission_id_list
             .Should()
             .Contain(10221201); // Clear a "Toll of the Deep" Trial on Expert
+    }
+
+    [Fact]
+    public async Task Record_Event_Trial_Coop_CompletesMissions()
+    {
+        int questId = 229030303; // The Angelic Herald: Master (Co-Op)
+        int eventId = 22903; // One Starry Dragonyule
+
+        await Client.PostMsgpack<EarnEventEntryData>(
+            "/earn_event/entry",
+            new EarnEventEntryRequest() { event_id = eventId }
+        );
+
+        DungeonSession mockSession =
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { chara_id = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
+                {
+                    { 1, Enumerable.Empty<AtgenEnemy>() }
+                }
+            };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordData response = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = key,
+                    play_record = new PlayRecord
+                    {
+                        time = 10,
+                        treasure_record =
+                        [
+                            new()
+                            {
+                                area_idx = 0,
+                                drop_obj = [],
+                                enemy = [],
+                                enemy_smash = []
+                            }
+                        ],
+                        live_unit_no_list = new List<int>(),
+                        damage_record = new List<AtgenDamageRecord>(),
+                        dragon_damage_record = new List<AtgenDamageRecord>(),
+                        battle_royal_record = new AtgenBattleRoyalRecord(),
+                        wave = 3
+                    }
+                }
+            )
+        ).data;
+
+        AtgenNormalMissionNotice? missionNotice = response
+            .update_data_list
+            .mission_notice
+            ?.period_mission_notice;
+
+        missionNotice.Should().NotBeNull();
+        missionNotice!.new_complete_mission_id_list.Should().Contain(11651001); // Clear a "One Starry Dragonyule" Trial on Master
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -30,6 +30,7 @@ public class DungeonRecordTest : TestFixture
         this.ApiContext.PlayerEventItems.ExecuteDelete();
         this.ApiContext.PlayerEventPassives.ExecuteDelete();
         this.ApiContext.PlayerEventRewards.ExecuteDelete();
+        this.ApiContext.CompletedDailyMissions.ExecuteDelete();
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
@@ -222,8 +222,8 @@ public class MissionTest : TestFixture
         int missionId1 = 15070301; // Clear a Quest
         int missionId2 = 15070401; // Clear Three Quests
 
-        DateOnly today = new(2023, 12, 13);
-        DateOnly yesterday = new(2023, 12, 12);
+        DateOnly today = DateOnly.FromDateTime(DateTime.Now);
+        DateOnly yesterday = today.AddDays(-1);
 
         await this.AddToDatabase(
             [
@@ -323,8 +323,8 @@ public class MissionTest : TestFixture
     public async Task GetDailyMissionList_ReturnsUnionOfTables()
     {
         int missionId = 15070301; // Clear a Quest
-        DateOnly today = new(2023, 12, 13);
-        DateOnly yesterday = new(2023, 12, 12);
+        DateOnly today = DateOnly.FromDateTime(DateTime.Now);
+        DateOnly yesterday = today.AddDays(-1);
 
         await this.AddToDatabase(
             [

--- a/DragaliaAPI.MissionDesigner/Missions/StarryDragonyule.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/StarryDragonyule.cs
@@ -22,7 +22,7 @@ public static class StarryDragonyule
             new ReadQuestStoryMission()
             {
                 MissionId = 11650201,
-                QuestStoryId = 11650201 // Final story ID; cannot progress with all 5 as _CompleteValue = 1
+                QuestStoryId = 2290306 // Final story ID; cannot progress with all 5 as _CompleteValue = 1
             },
             // Collect 1,000 Heroism in One Invasion
             new EventPointCollectionRecordMission() { MissionId = 11650301, EventId = EventId },
@@ -37,36 +37,46 @@ public static class StarryDragonyule
             // Defeat 1,000 Enemies in Invasions
             new EarnEnemiesKilledMission() { MissionId = 11650401, EventId = EventId },
             // Clear an Invasion on Standard
-            new ClearQuestMission() { MissionId = 11650501, QuestId = 229031201 },
+            new EventRegularBattleClearMission()
+            {
+                MissionId = 11650501,
+                EventId = EventId,
+                VariationType = VariationTypes.Normal
+            },
             // Clear an Invasion on Expert
-            new ClearQuestMission() { MissionId = 11650601, QuestId = 229031202 },
+            new EventRegularBattleClearMission()
+            {
+                MissionId = 11650601,
+                EventId = EventId,
+                VariationType = VariationTypes.Hard
+            },
             // Collect 7,500 Heroism in One Invasion on Master
             new EventPointCollectionRecordMission()
             {
                 MissionId = 11650701,
                 EventId = EventId,
-                QuestId = 229031203
+                VariationType = VariationTypes.VeryHard
             },
             // Clear a "One Starry Dragonyule" Trial on Standard
             new EventTrialClearMission()
             {
                 MissionId = 11650801,
-                QuestId = 229031301,
-                EventId = EventId
+                EventId = EventId,
+                VariationType = VariationTypes.Normal
             },
             // Clear a "One Starry Dragonyule" Trial on Expert
             new EventTrialClearMission()
             {
                 MissionId = 11650901,
                 EventId = EventId,
-                QuestId = 229031302,
+                VariationType = VariationTypes.Hard
             },
             // Clear a "One Starry Dragonyule" Trial on Master
             new EventTrialClearMission()
             {
-                MissionId = 11650001,
+                MissionId = 11651001,
                 EventId = EventId,
-                QuestId = 229031303,
+                VariationType = VariationTypes.VeryHard
             },
             // Clear A Dragonyule Miracle
             new ClearQuestMission() { MissionId = 11651101, QuestId = 229030401, }

--- a/DragaliaAPI.MissionDesigner/Missions/TollOfTheDeep.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/TollOfTheDeep.cs
@@ -82,14 +82,14 @@ public static class TollOfTheDeep
             {
                 MissionId = 10221101,
                 EventId = EventId,
-                QuestId = 208450701
+                VariationType = VariationTypes.Hell,
             },
             // Clear a "Toll of the Deep" Trial on Expert
             new EventTrialClearMission()
             {
                 MissionId = 10221201,
                 EventId = EventId,
-                QuestId = 208450702
+                VariationType = VariationTypes.Variation6,
             },
             // Earn the "Light of the Deep" Epithet
             // Earned from 'Completely Clear a Challenge Battle On Master'

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionMission.cs
@@ -4,13 +4,13 @@ public class EventPointCollectionMission : Mission
 {
     public required int EventId { get; init; }
 
-    public int? QuestId { get; init; }
+    public VariationTypes? VariationType { get; init; } = null;
 
     protected override MissionCompleteType CompleteType => MissionCompleteType.EventPointCollection;
 
     protected override int? Parameter => this.EventId;
 
-    protected override int? Parameter2 => this.QuestId;
+    protected override int? Parameter2 => (int?)this.VariationType;
 
     protected override bool UseTotalValue => false;
 }

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionRecordMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionRecordMission.cs
@@ -4,13 +4,13 @@ public class EventPointCollectionRecordMission : Mission
 {
     public required int EventId { get; init; }
 
-    public int? QuestId { get; init; }
+    public VariationTypes? VariationType { get; init; }
 
     protected override MissionCompleteType CompleteType => MissionCompleteType.EventPointCollection;
 
     protected override int? Parameter => this.EventId;
 
-    protected override int? Parameter2 => this.QuestId;
+    protected override int? Parameter2 => (int?)this.VariationType;
 
     protected override bool UseTotalValue => true;
 }

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventRegularBattleClearMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventRegularBattleClearMission.cs
@@ -7,5 +7,9 @@ public class EventRegularBattleClearMission : Mission
 
     public required int EventId { get; init; }
 
+    public VariationTypes? VariationType { get; init; }
+
     protected override int? Parameter => this.EventId;
+
+    protected override int? Parameter2 => (int?)this.VariationType;
 }

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventTrialClearMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventTrialClearMission.cs
@@ -6,9 +6,9 @@ public class EventTrialClearMission : Mission
 
     public required int EventId { get; init; }
 
-    public required int QuestId { get; init; }
+    public required VariationTypes VariationType { get; init; }
 
     protected override int? Parameter => this.EventId;
 
-    protected override int? Parameter2 => this.QuestId;
+    protected override int? Parameter2 => (int)this.VariationType;
 }

--- a/DragaliaAPI.Shared/MasterAsset/Models/Missions/MissionCompleteType.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/Missions/MissionCompleteType.cs
@@ -149,7 +149,7 @@ public enum MissionCompleteType
     EventParticipation,
 
     /// <summary>
-    /// int eventId
+    /// int eventId, VariationTypes variationType
     /// </summary>
     EventRegularBattleClear,
 

--- a/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -1344,7 +1344,7 @@
     "_MissionId": 11650201,
     "_CompleteType": "QuestStoryCleared",
     "_UseTotalValue": 0,
-    "_Parameter": 11650201
+    "_Parameter": 2290306
   },
   {
     "_Id": 1165030102,
@@ -1398,17 +1398,19 @@
     "_Id": 1165050102,
     "_MissionType": "Period",
     "_MissionId": 11650501,
-    "_CompleteType": "QuestCleared",
+    "_CompleteType": "EventRegularBattleClear",
     "_UseTotalValue": 0,
-    "_Parameter": 229031201
+    "_Parameter": 22903,
+    "_Parameter2": 1
   },
   {
     "_Id": 1165060102,
     "_MissionType": "Period",
     "_MissionId": 11650601,
-    "_CompleteType": "QuestCleared",
+    "_CompleteType": "EventRegularBattleClear",
     "_UseTotalValue": 0,
-    "_Parameter": 229031202
+    "_Parameter": 22903,
+    "_Parameter2": 2
   },
   {
     "_Id": 1165070102,
@@ -1417,7 +1419,7 @@
     "_CompleteType": "EventPointCollection",
     "_UseTotalValue": 1,
     "_Parameter": 22903,
-    "_Parameter2": 229031203
+    "_Parameter2": 3
   },
   {
     "_Id": 1165080102,
@@ -1426,7 +1428,7 @@
     "_CompleteType": "EventTrialClear",
     "_UseTotalValue": 0,
     "_Parameter": 22903,
-    "_Parameter2": 229031301
+    "_Parameter2": 1
   },
   {
     "_Id": 1165090102,
@@ -1435,16 +1437,16 @@
     "_CompleteType": "EventTrialClear",
     "_UseTotalValue": 0,
     "_Parameter": 22903,
-    "_Parameter2": 229031302
+    "_Parameter2": 2
   },
   {
-    "_Id": 1165000102,
+    "_Id": 1165100102,
     "_MissionType": "Period",
-    "_MissionId": 11650001,
+    "_MissionId": 11651001,
     "_CompleteType": "EventTrialClear",
     "_UseTotalValue": 0,
     "_Parameter": 22903,
-    "_Parameter2": 229031303
+    "_Parameter2": 3
   },
   {
     "_Id": 1165110102,
@@ -1713,7 +1715,7 @@
     "_CompleteType": "EventTrialClear",
     "_UseTotalValue": 0,
     "_Parameter": 20845,
-    "_Parameter2": 208450701
+    "_Parameter2": 5
   },
   {
     "_Id": 1022120106,
@@ -1722,7 +1724,7 @@
     "_CompleteType": "EventTrialClear",
     "_UseTotalValue": 0,
     "_Parameter": 20845,
-    "_Parameter2": 208450702
+    "_Parameter2": 6
   },
   {
     "_Id": 1022130106,

--- a/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
@@ -315,7 +315,7 @@ public class DungeonRecordRewardServiceTest
             x =>
                 x.OnEventPointCollected(
                     session.QuestData.Gid,
-                    session.QuestId,
+                    session.QuestVariation,
                     points + boostedPoints
                 )
         );

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -131,7 +131,7 @@ public class DungeonRecordRewardService(
         {
             missionProgressionService.OnEventPointCollected(
                 session.QuestGid,
-                session.QuestId,
+                session.QuestVariation,
                 totalPoints + boostedPoints
             );
         }
@@ -143,7 +143,7 @@ public class DungeonRecordRewardService(
         {
             missionProgressionService.OnEventPointCollected(
                 session.QuestGid,
-                session.QuestId,
+                session.QuestVariation,
                 enemyScore
             );
         }

--- a/DragaliaAPI/Features/Missions/IMissionProgressionService.cs
+++ b/DragaliaAPI/Features/Missions/IMissionProgressionService.cs
@@ -73,11 +73,11 @@ public interface IMissionProgressionService
     void OnPartyPowerReached(int might);
     void OnTreasureTrade(int tradeId, EntityTypes type, int id, int count, int total);
     void OnEventParticipation(int eventId);
-    void OnEventRegularBattleCleared(int eventId);
+    void OnEventRegularBattleCleared(int eventId, VariationTypes variationType);
     void OnEventQuestClearedWithCrest(int eventId, AbilityCrests crest);
-    void OnEventPointCollected(int eventId, int questId, int quantity);
+    void OnEventPointCollected(int eventId, VariationTypes variationType, int quantity);
     void OnEventChallengeBattleCleared(int eventId, int questId, bool fullClear);
-    void OnEventTrialCleared(int eventId, int questId);
+    void OnEventTrialCleared(int eventId, VariationTypes variationType);
 
     void EnqueueEvent(
         MissionCompleteType type,

--- a/DragaliaAPI/Features/Missions/MissionProgressionService.cs
+++ b/DragaliaAPI/Features/Missions/MissionProgressionService.cs
@@ -226,19 +226,25 @@ public class MissionProgressionService(
     public void OnEventParticipation(int eventId) =>
         EnqueueEvent(MissionCompleteType.EventParticipation, 1, 1, eventId);
 
-    public void OnEventRegularBattleCleared(int eventId) =>
-        EnqueueEvent(MissionCompleteType.EventRegularBattleClear, 1, 1, eventId);
+    public void OnEventRegularBattleCleared(int eventId, VariationTypes variationType) =>
+        EnqueueEvent(
+            MissionCompleteType.EventRegularBattleClear,
+            1,
+            1,
+            eventId,
+            (int)variationType
+        );
 
     public void OnEventQuestClearedWithCrest(int eventId, AbilityCrests crest) =>
         EnqueueEvent(MissionCompleteType.EventQuestClearWithCrest, 1, 1, eventId, (int)crest);
 
-    public void OnEventPointCollected(int eventId, int questId, int quantity) =>
+    public void OnEventPointCollected(int eventId, VariationTypes variationType, int quantity) =>
         EnqueueEvent(
             MissionCompleteType.EventPointCollection,
             quantity,
             quantity,
             eventId,
-            questId
+            (int)variationType
         );
 
     public void OnEventChallengeBattleCleared(int eventId, int questId, bool fullClear) =>
@@ -251,8 +257,8 @@ public class MissionProgressionService(
             fullClear ? 1 : 0
         );
 
-    public void OnEventTrialCleared(int eventId, int questId) =>
-        EnqueueEvent(MissionCompleteType.EventTrialClear, 1, 1, eventId, questId);
+    public void OnEventTrialCleared(int eventId, VariationTypes variationType) =>
+        EnqueueEvent(MissionCompleteType.EventTrialClear, 1, 1, eventId, (int)variationType);
 
     public void EnqueueEvent(
         MissionCompleteType type,

--- a/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/Features/Quest/QuestService.cs
@@ -324,7 +324,10 @@ public class QuestService(
 
         if (questData.IsEventRegularBattle)
         {
-            missionProgressionService.OnEventRegularBattleCleared(questData.Gid);
+            missionProgressionService.OnEventRegularBattleCleared(
+                questData.Gid,
+                questData.VariationType
+            );
         }
         else if (questData.IsEventChallengeBattle)
         {
@@ -339,7 +342,7 @@ public class QuestService(
         }
         else if (questData.IsEventTrial)
         {
-            missionProgressionService.OnEventTrialCleared(questData.Gid, questData.Id);
+            missionProgressionService.OnEventTrialCleared(questData.Gid, questData.VariationType);
         }
     }
 }

--- a/DragaliaAPI/Models/DungeonSession.cs
+++ b/DragaliaAPI/Models/DungeonSession.cs
@@ -1,4 +1,5 @@
 ﻿using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset.Models;
 
 namespace DragaliaAPI.Models;
@@ -12,6 +13,8 @@ public class DungeonSession
     public int QuestId => QuestData?.Id ?? 0;
 
     public int QuestGid => QuestData?.Gid ?? 0;
+
+    public VariationTypes QuestVariation => QuestData?.VariationType ?? VariationTypes.Normal;
 
     public bool IsHost { get; set; } = true;
 


### PR DESCRIPTION
- Don't constrain missions like Clear an Invasion on Expert to a particular quest ID, because we need to detect co-op clears as well. Use the VariationType to check for the difficulty.
- Fix wrong story ID in "Clear all event stories" mission