### PR TITLE
Fix event item IDs sometimes not matching the item type

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
@@ -17,7 +17,7 @@ public class ISavefileUpdateTest : TestFixture
     public void ISavefileUpdate_HasExpectedCount()
     {
         // Update this test when adding a new update.
-        this.updates.Should().HaveCount(15);
+        this.updates.Should().HaveCount(16);
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -20,8 +20,13 @@ public abstract class SavefileUpdateTestFixture : TestFixture
             .SavefileVersion;
     }
 
-    public int GetSavefileVersion()
+    protected int GetSavefileVersion()
     {
         return this.ApiContext.Players.Find(ViewerId)!.SavefileVersion;
+    }
+
+    protected async Task LoadIndex()
+    {
+        await this.Client.PostMsgpack<LoadIndexData>("load/index", new LoadIndexRequest());
     }
 }

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
@@ -1,0 +1,64 @@
+using DragaliaAPI.Database.Entities;
+
+namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
+
+public class V16UpdateTest : SavefileUpdateTestFixture
+{
+    public V16UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task V16Update_ConvertsEventItems()
+    {
+        await this.AddToDatabase(
+            [
+                new DbPlayerEventItem()
+                {
+                    EventId = 20844,
+                    Id = 2084401,
+                    Type = 10003,
+                },
+                new DbPlayerEventItem()
+                {
+                    EventId = 20844,
+                    Id = 2084402,
+                    Type = 10001,
+                },
+                new DbPlayerEventItem()
+                {
+                    EventId = 20844,
+                    Id = 2084403,
+                    Type = 10002,
+                },
+            ]
+        );
+        this.ApiContext.ChangeTracker.Clear();
+
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerEventItems.Should()
+            .BeEquivalentTo(
+                [
+                    new DbPlayerEventItem()
+                    {
+                        EventId = 20844,
+                        Id = 2084401,
+                        Type = 10001,
+                    },
+                    new DbPlayerEventItem()
+                    {
+                        EventId = 20844,
+                        Id = 2084402,
+                        Type = 10002,
+                    },
+                    new DbPlayerEventItem()
+                    {
+                        EventId = 20844,
+                        Id = 2084403,
+                        Type = 10003,
+                    },
+                ],
+                opts => opts.Excluding(x => x.ViewerId).Excluding(x => x.Owner)
+            );
+    }
+}

--- a/DragaliaAPI/Features/Event/EventDataExtensions.cs
+++ b/DragaliaAPI/Features/Event/EventDataExtensions.cs
@@ -27,7 +27,7 @@ internal static class EventDataExtensions
         ).Where(x => x != 0);
     }
 
-    public static IEnumerable<int> GetEventSpecificItemIds(this EventData data)
+    public static IEnumerable<(int Id, int Type)> GetEventSpecificItemIds(this EventData data)
     {
         int eventId = data.Id;
 
@@ -36,44 +36,44 @@ internal static class EventDataExtensions
             EventKindType.Build
                 => MasterAsset
                     .BuildEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.Raid
                 => MasterAsset
                     .RaidEventItem.Enumerable.Where(x => x.RaidEventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.RaidEventItemType)),
             EventKindType.Combat
                 => MasterAsset
                     .CombatEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.BattleRoyal
                 => MasterAsset
                     .BattleRoyalEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.Clb01
                 => MasterAsset
                     .Clb01EventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.Collect
                 => MasterAsset
                     .CollectEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.Earn
                 => MasterAsset
                     .EarnEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.ExHunter
                 => MasterAsset
                     .ExHunterEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.ExRush
                 => MasterAsset
                     .ExRushEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
             EventKindType.Simple
                 => MasterAsset
                     .SimpleEventItem.Enumerable.Where(x => x.EventId == eventId)
-                    .Select(x => x.Id),
-            _ => Enumerable.Empty<int>(),
+                    .Select(x => (x.Id, (int)x.EventItemType)),
+            _ => [],
         };
     }
 

