### PR TITLE
Dragon's Roost gifting fixes

### DIFF
--- a/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -278,7 +278,7 @@ public class DragonTest : TestFixture
     public async Task DragonBuyGiftToSend_IncreasesReliabilityAndReturnsGifts()
     {
         await this.AddToDatabase(
-            DbPlayerDragonReliabilityFactory.Create(ViewerId, Dragons.HighJupiter)
+            new DbPlayerDragonReliability() { DragonId = Dragons.HighJupiter, Level = 1 }
         );
 
         DragonBuyGiftToSendRequest request = new DragonBuyGiftToSendRequest()
@@ -307,6 +307,9 @@ public class DragonTest : TestFixture
             .First();
         dragonData.reliability_total_exp.Should().Be(1000);
         dragonData.reliability_level.Should().Be(6);
+        dragonData
+            .last_contact_time.Should()
+            .BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -72,6 +72,25 @@ public class FortTest : TestFixture
     }
 
     [Fact]
+    public async Task GetData_ReportsFreeDragonGiftCount()
+    {
+        await this.ApiContext.PlayerDragonGifts.ExecuteDeleteAsync();
+        await this.AddToDatabase(
+            [new DbPlayerDragonGift() { DragonGiftId = DragonGifts.FreshBread, Quantity = 1 }]
+        );
+
+        (await this.Client.PostMsgpack<FortGetDataData>("/fort/get_data", new FortGetDataRequest()))
+            .data.dragon_contact_free_gift_count.Should()
+            .Be(1);
+
+        await this.ApiContext.PlayerDragonGifts.ExecuteDeleteAsync();
+
+        (await this.Client.PostMsgpack<FortGetDataData>("/fort/get_data", new FortGetDataRequest()))
+            .data.dragon_contact_free_gift_count.Should()
+            .Be(0);
+    }
+
+    [Fact]
     public async Task AddCarpenter_ReturnsValidResult()
     {
         DbPlayerUserData oldUserData = this.ApiContext.PlayerUserData.AsNoTracking()
@@ -148,7 +167,7 @@ public class FortTest : TestFixture
 
         this.ApiContext.PlayerFortBuilds.AsNoTracking()
             .Should()
-            .NotContain(x => x.PlantId == FortPlants.StaffDojo);
+            .NotContain(x => x.BuildId == build.BuildId);
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -141,14 +141,14 @@ public class FortTest : TestFixture
         ).Entity;
         await this.ApiContext.SaveChangesAsync();
 
-        FortBuildCancelData response = (
-            await this.Client.PostMsgpack<FortBuildCancelData>(
-                "/fort/build_cancel",
-                new FortBuildCancelRequest(build.BuildId)
-            )
-        ).data;
+        await this.Client.PostMsgpack<FortBuildCancelData>(
+            "/fort/build_cancel",
+            new FortBuildCancelRequest(build.BuildId)
+        );
 
-        // this removes it from the player
+        this.ApiContext.PlayerFortBuilds.AsNoTracking()
+            .Should()
+            .NotContain(x => x.PlantId == FortPlants.StaffDojo);
     }
 
     [Fact]
