### PR TITLE
Add auto-repeat

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
@@ -1,0 +1,309 @@
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
+using DragaliaAPI.Shared.Definitions.Enums.EventItemTypes;
+
+namespace DragaliaAPI.Integration.Test.Features.Dungeon;
+
+public class AutoRepeatTest : TestFixture
+{
+    public AutoRepeatTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task AutoRepeat_RecordReturnsRepeatKey()
+    {
+        DungeonStartStartData startResponse = (
+            await Client.PostMsgpack<DungeonStartStartData>(
+                "/dungeon_start/start",
+                new DungeonStartStartRequest()
+                {
+                    party_no_list = [38],
+                    quest_id = 100010103,
+                    repeat_setting = new()
+                    {
+                        repeat_count = 45,
+                        repeat_type = RepeatSettingType.Specified,
+                        use_item_list = [UseItem.Honey]
+                    }
+                }
+            )
+        ).data;
+
+        startResponse.ingame_data.repeat_state.Should().Be(1);
+
+        DungeonRecordRecordData recordResponse = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [] },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        recordResponse.repeat_data.repeat_count.Should().Be(1);
+        recordResponse.repeat_data.repeat_key.Should().NotBeNullOrEmpty();
+        recordResponse.repeat_data.repeat_state.Should().Be(1);
+
+        DungeonStartStartAssignUnitData startResponse2 = (
+            await Client.PostMsgpack<DungeonStartStartAssignUnitData>(
+                "/dungeon_start/start_assign_unit",
+                new DungeonStartStartAssignUnitRequest()
+                {
+                    request_party_setting_list = [new() { chara_id = Charas.ThePrince }],
+                    quest_id = 100010103,
+                    repeat_state = 1,
+                    repeat_setting = null,
+                }
+            )
+        ).data;
+
+        startResponse2.ingame_data.repeat_state.Should().Be(1);
+
+        DungeonRecordRecordData recordResponse2 = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse2.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [] },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        recordResponse2.repeat_data.repeat_count.Should().Be(2);
+        recordResponse2.repeat_data.repeat_key.Should().NotBeNullOrEmpty();
+        recordResponse2.repeat_data.repeat_state.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task AutoRepeat_CallsRepeatEnd_ReturnsMergedRewardLists()
+    {
+        DungeonStartStartData startResponse = (
+            await Client.PostMsgpack<DungeonStartStartData>(
+                "/dungeon_start/start",
+                new DungeonStartStartRequest()
+                {
+                    party_no_list = [38],
+                    quest_id = 100010103,
+                    repeat_setting = new()
+                    {
+                        repeat_count = 45,
+                        repeat_type = RepeatSettingType.Specified,
+                        use_item_list = [UseItem.Honey]
+                    }
+                }
+            )
+        ).data;
+
+        DungeonRecordRecordData recordResponse = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [] },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        DungeonStartStartAssignUnitData startResponse2 = (
+            await Client.PostMsgpack<DungeonStartStartAssignUnitData>(
+                "/dungeon_start/start_assign_unit",
+                new DungeonStartStartAssignUnitRequest()
+                {
+                    request_party_setting_list = [new() { chara_id = Charas.ThePrince }],
+                    quest_id = 100010103,
+                    repeat_state = 1,
+                    repeat_setting = null,
+                }
+            )
+        ).data;
+
+        DungeonRecordRecordData recordResponse2 = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse2.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [] },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        RepeatEndData repeatEndResponse = (
+            await Client.PostMsgpack<RepeatEndData>("repeat/end", new RepeatEndRequest())
+        ).data;
+
+        repeatEndResponse.repeat_data.Should().BeEquivalentTo(recordResponse2.repeat_data);
+
+        // Breaking news: lazy developer too lazy to test cumbersome merging logic
+        int expectedCoin =
+            recordResponse.ingame_result_data.reward_record.take_coin
+            + recordResponse2.ingame_result_data.reward_record.take_coin;
+
+        repeatEndResponse
+            .ingame_result_data.reward_record.Should()
+            .BeEquivalentTo(
+                new RewardRecord() { take_coin = expectedCoin },
+                opts => opts.Including(x => x.take_coin)
+            );
+
+        repeatEndResponse.update_data_list.Should().NotBeNull();
+        repeatEndResponse
+            .update_data_list.user_data.Should()
+            .BeEquivalentTo(recordResponse2.update_data_list.user_data);
+    }
+
+    [Fact]
+    public async Task AutoRepeat_EventMission_GrantsAccumulatedPoints()
+    {
+        int eventId = 20816;
+        int questId = 208160502; // Flames of Reflection -- The Path To Mastery: Master
+
+        await AddToDatabase(
+            new DbQuest()
+            {
+                QuestId = questId,
+                State = 0,
+                ViewerId = ViewerId
+            }
+        );
+
+        await Client.PostMsgpack<MemoryEventActivateData>(
+            "/memory_event/activate",
+            new MemoryEventActivateRequest() { event_id = eventId }
+        );
+        DungeonStartStartData startResponse = (
+            await Client.PostMsgpack<DungeonStartStartData>(
+                "/dungeon_start/start",
+                new DungeonStartStartRequest()
+                {
+                    party_no_list = [38],
+                    quest_id = questId,
+                    repeat_setting = new()
+                    {
+                        repeat_count = 45,
+                        repeat_type = RepeatSettingType.Specified,
+                        use_item_list = [UseItem.Honey]
+                    }
+                }
+            )
+        ).data;
+
+        DungeonRecordRecordData recordResponse = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [], wave = 5 },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        DungeonStartStartAssignUnitData startResponse2 = (
+            await Client.PostMsgpack<DungeonStartStartAssignUnitData>(
+                "/dungeon_start/start_assign_unit",
+                new DungeonStartStartAssignUnitRequest()
+                {
+                    request_party_setting_list = [new() { chara_id = Charas.ThePrince }],
+                    quest_id = questId,
+                    repeat_state = 1,
+                    repeat_setting = null,
+                }
+            )
+        ).data;
+
+        DungeonRecordRecordData recordResponse2 = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse2.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [], wave = 5 },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        RepeatEndData repeatEndResponse = (
+            await Client.PostMsgpack<RepeatEndData>("repeat/end", new RepeatEndRequest())
+        ).data;
+
+        int expectedPoints =
+            recordResponse.ingame_result_data.reward_record.take_accumulate_point
+            + recordResponse2.ingame_result_data.reward_record.take_accumulate_point;
+        int expectedBoostPoints =
+            recordResponse.ingame_result_data.reward_record.take_boost_accumulate_point
+            + recordResponse2.ingame_result_data.reward_record.take_boost_accumulate_point;
+
+        repeatEndResponse
+            .ingame_result_data.reward_record.take_accumulate_point.Should()
+            .Be(expectedPoints);
+
+        repeatEndResponse
+            .ingame_result_data.reward_record.take_boost_accumulate_point.Should()
+            .Be(expectedBoostPoints);
+
+        repeatEndResponse
+            .update_data_list.build_event_user_list.Should()
+            .Contain(x => x.build_event_id == eventId);
+
+        repeatEndResponse
+            .update_data_list.build_event_user_list.First(x => x.build_event_id == eventId)
+            .user_build_event_item_list.Should()
+            .ContainEquivalentOf(
+                new AtgenUserBuildEventItemList()
+                {
+                    user_build_event_item = (int)BuildEventItemType.BuildEventPoint,
+                    event_item_value = expectedPoints + expectedBoostPoints
+                }
+            );
+    }
+
+    [Fact]
+    public async Task AutoRepeat_ActiveRepeat_MypageInfoReturnsRepeatInfo()
+    {
+        DungeonStartStartData startResponse = (
+            await Client.PostMsgpack<DungeonStartStartData>(
+                "/dungeon_start/start",
+                new DungeonStartStartRequest()
+                {
+                    party_no_list = [38],
+                    quest_id = 100010103,
+                    repeat_setting = new()
+                    {
+                        repeat_count = 45,
+                        repeat_type = RepeatSettingType.Specified,
+                        use_item_list = [UseItem.Honey]
+                    }
+                }
+            )
+        ).data;
+
+        DungeonRecordRecordData recordResponse = (
+            await Client.PostMsgpack<DungeonRecordRecordData>(
+                "dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    dungeon_key = startResponse.ingame_data.dungeon_key,
+                    play_record = new() { treasure_record = [] },
+                    repeat_state = 1,
+                }
+            )
+        ).data;
+
+        MypageInfoData mypageResponse = (
+            await Client.PostMsgpack<MypageInfoData>("mypage/info", new MypageInfoRequest() { })
+        ).data;
+
+        mypageResponse.repeat_data.Should().BeEquivalentTo(recordResponse.repeat_data);
+    }
+}

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -184,6 +184,8 @@ public class DungeonRecordTest : TestFixture
                     last_weekly_reset_time = DateTimeOffset.UtcNow
                 }
             );
