### PR TITLE
Don't use total value for Clear 2 Void Battles mission

### DIFF
--- a/DragaliaAPI.MissionDesigner/Missions/V1Missions.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/V1Missions.cs
@@ -167,7 +167,7 @@ public static class V1Missions
                 MissionType.MainStory,
                 10030201,
                 MissionCompleteType.EventGroupCleared,
-                true,
+                false,
                 Parameter: 30000,
                 Parameter2: null,
                 Parameter3: null,

--- a/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -109,7 +109,7 @@
     "_MissionType": "MainStory",
     "_MissionId": 10030201,
     "_CompleteType": "EventGroupCleared",
-    "_UseTotalValue": 1,
+    "_UseTotalValue": 0,
     "_Parameter": 30000
   },
   {


### PR DESCRIPTION
The total value of the EventGroupCleared mission is always 1, so this mission was impossible to complete if the initial progress handler did not complete it for you.

It's debatable whether 'Clear 2 Void Battles' means clear 2 _different_ void battles. I have interpreted it in the same way as the 'Clear Five Quests' daily endeavour which is to make it so 2 clears of the same quest count.