@@ -188,23 +188,23 @@ public class FortTest : TestFixture
     [Fact]
     public async Task BuildStart_ReturnsValidResult()
     {
-        int ExpectedPositionX = 2;
-        int ExpectedPositionZ = 2;
+        int expectedPositionX = 2;
+        int expectedPositionZ = 2;
 
         FortBuildStartData response = (
             await this.Client.PostMsgpack<FortBuildStartData>(
                 "/fort/build_start",
                 new FortBuildStartRequest(
                     FortPlants.FlameAltar,
-                    ExpectedPositionX,
-                    ExpectedPositionZ
+                    expectedPositionX,
+                    expectedPositionZ
                 )
             )
         ).data;
 
         BuildList result = response.update_data_list.build_list.First();
-        result.position_x.Should().Be(ExpectedPositionX);
-        result.position_z.Should().Be(ExpectedPositionZ);
+        result.position_x.Should().Be(expectedPositionX);
+        result.position_z.Should().Be(expectedPositionZ);
         result.build_start_date.Should().NotBe(DateTimeOffset.UnixEpoch);
         result.build_end_date.Should().NotBe(DateTimeOffset.UnixEpoch);
         result.build_end_date.Should().BeAfter(result.build_start_date);
@@ -256,7 +256,7 @@ public class FortTest : TestFixture
         halidom.BuildEndDate = DateTimeOffset.FromUnixTimeSeconds(1388924543);
         halidom.Level = 10;
 
-        int rows = await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync();
 
         FortLevelupAtOnceData response = (
             await this.Client.PostMsgpack<FortLevelupAtOnceData>(
@@ -459,20 +459,20 @@ public class FortTest : TestFixture
         ).Entity;
         await this.ApiContext.SaveChangesAsync();
 
-        int ExpectedPositionX = 4;
-        int ExpectedPositionZ = 4;
+        int expectedPositionX = 4;
+        int expectedPositionZ = 4;
         FortMoveData response = (
             await this.Client.PostMsgpack<FortMoveData>(
                 "/fort/move",
-                new FortMoveRequest(build.BuildId, ExpectedPositionX, ExpectedPositionZ)
+                new FortMoveRequest(build.BuildId, expectedPositionX, expectedPositionZ)
             )
         ).data;
 
         BuildList result = response.update_data_list.build_list.First(
             x => x.build_id == (ulong)build.BuildId
         );
-        result.position_x.Should().Be(ExpectedPositionX);
-        result.position_z.Should().Be(ExpectedPositionZ);
+        result.position_x.Should().Be(expectedPositionX);
+        result.position_z.Should().Be(expectedPositionZ);
     }
 
     [Fact]

--- a/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
@@ -189,7 +189,7 @@ public class MissionTest : TestFixture
         int missionId1 = 15070301; // Clear a Quest
         int missionId2 = 15070401; // Clear Three Quests
 
-        ResetHelper resetHelper = new(new DateTimeProvider());
+        ResetHelper resetHelper = new(TimeProvider.System);
 
         DateOnly today = DateOnly.FromDateTime(resetHelper.LastDailyReset.Date);
         DateOnly yesterday = today.AddDays(-1);

--- a/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
+++ b/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
@@ -13,6 +13,7 @@ public class FortControllerTest
     private readonly Mock<IBonusService> mockBonusService;
     private readonly Mock<IUpdateDataService> mockUpdateDataService;
     private readonly Mock<IRewardService> mockRewardService;
+    private readonly Mock<IDragonService> mockDragonService;
 
     private readonly FortController fortController;
 
@@ -22,12 +23,14 @@ public class FortControllerTest
         mockBonusService = new(MockBehavior.Strict);
         mockUpdateDataService = new(MockBehavior.Strict);
         mockRewardService = new(MockBehavior.Strict);
+        mockDragonService = new(MockBehavior.Strict);
 
         fortController = new(
             mockFortService.Object,
             mockBonusService.Object,
             mockUpdateDataService.Object,
-            mockRewardService.Object
+            mockRewardService.Object,
+            mockDragonService.Object
         );
     }
 
@@ -63,11 +66,14 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
+        this.mockDragonService.Setup(x => x.GetFreeGiftCount()).ReturnsAsync(2);
+
         FortGetDataData data = (await fortController.GetData()).GetData<FortGetDataData>()!;
 
         data.build_list.Should().BeEquivalentTo(buildList);
         data.fort_bonus_list.Should().BeEquivalentTo(bonusList);
         data.fort_detail.Should().BeEquivalentTo(detail);
+        data.dragon_contact_free_gift_count.Should().Be(2);
 
         mockFortService.VerifyAll();
         mockBonusService.VerifyAll();

--- a/DragaliaAPI.Test/Features/Login/ResetHelperTest.cs
+++ b/DragaliaAPI.Test/Features/Login/ResetHelperTest.cs
@@ -4,15 +4,15 @@ namespace DragaliaAPI.Test.Features.Login;
 
 public class ResetHelperTest
 {
-    private readonly Mock<IDateTimeProvider> mockDateTimeProvider;
+    private readonly Mock<TimeProvider> mockTimeProvider;
 
     private readonly IResetHelper resetHelper;
 
     public ResetHelperTest()
     {
-        this.mockDateTimeProvider = new(MockBehavior.Strict);
+        this.mockTimeProvider = new(MockBehavior.Strict);
 
-        this.resetHelper = new ResetHelper(this.mockDateTimeProvider.Object);
+        this.resetHelper = new ResetHelper(this.mockTimeProvider.Object);
     }
 
     /// <summary>
@@ -83,7 +83,7 @@ public class ResetHelperTest
     [MemberData(nameof(DailyResetData))]
     public void LastDailyReset_ReturnsCorrectReset(DateTimeOffset now, DateTimeOffset expectedReset)
     {
-        this.mockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(now);
+        this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(now);
 
         this.resetHelper.LastDailyReset.Should().Be(expectedReset);
     }
@@ -95,7 +95,7 @@ public class ResetHelperTest
         DateTimeOffset expectedReset
     )
     {
-        this.mockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(now);
+        this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(now);
 
         this.resetHelper.LastWeeklyReset.Should().Be(expectedReset);
     }