+
+        response.repeat_data.Should().BeNull();
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -182,7 +182,7 @@ public class DungeonStartTest : TestFixture
         (
             await Client.PostMsgpack<DungeonStartStartData>(
                 $"/dungeon_start/{endpoint}",
-                new DungeonStartStartRequest() { quest_id = 100010104 },
+                new DungeonStartStartRequest() { quest_id = 100010104, party_no_list = [1] },
                 ensureSuccessHeader: false
             )
         )

--- a/DragaliaAPI.Shared/Definitions/Enums/Dungeon/RepeatSettingType.cs
+++ b/DragaliaAPI.Shared/Definitions/Enums/Dungeon/RepeatSettingType.cs
@@ -1,0 +1,8 @@
+namespace DragaliaAPI.Shared.Definitions.Enums.Dungeon;
+
+public enum RepeatSettingType
+{
+    None,
+    UseAllStamina,
+    Specified
+}

--- a/DragaliaAPI/Controllers/Dragalia/MypageController.cs
+++ b/DragaliaAPI/Controllers/Dragalia/MypageController.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Features.Missions;
+﻿using DragaliaAPI.Features.Dungeon.AutoRepeat;
+using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Shop;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
@@ -14,6 +15,7 @@ namespace DragaliaAPI.Controllers.Dragalia;
 public class MypageController(
     IMissionService missionService,
     IShopRepository shopRepository,
+    IAutoRepeatService autoRepeatService,
     IUpdateDataService updateDataService
 ) : DragaliaControllerBase
 {
@@ -42,6 +44,11 @@ public class MypageController(
         resp.is_shop_notification = await shopRepository.GetDailySummonCountAsync() == 0;
         resp.update_data_list = await updateDataService.SaveChangesAsync();
         resp.update_data_list.mission_notice = await missionService.GetMissionNotice(null);
+
+        RepeatInfo? repeatInfo = await autoRepeatService.GetRepeatInfo();
+
+        if (repeatInfo != null)
+            resp.repeat_data = new(repeatInfo.Key.ToString(), repeatInfo.CurrentCount, 1);
 
         return Ok(resp);
     }

--- a/DragaliaAPI/Extensions/DistributedCacheExtensions.cs
+++ b/DragaliaAPI/Extensions/DistributedCacheExtensions.cs
@@ -1,0 +1,26 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace DragaliaAPI.Extensions;
+
+public static class DistributedCacheExtensions
+{
+    public static async Task<TObject?> GetJsonAsync<TObject>(
+        this IDistributedCache cache,
+        string key
+    )
+        where TObject : class
+    {
+        string? json = await cache.GetStringAsync(key);
+        if (json == null)
+            return default;
+
+        return JsonSerializer.Deserialize<TObject>(json);
+    }
+
+    public static Task SetJsonAsync(
+        this IDistributedCache cache,
+        string key,
+        object entry,
+        DistributedCacheEntryOptions options
+    ) => cache.SetStringAsync(key, JsonSerializer.Serialize(entry), options);
+}

--- a/DragaliaAPI/Extensions/EnumerableExtensions.cs
+++ b/DragaliaAPI/Extensions/EnumerableExtensions.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Extensions;
 
-public static class IEnumerableExtensions
+public static class EnumerableExtensions
 {
     public static bool TryGetElementAt<TElement>(
         this IEnumerable<TElement> enumerable,

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
@@ -93,10 +93,6 @@ public class AutoRepeatService(
         };
     }
 
-    /// <summary>
-    /// Attempt to get a player's pre-configured <see cref="RepeatInfo"/> from dungeon start via viewer ID lookup.
-    /// </summary>
-    /// <returns>The <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
     public async Task<RepeatInfo?> GetRepeatInfo()
     {
         string? key = await this.distributedCache.GetStringAsync(
@@ -108,12 +104,25 @@ public class AutoRepeatService(
         return await this.GetRepeatInfo(Guid.Parse(key));
     }
 
+    public async Task<RepeatInfo?> ClearRepeatInfo()
+    {
+        RepeatInfo? info = await this.GetRepeatInfo();
+        if (info != null)
+            await this.distributedCache.RemoveAsync(Schema.RepeatInfo(info.Key));
+
+        await this.distributedCache.RemoveAsync(
+            Schema.RepeatKey(this.playerIdentityService.ViewerId)
+        );
+
+        return info;
+    }
+
     /// <summary>
     /// Attempts to get a player's <see cref="RepeatInfo"/> via key lookup.
     /// </summary>
     /// <param name="key">The <see cref="RepeatInfo"/>'s key.</param>
     /// <returns>The <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
-    public Task<RepeatInfo?> GetRepeatInfo(Guid key) =>
+    private Task<RepeatInfo?> GetRepeatInfo(Guid key) =>
         this.distributedCache.GetJsonAsync<RepeatInfo>(Schema.RepeatInfo(key));
 
     private static class Schema

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
@@ -1,0 +1,149 @@
+using DragaliaAPI.Extensions;
+using DragaliaAPI.Features.Dungeon.Start;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Models.Options;
+using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
+using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Options;
+
+namespace DragaliaAPI.Features.Dungeon.AutoRepeat;
+
+public class AutoRepeatService(
+    IDistributedCache distributedCache,
+    IPlayerIdentityService playerIdentityService,
+    IOptionsMonitor<RedisOptions> options,
+    ILogger<AutoRepeatService> logger
+) : IAutoRepeatService
+{
+    private readonly IDistributedCache distributedCache = distributedCache;
+    private readonly IPlayerIdentityService playerIdentityService = playerIdentityService;
+
+    private readonly DistributedCacheEntryOptions cacheOptions =
+        new()
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(
+                options.CurrentValue.AutoRepeatExpiryTimeMinutes
+            )
+        };
+
+    public async Task SetRepeatSetting(RepeatSetting repeatSetting)
+    {
+        RepeatInfo info =
+            new()
+            {
+                Key = Guid.NewGuid(),
+                Type = repeatSetting.repeat_type,
+                UseItemList = repeatSetting.use_item_list,
+                MaxCount = repeatSetting.repeat_count,
+                CurrentCount = 0
+            };
+
+        logger.LogDebug("Saving auto-repeat setting: {@info}", info);
+
+        await this.WriteRepeatInfo(info);
+    }
+
+    public async Task<RepeatData?> RecordRepeat(
+        string? repeatKey,
+        IngameResultData ingameResultData,
+        UpdateDataList updateDataList
+    )
+    {
+        RepeatInfo? info;
+
+        if (repeatKey != null)
+        {
+            info = await this.GetRepeatInfo(Guid.Parse(repeatKey));
+            if (info == null)
+            {
+                logger.LogWarning("Invalid repeat key: {@key}", repeatKey);
+                return null;
+            }
+
+            logger.LogTrace("Found repeat info: {@info}", info);
+        }
+        else
+        {
+            /*
+             * The repeat_key is null on the first auto-repeat iteration before the client knows the repeat_key.
+             * During the first auto repeat, it may have been configured in /dungeon_start/start, or during the quest.
+             *
+             * In the former case, we need to retrieve the pre-configured settings from the start request,
+             * and in the latter case we need to create default settings.
+             */
+
+            info = await this.GetRepeatInfo();
+            logger.LogTrace("Repeat key was null, found repeat info {@info}", info);
+
+            info ??= CreateDefaultRepeatInfo();
+        }
+
+        info.CurrentCount += 1;
+        info.IngameResultData = info.IngameResultData.CombineWith(ingameResultData);
+        info.UpdateDataList = info.UpdateDataList.CombineWith(updateDataList);
+
+        await this.WriteRepeatInfo(info);
+
+        return new RepeatData()
+        {
+            repeat_count = info.CurrentCount,
+            repeat_key = info.Key.ToString(),
+            repeat_state = 1,
+        };
+    }
+
+    /// <summary>
+    /// Attempt to get a player's pre-configured <see cref="RepeatInfo"/> from dungeon start via viewer ID lookup.
+    /// </summary>
+    /// <returns>The <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
+    public async Task<RepeatInfo?> GetRepeatInfo()
+    {
+        string? key = await this.distributedCache.GetStringAsync(
+            Schema.RepeatKey(this.playerIdentityService.ViewerId)
+        );
+        if (key == null)
+            return null;
+
+        return await this.GetRepeatInfo(Guid.Parse(key));
+    }
+
+    /// <summary>
+    /// Attempts to get a player's <see cref="RepeatInfo"/> via key lookup.
+    /// </summary>
+    /// <param name="key">The <see cref="RepeatInfo"/>'s key.</param>
+    /// <returns>The <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
+    public Task<RepeatInfo?> GetRepeatInfo(Guid key) =>
+        this.distributedCache.GetJsonAsync<RepeatInfo>(Schema.RepeatInfo(key));
+
+    private static class Schema
+    {
+        public static string RepeatKey(long viewerId) => $":autorepeat:{viewerId}";
+
+        public static string RepeatInfo(Guid repeatKey) => $":autorepeat:{repeatKey}";
+    }
+
+    private static RepeatInfo CreateDefaultRepeatInfo() =>
+        new()
+        {
+            Key = Guid.NewGuid(),
+            Type = RepeatSettingType.Specified,
+            UseItemList = [],
+            MaxCount = 99,
+        };
+
+    private async Task WriteRepeatInfo(RepeatInfo info)
+    {
+        await this.distributedCache.SetStringAsync(
+            Schema.RepeatKey(this.playerIdentityService.ViewerId),
+            info.Key.ToString(),
+            this.cacheOptions
+        );
+
+        await this.distributedCache.SetJsonAsync(
+            Schema.RepeatInfo(info.Key),
+            info,
+            this.cacheOptions
+        );
+    }
+}

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/IAutoRepeatService.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/IAutoRepeatService.cs
@@ -1,0 +1,16 @@
+using DragaliaAPI.Features.Dungeon.AutoRepeat;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
+
+namespace DragaliaAPI.Features.Dungeon.Start;
+
+public interface IAutoRepeatService
+{
+    Task SetRepeatSetting(RepeatSetting repeatSetting);
+    Task<RepeatInfo?> GetRepeatInfo();
+    Task<RepeatData?> RecordRepeat(
+        string? repeatKey,
+        IngameResultData ingameResultData,
+        UpdateDataList updateDataList
+    );
+}

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/IAutoRepeatService.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/IAutoRepeatService.cs
@@ -1,13 +1,36 @@
 using DragaliaAPI.Features.Dungeon.AutoRepeat;
 using DragaliaAPI.Models.Generated;
-using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
 
-namespace DragaliaAPI.Features.Dungeon.Start;
+namespace DragaliaAPI.Features.Dungeon.AutoRepeat;
 
 public interface IAutoRepeatService
 {
+    /// <summary>
+    /// Save a <see cref="RepeatSetting"/> to the cache.
+    /// </summary>
+    /// <param name="repeatSetting">Instance of <see cref="RepeatSetting"/>.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     Task SetRepeatSetting(RepeatSetting repeatSetting);
+
+    /// <summary>
+    /// Gets an instance of <see cref="RepeatInfo"/> associated with the user by viewer ID lookup.
+    /// </summary>
+    /// <returns>An instance of <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
     Task<RepeatInfo?> GetRepeatInfo();
+
+    /// <summary>
+    /// Clear the current player's repeat info, and return it if it was found.
+    /// </summary>
+    /// <returns>An instance of <see cref="RepeatInfo"/>, or <see langword="null"/> if none was found.</returns>
+    Task<RepeatInfo?> ClearRepeatInfo();
+
+    /// <summary>
+    /// Record a clear during an auto-repeat, and either create or update a <see cref="RepeatInfo"/>.
+    /// </summary>
+    /// <param name="repeatKey">The repeat key.</param>
+    /// <param name="ingameResultData">The <see cref="IngameResultData"/> for this clear.</param>
+    /// <param name="updateDataList">The <see cref="UpdateDataList"/> for this clear.</param>
+    /// <returns></returns>
     Task<RepeatData?> RecordRepeat(
         string? repeatKey,
         IngameResultData ingameResultData,

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
@@ -1,6 +1,7 @@
 using DragaliaAPI.Controllers;
 using DragaliaAPI.Features.Dungeon.Start;
 using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Services.Exceptions;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DragaliaAPI.Features.Dungeon.AutoRepeat;
@@ -17,11 +18,13 @@ public class RepeatController(
     [HttpPost("end")]
     public async Task<DragaliaResult<RepeatEndData>> End()
     {
-        RepeatInfo? info = await this.autoRepeatService.GetRepeatInfo();
+        RepeatInfo? info = await this.autoRepeatService.ClearRepeatInfo();
         if (info == null)
         {
-            this.logger.LogWarning("Failed to retrieve repeat data");
-            return this.Code(ResultCode.DungeonRepeatNotPlayable);
+            throw new DragaliaException(
+                ResultCode.DungeonRepeatNotPlayable,
+                "Failed to retrieve repeat data"
+            );
         }
 
         RepeatEndData response =

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
@@ -39,7 +39,8 @@ public class RepeatController(
                     over_discard_entity_list = [],
                     over_present_limit_entity_list = [],
                     over_present_entity_list = []
-                }
+                },
+                repeat_data = new(info.Key.ToString(), info.CurrentCount, 1)
             };
 
         return response;

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
@@ -1,0 +1,44 @@
+using DragaliaAPI.Controllers;
+using DragaliaAPI.Features.Dungeon.Start;
+using DragaliaAPI.Models.Generated;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DragaliaAPI.Features.Dungeon.AutoRepeat;
+
+[Route("repeat")]
+public class RepeatController(
+    IAutoRepeatService autoRepeatService,
+    ILogger<RepeatController> logger
+) : DragaliaControllerBase
+{
+    private readonly IAutoRepeatService autoRepeatService = autoRepeatService;
+    private readonly ILogger<RepeatController> logger = logger;
+
+    [HttpPost("end")]
+    public async Task<DragaliaResult<RepeatEndData>> End()
+    {
+        RepeatInfo? info = await this.autoRepeatService.GetRepeatInfo();
+        if (info == null)
+        {
+            this.logger.LogWarning("Failed to retrieve repeat data");
+            return this.Code(ResultCode.DungeonRepeatNotPlayable);
+        }
+
+        RepeatEndData response =
+            new()
+            {
+                ingame_result_data = info.IngameResultData,
+                update_data_list = info.UpdateDataList,
+                entity_result = new()
+                {
+                    converted_entity_list = [],
+                    new_get_entity_list = [],
+                    over_discard_entity_list = [],
+                    over_present_limit_entity_list = [],
+                    over_present_entity_list = []
+                }
+            };
+
+        return response;
+    }
+}

--- a/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatInfo.cs
+++ b/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatInfo.cs
@@ -1,0 +1,18 @@
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
+
+namespace DragaliaAPI.Features.Dungeon.AutoRepeat;
+
+public class RepeatInfo
+{
+    public Guid Key { get; init; }
+    public RepeatSettingType Type { get; init; }
+    public List<UseItem> UseItemList { get; init; } = [];
+    public int MaxCount { get; init; }
+    public int CurrentCount { get; set; }
+
+    public IngameResultData? IngameResultData { get; set; }
+
+    public UpdateDataList? UpdateDataList { get; set; }
+}

--- a/DragaliaAPI/Features/Dungeon/Extensions.cs
+++ b/DragaliaAPI/Features/Dungeon/Extensions.cs
@@ -17,22 +17,14 @@ public static class Extensions
     )
     {
         if (first == null)
-        {
             return second;
-        }
 
-        first.reward_record.take_coin += second.reward_record.take_coin;
-        first.reward_record.drop_all.AddRange(second.reward_record.drop_all);
+        first.reward_record = first.reward_record.CombineWith(second.reward_record);
+        first.grow_record = first.grow_record.CombineWith(second.grow_record);
 
-        first.grow_record.take_chara_exp += second.grow_record.take_chara_exp;
-        first.grow_record.take_player_exp += second.grow_record.take_player_exp;
-        first.grow_record.take_mana += second.grow_record.take_mana;
-
-        first.reward_record.quest_bonus_list = first.reward_record.quest_bonus_list.Concat(
-            second.reward_record.quest_bonus_list
-        );
-
-        first.reward_record.player_level_up_fstone += second.reward_record.player_level_up_fstone;
+        first.converted_entity_list = first
+            .converted_entity_list.Concat(second.converted_entity_list)
+            .Merge();
 
         return first;
     }
@@ -40,10 +32,7 @@ public static class Extensions
     public static UpdateDataList CombineWith(this UpdateDataList? first, UpdateDataList second)
     {
         if (first == null)
-        {
-            first = second;
-            return first;
-        }
+            return second;
 
         /*
          * Combining a massive type like UpdateDataList is a huge endeavour, but here we are only going to combine
@@ -51,30 +40,118 @@ public static class Extensions
          *
          * TODO:
          * - Mission notices
-         * - Event data
          */
 
-        first.material_list = CombineNullableLists(first.material_list, second.material_list);
-        first.ability_crest_list = CombineNullableLists(
-            first.ability_crest_list,
-            second.ability_crest_list
+        first.material_list = UnionNullableLists(
+            second.material_list, // Second goes first for more up-to-date quantities
+            first.material_list,
+            m => m.material_id
         );
+        first.ability_crest_list = UnionNullableLists(
+            first.ability_crest_list,
+            second.ability_crest_list,
+            a => a.ability_crest_id
+        );
+
+        // Properties that will always be more up to date in the more recent list
+        first.user_data = second.user_data;
+        first.quest_list = second.quest_list;
+        first.build_event_user_list = second.build_event_user_list;
+        first.earn_event_user_list = second.earn_event_user_list;
+        first.raid_event_user_list = second.raid_event_user_list;
+        first.event_passive_list = second.event_passive_list;
+        first.clb_01_event_user_list = second.clb_01_event_user_list;
+        first.combat_event_user_list = second.combat_event_user_list;
+        first.ex_hunter_event_user_list = second.ex_hunter_event_user_list;
+        first.ex_rush_event_user_list = second.ex_rush_event_user_list;
 
         return first;
     }
 
-    private static List<TElement>? CombineNullableLists<TElement>(
-        List<TElement>? first,
-        IEnumerable<TElement>? second
+    public static IEnumerable<ConvertedEntityList> Merge(
+        this IEnumerable<ConvertedEntityList> source
+    ) =>
+        source
+            .GroupBy(
+                x =>
+                    new
+                    {
+                        x.before_entity_id,
+                        x.before_entity_type,
+                        x.after_entity_id,
+                        x.after_entity_type
+                    }
+            )
+            .Select(
+                group =>
+                    group.Aggregate(
+                        new ConvertedEntityList
+                        {
+                            before_entity_id = group.Key.before_entity_id,
+                            before_entity_type = group.Key.before_entity_type,
+                            after_entity_id = group.Key.after_entity_id,
+                            after_entity_type = group.Key.after_entity_type
+                        },
+                        (acc, current) =>
+                        {
+                            acc.before_entity_quantity += current.before_entity_quantity;
+                            acc.after_entity_quantity += current.after_entity_quantity;
+                            return acc;
+                        }
+                    )
+            );
+
+    private static IEnumerable<AtgenDropAll> Merge(this IEnumerable<AtgenDropAll> source) =>
+        source
+            .GroupBy(x => new { x.type, x.id, })
+            .Select(
+                group =>
+                    group.Aggregate(
+                        new AtgenDropAll { id = group.Key.id, type = group.Key.type, },
+                        (acc, current) =>
+                        {
+                            acc.quantity += current.quantity;
+                            return acc;
+                        }
+                    )
+            );
+
+    private static IEnumerable<TElement>? UnionNullableLists<TElement, TKey>(
+        IEnumerable<TElement>? first,
+        IEnumerable<TElement>? second,
+        Func<TElement, TKey> keySelector
     )
     {
         if (first == null)
-            return second?.ToList();
+            return second;
 
         if (second == null)
             return first;
 
-        first.AddRange(second);
+        return first.UnionBy(second, keySelector);
+    }
+
+    private static RewardRecord CombineWith(this RewardRecord first, RewardRecord second)
+    {
+        first.take_coin += second.take_coin;
+        first.drop_all = first.drop_all.Concat(second.drop_all).Merge().ToList();
+
+        first.quest_bonus_list = first.quest_bonus_list.Concat(second.quest_bonus_list);
+
+        first.take_accumulate_point += second.take_accumulate_point;
+        first.take_boost_accumulate_point += second.take_boost_accumulate_point;
+
+        first.player_level_up_fstone += second.player_level_up_fstone;
+
+        return first;
+    }
+
+    private static GrowRecord CombineWith(this GrowRecord first, GrowRecord second)
+    {
+        first.take_chara_exp += second.take_chara_exp;
+        first.take_player_exp += second.take_player_exp;
+        first.take_mana += second.take_mana;
+
         return first;
     }
 }

--- a/DragaliaAPI/Features/Dungeon/Extensions.cs
+++ b/DragaliaAPI/Features/Dungeon/Extensions.cs
@@ -1,0 +1,80 @@
+using DragaliaAPI.Models.Generated;
+
+namespace DragaliaAPI.Features.Dungeon;
+
+public static class Extensions
+{
+    /// <summary>
+    /// Combine two instances of <see cref="IngameResultData"/>. Modifies <paramref name="first"/> to include the data
+    /// in both <paramref name="first"/> and <paramref name="second"/>.
+    /// </summary>
+    /// <param name="first">First instance of <see cref="IngameResultData"/>.</param>
+    /// <param name="second">Second instance of <see cref="IngameResultData"/>.</param>
+    /// <returns><paramref name="first"/> after combining.</returns>
+    public static IngameResultData CombineWith(
+        this IngameResultData? first,
+        IngameResultData second
+    )
+    {
+        if (first == null)
+        {
+            return second;
+        }
+
+        first.reward_record.take_coin += second.reward_record.take_coin;
+        first.reward_record.drop_all.AddRange(second.reward_record.drop_all);
+
+        first.grow_record.take_chara_exp += second.grow_record.take_chara_exp;
+        first.grow_record.take_player_exp += second.grow_record.take_player_exp;
+        first.grow_record.take_mana += second.grow_record.take_mana;
+
+        first.reward_record.quest_bonus_list = first.reward_record.quest_bonus_list.Concat(
+            second.reward_record.quest_bonus_list
+        );
+
+        first.reward_record.player_level_up_fstone += second.reward_record.player_level_up_fstone;
+
+        return first;
+    }
+
+    public static UpdateDataList CombineWith(this UpdateDataList? first, UpdateDataList second)
+    {
+        if (first == null)
+        {
+            first = second;
+            return first;
+        }
+
+        /*
+         * Combining a massive type like UpdateDataList is a huge endeavour, but here we are only going to combine
+         * things that are relevant for dungeon clears.
+         *
+         * TODO:
+         * - Mission notices
+         * - Event data
+         */
+
+        first.material_list = CombineNullableLists(first.material_list, second.material_list);
+        first.ability_crest_list = CombineNullableLists(
+            first.ability_crest_list,
+            second.ability_crest_list
+        );
+
+        return first;
+    }
+
+    private static List<TElement>? CombineNullableLists<TElement>(
+        List<TElement>? first,
+        IEnumerable<TElement>? second
+    )
+    {
+        if (first == null)
+            return second?.ToList();
+
+        if (second == null)
+            return first;
+
+        first.AddRange(second);
+        return first;
+    }
+}

--- a/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -8,13 +8,15 @@ public interface IDungeonStartService
     Task<IngameData> GetIngameData(
         int questId,
         IList<int> partyNoList,
+        RepeatSetting? repeatSetting = null,
         ulong? supportViewerId = null
     );
 
-    Task<IngameData> GetIngameData(
+    Task<IngameData> GetAssignUnitIngameData(
         int questId,
         IList<PartySettingList> party,
-        ulong? supportViewerId = null
+        ulong? supportViewerId = null,
+        RepeatSetting? repeatSetting = null
     );
 
     Task<IngameQuestData> InitiateQuest(int questId);

--- a/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -7,13 +7,13 @@ public interface IDungeonStartService
 {
     Task<IngameData> GetIngameData(
         int questId,
-        IEnumerable<int> partyNoList,
+        IList<int> partyNoList,
         ulong? supportViewerId = null
     );
 
     Task<IngameData> GetIngameData(
         int questId,
-        IEnumerable<PartySettingList> party,
+        IList<PartySettingList> party,
         ulong? supportViewerId = null
     );
 
@@ -28,7 +28,7 @@ public interface IDungeonStartService
     Task<IngameData> GetWallIngameData(
         int wallId,
         int wallLevel,
-        IEnumerable<PartySettingList> party,
+        IList<PartySettingList> party,
         ulong? supportViewerId = null
     );
 }

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -162,39 +162,3 @@ public class DungeonRecordService(
         growRecord.mana_bonus_factor = 1;
     }
 }
-
-file static class Extensions
-{
-    public static IEnumerable<ConvertedEntityList> Merge(
-        this IEnumerable<ConvertedEntityList> source
-    ) =>
-        source
-            .GroupBy(
-                x =>
-                    new
-                    {
-                        x.before_entity_id,
-                        x.before_entity_type,
-                        x.after_entity_id,
-                        x.after_entity_type
-                    }
-            )
-            .Select(
-                group =>
-                    group.Aggregate(
-                        new ConvertedEntityList
-                        {
-                            before_entity_id = group.Key.before_entity_id,
-                            before_entity_type = group.Key.before_entity_type,
-                            after_entity_id = group.Key.after_entity_id,
-                            after_entity_type = group.Key.after_entity_type
-                        },
-                        (acc, current) =>
-                        {
-                            acc.before_entity_quantity += current.before_entity_quantity;
-                            acc.after_entity_quantity += current.after_entity_quantity;
-                            return acc;
-                        }
-                    )
-            );
-}

--- a/DragaliaAPI/Features/Dungeon/Skip/DungeonSkipController.cs
+++ b/DragaliaAPI/Features/Dungeon/Skip/DungeonSkipController.cs
@@ -232,29 +232,5 @@ public class DungeonSkipController(
 
     private static IngameResultData CombineIngameResultData(
         IEnumerable<IngameResultData> ingameResultDatas
-    )
-    {
-        return ingameResultDatas.Aggregate(
-            (acc, current) =>
-            {
-                // TODO: Combine other things
-                acc.reward_record.take_coin += current.reward_record.take_coin;
-                acc.reward_record.drop_all.AddRange(current.reward_record.drop_all);
-
-                acc.grow_record.take_chara_exp += current.grow_record.take_chara_exp;
-                acc.grow_record.take_player_exp += current.grow_record.take_player_exp;
-                acc.grow_record.take_mana += current.grow_record.take_mana;
-
-                acc.reward_record.quest_bonus_list = acc.reward_record.quest_bonus_list.Concat(
-                    current.reward_record.quest_bonus_list
-                );
-
-                acc.reward_record.player_level_up_fstone += current
-                    .reward_record
-                    .player_level_up_fstone;
-
-                return acc;
-            }
-        );
-    }
+    ) => ingameResultDatas.Aggregate((acc, current) => acc.CombineWith(current));
 }

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
@@ -32,6 +32,7 @@ public class DungeonStartController(
         IngameData ingameData = await dungeonStartService.GetIngameData(
             request.quest_id,
             request.party_no_list,
+            request.repeat_setting,
             request.support_viewer_id
         );
 
@@ -79,18 +80,23 @@ public class DungeonStartController(
     }
 
     [HttpPost("start_assign_unit")]
-    public async Task<DragaliaResult> StartAssignUnit(DungeonStartStartAssignUnitRequest request)
+    public async Task<DragaliaResult<DungeonStartStartAssignUnitData>> StartAssignUnit(
+        DungeonStartStartAssignUnitRequest request
+    )
     {
         if (!await dungeonStartService.ValidateStamina(request.quest_id, StaminaType.Single))
             return this.Code(ResultCode.QuestStaminaSingleShort);
 
-        IngameData ingameData = await dungeonStartService.GetIngameData(
+        IngameData ingameData = await dungeonStartService.GetAssignUnitIngameData(
             request.quest_id,
             request.request_party_setting_list,
-            request.support_viewer_id
+            request.support_viewer_id,
+            request.repeat_setting
         );
 
         DungeonStartStartData response = await BuildResponse(request.quest_id, ingameData);
+
+        response.ingame_data.repeat_state = request.repeat_state;
 
         return Ok(response);
     }
@@ -106,7 +112,7 @@ public class DungeonStartController(
         if (!await dungeonStartService.ValidateStamina(request.quest_id, StaminaType.Multi))
             return this.Code(ResultCode.QuestStaminaMultiShort);
 
-        IngameData ingameData = await dungeonStartService.GetIngameData(
+        IngameData ingameData = await dungeonStartService.GetAssignUnitIngameData(
             request.quest_id,
             request.request_party_setting_list
         );

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
@@ -1,4 +1,5 @@
 ﻿using DragaliaAPI.Controllers;
+using DragaliaAPI.Extensions;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.TimeAttack;
 using DragaliaAPI.Models.Generated;

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -62,7 +62,7 @@ public class DungeonStartService(
 
     public async Task<IngameData> GetIngameData(
         int questId,
-        IEnumerable<int> partyNoList,
+        IList<int> partyNoList,
         ulong? supportViewerId = null
     )
     {
@@ -98,7 +98,7 @@ public class DungeonStartService(
 
     public async Task<IngameData> GetIngameData(
         int questId,
-        IEnumerable<PartySettingList> party,
+        IList<PartySettingList> party,
         ulong? supportViewerId = null
     )
     {
@@ -169,7 +169,7 @@ public class DungeonStartService(
     public async Task<IngameData> GetWallIngameData(
         int wallId,
         int wallLevel,
-        IEnumerable<PartySettingList> party,
+        IList<PartySettingList> party,
         ulong? supportViewerId = null
     )
     {
@@ -320,7 +320,7 @@ public class DungeonStartService(
             new()
             {
                 quest_id = questId,
-                viewer_id = (ulong?)playerIdentityService.ViewerId ?? 0UL,
+                viewer_id = (ulong)playerIdentityService.ViewerId,
                 play_type = QuestPlayType.Default,
                 party_info = new() { support_data = new() },
                 start_time = DateTimeOffset.UtcNow,

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -31,7 +31,8 @@ public class DungeonStartService(
     IMapper mapper,
     ILogger<DungeonStartService> logger,
     IPaymentService paymentService,
-    IEventService eventService
+    IEventService eventService,
+    IAutoRepeatService autoRepeatService
 ) : IDungeonStartService
 {
     public async Task<bool> ValidateStamina(int questId, StaminaType staminaType)
@@ -63,6 +64,7 @@ public class DungeonStartService(
     public async Task<IngameData> GetIngameData(
         int questId,
         IList<int> partyNoList,
+        RepeatSetting? repeatSetting = null,
         ulong? supportViewerId = null
     )
     {
@@ -93,13 +95,20 @@ public class DungeonStartService(
             }
         );
 
+        if (repeatSetting != null)
+        {
+            await autoRepeatService.SetRepeatSetting(repeatSetting);
+            result.repeat_state = 1;
+        }
+
         return result;
     }
 
-    public async Task<IngameData> GetIngameData(
+    public async Task<IngameData> GetAssignUnitIngameData(
         int questId,
         IList<PartySettingList> party,
-        ulong? supportViewerId = null
+        ulong? supportViewerId = null,
+        RepeatSetting? repeatSetting = null
     )
     {
         IngameData result = await InitializeIngameData(questId, supportViewerId);

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -46,6 +46,7 @@ public class DungeonStartService(
         int requiredStamina = await questService.GetQuestStamina(questId, staminaType);
         int currentStamina = await userService.GetAndUpdateStamina(staminaType);
 
+        // Makes auto repeat stamina work amazingly enough
         if (currentStamina < requiredStamina)
         {
             logger.LogInformation(

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -2,6 +2,7 @@
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Entities.Scaffold;
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Features.Dungeon.AutoRepeat;
 using DragaliaAPI.Features.Event;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.Quest;
@@ -100,6 +101,10 @@ public class DungeonStartService(
         {
             await autoRepeatService.SetRepeatSetting(repeatSetting);
             result.repeat_state = 1;
+        }
+        else
+        {
+            await autoRepeatService.ClearRepeatInfo();
         }
 
         return result;

--- a/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/Models/Generated/Components.cs
@@ -8950,7 +8950,7 @@ public class UpdateDataList
     public IEnumerable<WeaponSkinList> weapon_skin_list { get; set; }
     public IEnumerable<WeaponBodyList> weapon_body_list { get; set; }
     public IEnumerable<WeaponPassiveAbilityList> weapon_passive_ability_list { get; set; }
-    public List<AbilityCrestList> ability_crest_list { get; set; }
+    public IEnumerable<AbilityCrestList> ability_crest_list { get; set; }
     public IEnumerable<AbilityCrestSetList> ability_crest_set_list { get; set; }
     public IEnumerable<TalismanList> talisman_list { get; set; }
 
@@ -8980,9 +8980,9 @@ public class UpdateDataList
     public IEnumerable<EnemyBookList> enemy_book_list { get; set; }
     public IEnumerable<ItemList> item_list { get; set; }
     public IEnumerable<AstralItemList> astral_item_list { get; set; }
-    public List<MaterialList> material_list { get; set; }
+    public IEnumerable<MaterialList> material_list { get; set; }
     public IEnumerable<QuestList> quest_list { get; set; }
-    public List<QuestEventList> quest_event_list { get; set; }
+    public IEnumerable<QuestEventList> quest_event_list { get; set; }
     public IEnumerable<DragonGiftList> dragon_gift_list { get; set; }
     public IEnumerable<DragonReliabilityList> dragon_reliability_list { get; set; }
     public IEnumerable<UnitStoryList> unit_story_list { get; set; }
@@ -9041,7 +9041,7 @@ public class UpdateDataList
         IEnumerable<WeaponSkinList> weapon_skin_list,
         IEnumerable<WeaponBodyList> weapon_body_list,
         IEnumerable<WeaponPassiveAbilityList> weapon_passive_ability_list,
-        List<AbilityCrestList> ability_crest_list,
+        IEnumerable<AbilityCrestList> ability_crest_list,
         IEnumerable<AbilityCrestSetList> ability_crest_set_list,
         IEnumerable<TalismanList> talisman_list,
         IEnumerable<PartyList> party_list,
@@ -9051,9 +9051,9 @@ public class UpdateDataList
         IEnumerable<EnemyBookList> enemy_book_list,
         IEnumerable<ItemList> item_list,
         IEnumerable<AstralItemList> astral_item_list,
-        List<MaterialList> material_list,
+        IEnumerable<MaterialList> material_list,
         IEnumerable<QuestList> quest_list,
-        List<QuestEventList> quest_event_list,
+        IEnumerable<QuestEventList> quest_event_list,
         IEnumerable<DragonGiftList> dragon_gift_list,
         IEnumerable<DragonReliabilityList> dragon_reliability_list,
         IEnumerable<UnitStoryList> unit_story_list,

--- a/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/Models/Generated/Components.cs
@@ -13,6 +13,7 @@ using DragaliaAPI.Photon.Shared.Enums;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Features.Presents;
 using DragaliaAPI.Shared.Json;
+using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
 using MessagePack;
 
 namespace DragaliaAPI.Models.Generated;
@@ -8107,11 +8108,11 @@ public class RepeatData
 [MessagePackObject(true)]
 public class RepeatSetting
 {
-    public int repeat_type { get; set; }
+    public RepeatSettingType repeat_type { get; set; }
     public int repeat_count { get; set; }
-    public IEnumerable<int> use_item_list { get; set; }
+    public List<UseItem> use_item_list { get; set; }
 
-    public RepeatSetting(int repeat_type, int repeat_count, IEnumerable<int> use_item_list)
+    public RepeatSetting(RepeatSettingType repeat_type, int repeat_count, List<UseItem> use_item_list)
     {
         this.repeat_type = repeat_type;
         this.repeat_count = repeat_count;
@@ -8949,7 +8950,7 @@ public class UpdateDataList
     public IEnumerable<WeaponSkinList> weapon_skin_list { get; set; }
     public IEnumerable<WeaponBodyList> weapon_body_list { get; set; }
     public IEnumerable<WeaponPassiveAbilityList> weapon_passive_ability_list { get; set; }
-    public IEnumerable<AbilityCrestList> ability_crest_list { get; set; }
+    public List<AbilityCrestList> ability_crest_list { get; set; }
     public IEnumerable<AbilityCrestSetList> ability_crest_set_list { get; set; }
     public IEnumerable<TalismanList> talisman_list { get; set; }
 
@@ -8979,9 +8980,9 @@ public class UpdateDataList
     public IEnumerable<EnemyBookList> enemy_book_list { get; set; }
     public IEnumerable<ItemList> item_list { get; set; }
     public IEnumerable<AstralItemList> astral_item_list { get; set; }
-    public IEnumerable<MaterialList> material_list { get; set; }
+    public List<MaterialList> material_list { get; set; }
     public IEnumerable<QuestList> quest_list { get; set; }
-    public IEnumerable<QuestEventList> quest_event_list { get; set; }
+    public List<QuestEventList> quest_event_list { get; set; }
     public IEnumerable<DragonGiftList> dragon_gift_list { get; set; }
     public IEnumerable<DragonReliabilityList> dragon_reliability_list { get; set; }
     public IEnumerable<UnitStoryList> unit_story_list { get; set; }
@@ -9040,7 +9041,7 @@ public class UpdateDataList
         IEnumerable<WeaponSkinList> weapon_skin_list,
         IEnumerable<WeaponBodyList> weapon_body_list,
         IEnumerable<WeaponPassiveAbilityList> weapon_passive_ability_list,
-        IEnumerable<AbilityCrestList> ability_crest_list,
+        List<AbilityCrestList> ability_crest_list,
         IEnumerable<AbilityCrestSetList> ability_crest_set_list,
         IEnumerable<TalismanList> talisman_list,
         IEnumerable<PartyList> party_list,
@@ -9050,9 +9051,9 @@ public class UpdateDataList
         IEnumerable<EnemyBookList> enemy_book_list,
         IEnumerable<ItemList> item_list,
         IEnumerable<AstralItemList> astral_item_list,
-        IEnumerable<MaterialList> material_list,
+        List<MaterialList> material_list,
         IEnumerable<QuestList> quest_list,
-        IEnumerable<QuestEventList> quest_event_list,
+        List<QuestEventList> quest_event_list,
         IEnumerable<DragonGiftList> dragon_gift_list,
         IEnumerable<DragonReliabilityList> dragon_reliability_list,
         IEnumerable<UnitStoryList> unit_story_list,

--- a/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/Models/Generated/Requests.cs
@@ -1333,7 +1333,7 @@ public class DungeonSkipStartRequest
 public class DungeonStartStartAssignUnitRequest
 {
     public int quest_id { get; set; }
-    public IEnumerable<PartySettingList> request_party_setting_list { get; set; }
+    public IList<PartySettingList> request_party_setting_list { get; set; }
     public int bet_count { get; set; }
     public int repeat_state { get; set; }
     public ulong support_viewer_id { get; set; }
@@ -1341,7 +1341,7 @@ public class DungeonStartStartAssignUnitRequest
 
     public DungeonStartStartAssignUnitRequest(
         int quest_id,
-        IEnumerable<PartySettingList> request_party_setting_list,
+        IList<PartySettingList> request_party_setting_list,
         int bet_count,
         int repeat_state,
         ulong support_viewer_id,
@@ -1363,11 +1363,11 @@ public class DungeonStartStartAssignUnitRequest
 public class DungeonStartStartMultiAssignUnitRequest
 {
     public int quest_id { get; set; }
-    public IEnumerable<PartySettingList> request_party_setting_list { get; set; }
+    public IList<PartySettingList> request_party_setting_list { get; set; }
 
     public DungeonStartStartMultiAssignUnitRequest(
         int quest_id,
-        IEnumerable<PartySettingList> request_party_setting_list
+        IList<PartySettingList> request_party_setting_list
     )
     {
         this.quest_id = quest_id;
@@ -1382,9 +1382,9 @@ public class DungeonStartStartMultiRequest
 {
     public int quest_id { get; set; }
     public int party_no { get; set; }
-    public IEnumerable<int> party_no_list { get; set; }
+    public IList<int> party_no_list { get; set; }
 
-    public DungeonStartStartMultiRequest(int quest_id, int party_no, IEnumerable<int> party_no_list)
+    public DungeonStartStartMultiRequest(int quest_id, int party_no, IList<int> party_no_list)
     {
         this.quest_id = quest_id;
         this.party_no = party_no;
@@ -4299,13 +4299,13 @@ public class WallStartStartAssignUnitRequest
 {
     public int wall_id { get; set; }
     public int wall_level { get; set; }
-    public IEnumerable<PartySettingList> request_party_setting_list { get; set; }
+    public IList<PartySettingList> request_party_setting_list { get; set; }
     public ulong support_viewer_id { get; set; }
 
     public WallStartStartAssignUnitRequest(
         int wall_id,
         int wall_level,
-        IEnumerable<PartySettingList> request_party_setting_list,
+        IList<PartySettingList> request_party_setting_list,
         ulong support_viewer_id
     )
     {

--- a/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/Models/Generated/Requests.cs
@@ -1194,13 +1194,14 @@ public class DungeonRecordRecordMultiRequest
     public DungeonRecordRecordMultiRequest() { }
 }
 
+#nullable restore
 [MessagePackObject(true)]
 public class DungeonRecordRecordRequest
 {
-    public PlayRecord play_record { get; set; }
-    public string dungeon_key { get; set; }
+    public required PlayRecord play_record { get; set; }
+    public required string dungeon_key { get; set; }
     public int repeat_state { get; set; }
-    public string repeat_key { get; set; }
+    public string? repeat_key { get; set; }
 
     public DungeonRecordRecordRequest(
         PlayRecord play_record,
@@ -1217,6 +1218,7 @@ public class DungeonRecordRecordRequest
 
     public DungeonRecordRecordRequest() { }
 }
+#nullable  disable
 
 [MessagePackObject(true)]
 public class DungeonRetryRequest
@@ -1394,16 +1396,18 @@ public class DungeonStartStartMultiRequest
     public DungeonStartStartMultiRequest() { }
 }
 
+#nullable restore
+
 [MessagePackObject(true)]
 public class DungeonStartStartRequest
 {
     public int quest_id { get; set; }
     public int party_no { get; set; }
-    public List<int> party_no_list { get; set; }
+    public required List<int> party_no_list { get; set; }
     public int bet_count { get; set; }
     public int repeat_state { get; set; }
     public ulong support_viewer_id { get; set; }
-    public RepeatSetting repeat_setting { get; set; }
+    public RepeatSetting? repeat_setting { get; set; }
 
     public DungeonStartStartRequest(
         int quest_id,
@@ -1426,6 +1430,8 @@ public class DungeonStartStartRequest
 
     public DungeonStartStartRequest() { }
 }
+
+#nullable disable
 
 [MessagePackObject(true)]
 public class EarnEventEntryRequest

--- a/DragaliaAPI/Models/Options/RedisOptions.cs
+++ b/DragaliaAPI/Models/Options/RedisOptions.cs
@@ -4,4 +4,6 @@ public class RedisOptions
 {
     public int SessionExpiryTimeMinutes { get; set; }
     public int DungeonExpiryTimeMinutes { get; set; }
+
+    public int AutoRepeatExpiryTimeMinutes { get; set; }
 }

--- a/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/ServiceConfiguration.cs
@@ -5,6 +5,7 @@ using DragaliaAPI.Features.ClearParty;
 using DragaliaAPI.Features.Dmode;
 using DragaliaAPI.Features.DmodeDungeon;
 using DragaliaAPI.Features.Dungeon;
+using DragaliaAPI.Features.Dungeon.AutoRepeat;
 using DragaliaAPI.Features.Dungeon.Record;
 using DragaliaAPI.Features.Dungeon.Start;
 using DragaliaAPI.Features.Emblem;
@@ -109,6 +110,7 @@ public static class ServiceConfiguration
             .AddScoped<IDungeonRecordDamageService, DungeonRecordDamageService>()
             .AddScoped<IQuestCompletionService, QuestCompletionService>()
             .AddScoped<IAbilityCrestMultiplierService, AbilityCrestMultiplierService>()
+            .AddScoped<IAutoRepeatService, AutoRepeatService>()
             // Event Feature
             .AddScoped<IEventRepository, EventRepository>()
             .AddScoped<IEventService, EventService>()

--- a/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/appsettings.json
@@ -78,12 +78,13 @@
     },
     "Dragalipatch": {
         "Mode": "RAW",
-        "CdnUrl": "http://lathna.xyz"
+        "CdnUrl": "https://minty.sbs"
     },
     "HashSalt": "dragalia",
     "Redis": {
         "SessionExpiryTimeMinutes": 60,
-        "DungeonExpiryTimeMinutes": 60
+        "DungeonExpiryTimeMinutes": 60,
+        "AutoRepeatExpiryTimeMinutes": 2880
     },
     "TimeAttackOptions": {
         "GroupId": 2


### PR DESCRIPTION
- Add redis caching of `repeat_setting` from start requests, and send this back on record requests when `repeat_setting` is 1
- Add `repeat/end` endpoint
- Send repeat data on `mypage/info` requests when the auto-repeat was interrupted.

Note: the client implements automatic stamina consumption itself through automatic calls to `item/use_recovery_stamina`, so no work is needed for this on the backend.