--- a/DragaliaAPI/Features/Event/EventDataExtensions.cs
+++ b/DragaliaAPI/Features/Event/EventDataExtensions.cs
@@ -7,26 +7,6 @@ namespace DragaliaAPI.Features.Event;
 
 internal static class EventDataExtensions
 {
-    public static IEnumerable<int> GetEventItemTypes(this EventData data)
-    {
-        return (
-            data.EventKindType switch
-            {
-                EventKindType.Build => Enum.GetValues<BuildEventItemType>().Cast<int>(),
-                EventKindType.BattleRoyal => Enum.GetValues<BattleRoyalEventItemType>().Cast<int>(),
-                EventKindType.Clb01 => Enum.GetValues<Clb01EventItemType>().Cast<int>(),
-                EventKindType.Collect => Enum.GetValues<CollectEventItemType>().Cast<int>(),
-                EventKindType.Combat => Enum.GetValues<CombatEventItemType>().Cast<int>(),
-                EventKindType.Earn => Enum.GetValues<EarnEventItemType>().Cast<int>(),
-                EventKindType.ExHunter => Enum.GetValues<ExHunterEventItemType>().Cast<int>(),
-                EventKindType.ExRush => Enum.GetValues<ExRushEventItemType>().Cast<int>(),
-                EventKindType.Raid => Enum.GetValues<RaidEventItemType>().Cast<int>(),
-                EventKindType.Simple => Enum.GetValues<SimpleEventItemType>().Cast<int>(),
-                _ => Enumerable.Empty<int>(),
-            }
-        ).Where(x => x != 0);
-    }
-
     public static IEnumerable<(int Id, int Type)> GetEventSpecificItemIds(this EventData data)
     {
         int eventId = data.Id;

--- a/DragaliaAPI/Features/Event/EventService.cs
+++ b/DragaliaAPI/Features/Event/EventService.cs
@@ -195,9 +195,10 @@ public class EventService(
             .Select(x => x.Id)
             .ToListAsync();
 
-        List<(int Id, int Type)> itemIds = data.GetEventSpecificItemIds()
-            .Zip(data.GetEventItemTypes(), (x, y) => (x, y))
-            .ExceptBy(items, info => info.x)
+        IEnumerable<(int Id, int Type)> eventSpecificItemIds = data.GetEventSpecificItemIds();
+
+        List<(int Id, int Type)> itemIds = eventSpecificItemIds
+            .ExceptBy(items, info => info.Id)
             .ToList();
 
         if (itemIds.Count > 0)

--- a/DragaliaAPI/Features/SavefileUpdate/V16Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V16Update.cs
@@ -42,8 +42,9 @@ public class V16Update(IEventRepository eventRepository, ILogger<V16Update> logg
             if (actualType != expectedType)
             {
                 logger.LogInformation(
-                    "Updating event item {@item} type to {expectedType}",
-                    item,
+                    "Updating event item {item} type from {currentType} to {expectedType}",
+                    item.Id,
+                    item.Type,
                     expectedType
                 );
 

--- a/DragaliaAPI/Features/SavefileUpdate/V16Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V16Update.cs
@@ -1,0 +1,54 @@
+using System.Collections.Frozen;
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Features.Event;
+using DragaliaAPI.Shared.MasterAsset;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.SavefileUpdate;
+
+/// <summary>
+/// Fixes mismatched event item IDs.
+/// </summary>
+/// <remarks>
+/// It was previously possible for event items to be created with an ID that did not match their item type.
+/// This updates rows where this mismatch occurs, but doesn't attempt to fix quantities.
+/// </remarks>
+[UsedImplicitly]
+public class V16Update(IEventRepository eventRepository, ILogger<V16Update> logger)
+    : ISavefileUpdate
+{
+    private static readonly FrozenDictionary<int, int> EventItemTypes;
+
+    static V16Update()
+    {
+        EventItemTypes = MasterAsset
+            .EventData.Enumerable.SelectMany(x => x.GetEventSpecificItemIds())
+            .ToFrozenDictionary(x => x.Id, x => x.Type);
+    }
+
+    public int SavefileVersion => 16;
+
+    public async Task Apply()
+    {
+        List<DbPlayerEventItem> items = await eventRepository.Items.ToListAsync();
+
+        foreach (DbPlayerEventItem item in items)
+        {
+            int expectedType = EventItemTypes[item.Id];
+            int actualType = item.Type;
+
+            if (actualType != expectedType)
+            {
+                logger.LogInformation(
+                    "Updating event item {@item} type to {expectedType}",
+                    item,
+                    expectedType
+                );
+
+                item.Type = expectedType;
+            }
+        }
+    }
+}


### PR DESCRIPTION
When creating event items, we do a .Zip() of the IDs from `<type>EventItem` from the MasterAsset into `Enum.GetValues<{Type}EventItemType>()`. 

However, it appears that `data.GetEventSpecificItemIds()` is not guaranteed to be returned in order, leading to situations like this:

![image](https://github.com/SapiensAnatis/Dawnshard/assets/5047192/54248930-69c3-4785-882c-bb568825c275)

Here, the Id and Type columns are out of sync, leading to event points being rewarded as gold event items and event points never getting saved.

This PR changes the `.GetEventSpecificItemIds()` to return the corresponding item type, since it is defined in the same MasterAsset entry.

I could equally have just added sorting to the returned event item IDs but using the type defined in the same MasterAsset entry feels like the safest approach.