### PR TITLE
Add support for random matching quests to plugin

### DIFF
--- a/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -2,9 +2,11 @@
 
 	<PropertyGroup>
 		<TargetFramework>net461</TargetFramework>
-		<PlatformTarget>x64</PlatformTarget>
+        <Nullable>disable</Nullable>
+        <LangVersion>7.3</LangVersion>
+        <PlatformTarget>x64</PlatformTarget>
 		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-		<AssemblyVersion>3.0.0</AssemblyVersion>
+        <AssemblyVersion>3.1.0</AssemblyVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net461</TargetFramework>
+    <PropertyGroup>
+        <TargetFramework>net461</TargetFramework>
         <Nullable>disable</Nullable>
         <LangVersion>7.3</LangVersion>
         <PlatformTarget>x64</PlatformTarget>
-		<RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
+        <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
         <AssemblyVersion>3.1.0</AssemblyVersion>
-	</PropertyGroup>
+    </PropertyGroup>
 
-	<ItemGroup>
-	  <None Remove="Models\RoomEntryCondition.cs~RF3a00b1.TMP" />
-	</ItemGroup>
+    <ItemGroup>
+      <None Remove="Models\RoomEntryCondition.cs~RF3a00b1.TMP" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="MessagePack" VersionOverride="2.5.108" />
-		<PackageReference Include="Newtonsoft.Json" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="MessagePack" VersionOverride="2.5.108" />
+        <PackageReference Include="Newtonsoft.Json" />
+    </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\DragaliaAPI.Photon.Shared\DragaliaAPI.Photon.Shared.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\DragaliaAPI.Photon.Shared\DragaliaAPI.Photon.Shared.csproj" />
+    </ItemGroup>
 
-	<ItemGroup>
-		<Reference Include="PhotonHivePlugin">
-			<HintPath>..\PhotonServer\src-server\Plugins\lib\net461\PhotonHivePlugin.dll</HintPath>
-		</Reference>
-	</ItemGroup>
+    <ItemGroup>
+        <Reference Include="PhotonHivePlugin">
+            <HintPath>..\PhotonServer\src-server\Plugins\lib\net461\PhotonHivePlugin.dll</HintPath>
+        </Reference>
+    </ItemGroup>
 
-	<Target Name="PostBuild" AfterTargets="PostBuildEvent">
-		<Exec Command="xcopy /Y /Q &quot;$(TargetDir)*.*&quot; &quot;$(SolutionDir)PhotonServer\deploy\Plugins\GluonPlugin\bin\&quot;" />
-	</Target>
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <Exec Command="xcopy /Y /Q &quot;$(TargetDir)*.*&quot; &quot;$(SolutionDir)PhotonServer\deploy\Plugins\GluonPlugin\bin\&quot;" />
+    </Target>
 
 </Project>

--- a/DragaliaAPI.Photon.Plugin/GluonPlugin.Helper.cs
+++ b/DragaliaAPI.Photon.Plugin/GluonPlugin.Helper.cs
@@ -72,6 +72,16 @@ namespace DragaliaAPI.Photon.Plugin
             bool callAsync = true
         )
         {
+            // We don't ever need to communicate with Redis for rooms that are in random matching mode
+            if (this.roomState.IsRandomMatching)
+            {
+                this.logger.DebugFormat(
+                    "Skipping request to StateManager endpoint {0}; room is in random matching mode",
+                    endpoint
+                );
+                return;
+            }
+
             HttpRequestCallback callback = this.LogIfFailedCallback;
 
             Uri baseUri;

--- a/DragaliaAPI.Photon.Plugin/Helpers/QuestHelper.Data.cs
+++ b/DragaliaAPI.Photon.Plugin/Helpers/QuestHelper.Data.cs
@@ -34,6 +34,19 @@ namespace DragaliaAPI.Photon.Plugin.Helpers
         /// </remarks>
         private static readonly ImmutableHashSet<int> RankedQuestIds;
 
+        /// <summary>
+        /// All random matching quest IDs.
+        /// </summary>
+        /// <remarks>
+        /// Query used:
+        /// <code>
+        /// SELECT q._Id || ', // ' || t._Text FROM "QuestData" q
+        /// JOIN "TextLabel" t on q._QuestViewName = t._Id
+        /// WHERE q._QuestPlayModeType = 4 or q._QuestPlayModeType = 5 -- QuestPlayModeTypes.RandomMatching / RandomMatchingSixteen
+        /// </code>
+        /// </remarks>
+        private static readonly ImmutableHashSet<int> RandomMatchingQuestIds;
+
         static QuestHelper()
         {
             RaidQuestIds = new int[]
@@ -482,6 +495,32 @@ namespace DragaliaAPI.Photon.Plugin.Helpers
                 227100106, // Surtr's Devouring Flame (Ranked)
                 227110105, // Iblis's Surging Cascade (Ranked)
                 227110106, // Iblis's Surging Cascade (Ranked)
+            }.ToImmutableHashSet();
+
+            RandomMatchingQuestIds = new[]
+            {
+                204380301, // Asura Clash: Beginner
+                204380302, // Asura Clash: Expert
+                204380401, // Asura Clash EX
+                204390301, // Satan Clash: Beginner
+                204390302, // Satan Clash: Expert
+                204390501, // Satan Clash: Nightmare
+                204400301, // True Bahamut Clash: Beginner
+                204400302, // True Bahamut Clash: Expert
+                229010201, // Repelling the Forest's Aggressors: Standard
+                229010202, // Repelling the Forest's Aggressors: Expert
+                229020201, // Repelling the Forces of Grams: Standard
+                229020202, // Repelling the Forces of Grams: Expert
+                229030201, // Repelling the Frosty Fiends: Standard
+                229030202, // Repelling the Frosty Fiends: Expert
+                229040201, // Repelling the Black Mana Forces: Standard
+                229040202, // Repelling the Black Mana Forces: Expert
+                229050201, // Repelling the Imperial Forces: Standard
+                229050202, // Repelling the Imperial Forces: Expert
+                229060201, // Repelling the Forest's Aggressors: Standard
+                229060202, // Repelling the Forest's Aggressors: Expert
+                229070201, // Repelling the Forces of Grams: Standard
+                229070202, // Repelling the Forces of Grams: Expert
             }.ToImmutableHashSet();
         }
     }

