### PR TITLE
Add failsafe when adding completed daily missions

### DIFF
--- a/DragaliaAPI/Features/Missions/IMissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/IMissionRepository.cs
@@ -21,7 +21,7 @@ public interface IMissionRepository
         int? groupId = null
     );
 
-    void AddCompletedDailyMission(DbPlayerMission originalMission);
+    Task AddCompletedDailyMission(DbPlayerMission originalMission);
 
     void RemoveCompletedDailyMission(DbCompletedDailyMission completedDailyMission);
     Task ClearDailyMissions();

--- a/DragaliaAPI/Features/Missions/MissionProgressionService.cs
+++ b/DragaliaAPI/Features/Missions/MissionProgressionService.cs
@@ -365,7 +365,7 @@ public class MissionProgressionService(
 
                     if (progressionInfo.MissionType == MissionType.Daily)
                     {
-                        missionRepository.AddCompletedDailyMission(progressingMission);
+                        await missionRepository.AddCompletedDailyMission(progressingMission);
                     }
                 }
                 else

--- a/DragaliaAPI/Features/Missions/MissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/MissionRepository.cs
@@ -76,16 +76,23 @@ public class MissionRepository(
             .Entity;
     }
 
-    public void AddCompletedDailyMission(DbPlayerMission originalMission)
+    public async Task AddCompletedDailyMission(DbPlayerMission originalMission)
     {
+        long viewerId = this.playerIdentityService.ViewerId;
+        int id = originalMission.Id;
+        DateOnly date = DateOnly.FromDateTime(resetHelper.LastDailyReset.UtcDateTime);
+
+        if (await this.apiContext.CompletedDailyMissions.FindAsync(viewerId, id, date) != null)
+            return;
+
         this.apiContext
             .CompletedDailyMissions
             .Add(
                 new DbCompletedDailyMission()
                 {
-                    ViewerId = this.playerIdentityService.ViewerId,
-                    Id = originalMission.Id,
-                    Date = DateOnly.FromDateTime(resetHelper.LastDailyReset.UtcDateTime),
+                    ViewerId = viewerId,
+                    Id = id,
+                    Date = date,
                     StartDate = originalMission.Start,
                     EndDate = originalMission.End,
                     Progress = originalMission.Progress


### PR DESCRIPTION
There are errors in the logs where people are getting PK exceptions adding to this table. I don't quite understand how that happens, but it's quite a severe issue in terms of blocking people from completing any quests so best to just add some resilience for now.