### PR TITLE
Add missing dragon reliability save update

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
@@ -17,7 +17,7 @@ public class ISavefileUpdateTest : TestFixture
     public void ISavefileUpdate_HasExpectedCount()
     {
         // Update this test when adding a new update.
-        this.updates.Should().HaveCount(16);
+        this.updates.Should().HaveCount(17);
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V17UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V17UpdateTest.cs
@@ -1,0 +1,28 @@
+using DragaliaAPI.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
+
+public class V17UpdateTest : SavefileUpdateTestFixture
+{
+    public V17UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task V17Update_AddsMissingReliabilities()
+    {
+        await this.AddToDatabase(new DbPlayerDragonData() { DragonId = Dragons.Arsene, });
+
+        this.ApiContext.PlayerDragonReliability.AsNoTracking()
+            .Should()
+            .NotContain(x => x.ViewerId == this.ViewerId && x.DragonId == Dragons.Arsene);
+
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerDragonReliability.AsNoTracking()
+            .Should()
+            .Contain(
+                x => x.ViewerId == this.ViewerId && x.DragonId == Dragons.Arsene && x.Level == 30
+            );
+    }
+}

--- a/DragaliaAPI/Features/PartyPower/PartyPowerService.cs
+++ b/DragaliaAPI/Features/PartyPower/PartyPowerService.cs
@@ -148,12 +148,7 @@ public class PartyPowerService(
                     "No dragon found for power calculation"
                 );
 
-            reliability =
-                await unitRepository.FindDragonReliabilityAsync(dragon.DragonId)
-                ?? throw new DragaliaException(
-                    ResultCode.CommonDbError,
-                    "No reliability found for power calculation"
-                );
+            reliability = await unitRepository.FindDragonReliabilityAsync(dragon.DragonId);
 
             dragonData = MasterAsset.DragonData[dragon.DragonId];
             dragonRarity = MasterAsset.DragonRarity[dragonData.Rarity];

--- a/DragaliaAPI/Features/SavefileUpdate/V17Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V17Update.cs
@@ -1,0 +1,58 @@
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.PlayerDetails;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.SavefileUpdate;
+
+/// <summary>
+/// Fixes dragons that have no dragon reliability entry.
+/// </summary>
+[UsedImplicitly]
+public class V17Update(
+    ApiContext apiContext,
+    IPlayerIdentityService playerIdentityService,
+    ILogger<V17Update> logger
+) : ISavefileUpdate
+{
+    private readonly ApiContext apiContext = apiContext;
+    private readonly IPlayerIdentityService playerIdentityService = playerIdentityService;
+    private readonly ILogger<V17Update> logger = logger;
+
+    public int SavefileVersion => 17;
+
+    public async Task Apply()
+    {
+        IAsyncEnumerable<Dragons> missingReliabilities = this.apiContext.PlayerDragonData.Where(
+            dragon => dragon.ViewerId == this.playerIdentityService.ViewerId
+        )
+            .Where(
+                dragon =>
+                    !this.apiContext.PlayerDragonReliability.Any(
+                        rel =>
+                            rel.ViewerId == this.playerIdentityService.ViewerId
+                            && rel.DragonId == dragon.DragonId
+                    )
+            )
+            .Select(x => x.DragonId)
+            .Distinct()
+            .AsAsyncEnumerable();
+
+        await foreach (Dragons missingReliability in missingReliabilities)
+        {
+            this.logger.LogDebug(
+                "Adding reliability entry for {missingReliability}",
+                missingReliability
+            );
+
+            this.apiContext.PlayerDragonReliability.Add(
+                DbPlayerDragonReliabilityFactory.Create(
+                    this.playerIdentityService.ViewerId,
+                    missingReliability
+                )
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Add a savefile update that detects missing dragon reliability entries and adds them
- Remove throw condition in party power calculation when reliability is missing; `GetDragonPower` is able to handle `reliability` being null, and if this throws on missing reliability during `V11Update` then `V17Update` will never be reached.