--- a/DragaliaAPI.Photon.Plugin/Helpers/QuestHelper.cs
+++ b/DragaliaAPI.Photon.Plugin/Helpers/QuestHelper.cs
@@ -5,5 +5,8 @@
         public static bool GetIsRaid(int questId) => RaidQuestIds.Contains(questId);
 
         public static bool GetIsRanked(int questId) => RankedQuestIds.Contains(questId);
+
+        public static bool GetIsRandomMatching(int questId) =>
+            RandomMatchingQuestIds.Contains(questId);
     }
 }

--- a/DragaliaAPI.Photon.Plugin/Models/PluginConfiguration.cs
+++ b/DragaliaAPI.Photon.Plugin/Models/PluginConfiguration.cs
@@ -29,6 +29,8 @@ namespace DragaliaAPI.Photon.Plugin.Models
 
         public string SecondaryBearerToken { get; }
 
+        public int RandomMatchingStartDelayMs { get; }
+
         public PluginConfiguration(IDictionary<string, string> config)
         {
             this.ApiServerUrl = config.GetUri(nameof(this.ApiServerUrl), UriKind.Absolute);
@@ -74,6 +76,8 @@ namespace DragaliaAPI.Photon.Plugin.Models
             );
 
             this.SecondaryBearerToken = config[nameof(SecondaryBearerToken)];
+
+            this.RandomMatchingStartDelayMs = config.GetInt(nameof(RandomMatchingStartDelayMs));
         }
     }
 }

--- a/DragaliaAPI.Photon.Plugin/Models/RoomState.cs
+++ b/DragaliaAPI.Photon.Plugin/Models/RoomState.cs
@@ -18,6 +18,10 @@ namespace DragaliaAPI.Photon.Plugin.Models
 
         public bool IsUseSecondaryServer { get; set; }
 
+        public bool IsRandomMatching { get; set; }
+
+        public object RandomMatchingStartTimer { get; set; }
+
         public RoomState() { }
 
         public RoomState(RoomState oldState)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,16 +21,18 @@ services:
     env_file:
       - .env
 
-  #  photonstatemanager:
-  #    hostname: photonstatemanager
-  #    image: ${DOCKER_REGISTRY-}photonstatemanager
-  #    build:
-  #        context: .
-  #        dockerfile: DragaliaAPI.Photon.StateManager/Dockerfile
-  #    ports:
-  #      - "5001:80"
-  #    env_file:
-  #      - .env
+  # photonstatemanager:
+  #   hostname: photonstatemanager
+  #   image: ${DOCKER_REGISTRY-}photonstatemanager
+  #   build:
+  #       context: .
+  #       dockerfile: DragaliaAPI.Photon.StateManager/Dockerfile
+  #   environment:
+  #     - HTTP_PORTS=80
+  #   ports:
+  #     - "5001:80"
+  #   env_file:
+  #     - .env
 
   postgres:
     hostname: postgres


### PR DESCRIPTION
For these quests, players are silently placed in a room behind a loading screen. Photon matchmaking will build up rooms of 1 or more players. Currently these never start; it seems to be on the plugin to trigger the start of the room.

- Detect random matching on room creation.
- If we are in random matching, don't send requests to the Redis API, as these rooms should not be joinable externally.
- If we are in random matching, and a second player joins, set a timer after which the game will start. The duration is configurable in the plugin config.
- If the timer is started, and a player leaves such that there is now only one player in the room, abort the timer.