### PR TITLE
Royal regimen fixes

### DIFF
--- a/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
+++ b/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
@@ -36,6 +36,11 @@ public class MasterAssetData<TKey, TItem>
     public IEnumerable<TItem> Enumerable => this.internalKeyCollection.Items;
 
     /// <summary>
+    /// Gets the number of items in the collection.
+    /// </summary>
+    public int Count => this.internalKeyCollection.Items.Length;
+
+    /// <summary>
     /// Get a <typeparam name="TItem"> instance corresponding to the given <typeparam name="TKey"/> key.</typeparam>
     /// </summary>
     /// <param name="key">The key to index with.</param>

--- a/DragaliaAPI.Test/Features/Missions/MissionControllerTest.cs
+++ b/DragaliaAPI.Test/Features/Missions/MissionControllerTest.cs
@@ -98,6 +98,9 @@ public class MissionControllerTest
             };
 
         this.mockMissionService.Setup(x => x.GetMissionNotice(null)).ReturnsAsync(notice);
+        this.mockMissionService
+            .Setup(x => x.GetCompletedDrillGroups())
+            .ReturnsAsync([new DrillMissionGroupList(1)]);
 
         this.mockMissionRepository
             .Setup(x => x.GetMissionsByType(MissionType.Drill))
@@ -131,7 +134,7 @@ public class MissionControllerTest
             .ContainEquivalentOf(
                 new DrillMissionList(500, 0, 0, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch)
             );
-        response.drill_mission_group_list.Should().BeNull();
+        response.drill_mission_group_list.Should().BeEquivalentTo([new DrillMissionGroupList(1)]);
 
         mockMissionService.VerifyAll();
         mockUpdateDataService.VerifyAll();

--- a/DragaliaAPI/Features/Missions/MissionController.cs
+++ b/DragaliaAPI/Features/Missions/MissionController.cs
@@ -54,6 +54,8 @@ public class MissionController(
             x => new DrillMissionList(x.Id, x.Progress, (int)x.State, x.End, x.Start)
         );
 
+        response.drill_mission_group_list = await this.missionService.GetCompletedDrillGroups();
+
         return response;
     }
 


### PR DESCRIPTION
- Send drill_mission_group_list from mission.get_drill_mission_list to fix group rewards being claimable after every restart
- Fix drill_mission_group_list returning [1, 2, 3] when royal regimen not started
- Send receivable_reward_count = 1 when having completed all previous drill mission groups without starting the next one, to stop the icon enabling access to the royal regimen from disappearing