@@ -107,7 +107,7 @@ public class ResetHelperTest
         DateTimeOffset expectedReset
     )
     {
-        this.mockDateTimeProvider.SetupGet(x => x.UtcNow).Returns(now);
+        this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(now);
 
         this.resetHelper.LastMonthlyReset.Should().Be(expectedReset);
     }

--- a/DragaliaAPI/Features/Fort/FortController.cs
+++ b/DragaliaAPI/Features/Fort/FortController.cs
@@ -14,18 +14,21 @@ public class FortController : DragaliaControllerBase
     private readonly IBonusService bonusService;
     private readonly IUpdateDataService updateDataService;
     private readonly IRewardService rewardService;
+    private readonly IDragonService dragonService;
 
     public FortController(
         IFortService fortService,
         IBonusService bonusService,
         IUpdateDataService updateDataService,
-        IRewardService rewardService
+        IRewardService rewardService,
+        IDragonService dragonService
     )
     {
         this.fortService = fortService;
         this.bonusService = bonusService;
         this.updateDataService = updateDataService;
         this.rewardService = rewardService;
+        this.dragonService = dragonService;
     }
 
     [HttpPost("get_data")]
@@ -36,12 +39,14 @@ public class FortController : DragaliaControllerBase
 
         FortBonusList bonusList = await bonusService.GetBonusList();
 
+        int freeGiftCount = await this.dragonService.GetFreeGiftCount();
+
         FortGetDataData data =
             new()
             {
                 build_list = buildList,
                 fort_bonus_list = bonusList,
-                dragon_contact_free_gift_count = 1, // One bread
+                dragon_contact_free_gift_count = freeGiftCount,
                 production_rp = await this.fortService.GetRupieProduction(),
                 production_st = await this.fortService.GetStaminaProduction(),
                 production_df = await this.fortService.GetDragonfruitProduction(),

--- a/DragaliaAPI/Helpers/IResetHelper.cs
+++ b/DragaliaAPI/Helpers/IResetHelper.cs
@@ -16,4 +16,9 @@ public interface IResetHelper
     /// Gets the last monthly reset (6AM UTC of the 1st of the current month).
     /// </summary>
     DateTimeOffset LastMonthlyReset { get; }
+
+    /// <summary>
+    /// Gets the current UTC time.
+    /// </summary>
+    DateTimeOffset UtcNow { get; }
 }

--- a/DragaliaAPI/Helpers/ResetHelper.cs
+++ b/DragaliaAPI/Helpers/ResetHelper.cs
@@ -1,26 +1,16 @@
-using System.Globalization;
-using DragaliaAPI.Extensions;
-
 namespace DragaliaAPI.Helpers;
 
-public class ResetHelper : IResetHelper
+public class ResetHelper(TimeProvider timeProvider) : IResetHelper
 {
-    private readonly IDateTimeProvider dateTimeProvider;
+    private readonly TimeProvider timeProvider = timeProvider;
 
     private const int UtcHourReset = 6;
 
-    public ResetHelper(IDateTimeProvider dateTimeProvider)
-    {
-        this.dateTimeProvider = dateTimeProvider;
-
-        CultureInfo culture = (CultureInfo)CultureInfo.CurrentCulture.Clone();
-        culture.DateTimeFormat.FirstDayOfWeek = DayOfWeek.Monday;
-        Thread.CurrentThread.CurrentCulture = culture;
-    }
-
     /// <inheritdoc />
     public DateTimeOffset LastDailyReset =>
-        this.dateTimeProvider.UtcNow.AddHours(-6).UtcDateTime.Date.AddHours(6);
+        this.timeProvider.GetUtcNow().AddHours(-6).UtcDateTime.Date.AddHours(6);
+
+    public DateTimeOffset UtcNow => this.timeProvider.GetUtcNow();
 
     /// <inheritdoc />
     public DateTimeOffset LastWeeklyReset

--- a/DragaliaAPI/Services/IDragonService.cs
+++ b/DragaliaAPI/Services/IDragonService.cs
@@ -16,4 +16,5 @@ public interface IDragonService
     Task<DragonLimitBreakData> DoDragonLimitBreak(DragonLimitBreakRequest request);
     Task<DragonSetLockData> DoDragonSetLock(DragonSetLockRequest request);
     Task<DragonSellData> DoDragonSell(DragonSellRequest request);
+    Task<int> GetFreeGiftCount();
 }


### PR DESCRIPTION
- Make the rotating gift use the last reset's DayOfWeek so that it
changes at reset rather than 12AM UTC
- Stop the ! notification icon from always appearing on the dragon's
roost button by correctly sending free_gift_count. This is based on
whether the Fresh Bread gift is available
- Update `LastContactTime` when gifting a dragon so that the 
'Recently Gifted' menu functions correctly
- Refactor ResetHelper to use TimeProvider rather than IDateTimeProvider