### PR TITLE
Fix dummy dragon gifts appearing after save import

### DIFF
--- a/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -186,6 +186,23 @@ public class SavefileImportTest : TestFixture
     }
 
     [Fact]
+    public async Task Import_DoesNotDeleteBuyableDragonGifts()
+    {
+        this.ApiContext.PlayerDragonGifts.Should()
+            .Contain(
+                x => x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.CompellingBook
+            );
+
+        HttpContent content = PrepareSavefileRequest();
+        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+
+        this.ApiContext.PlayerDragonGifts.Should()
+            .Contain(
+                x => x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.CompellingBook
+            );
+    }
+
+    [Fact]
     public async Task Import_IsIdempotent()
     {
         long viewerId = this.ApiContext.PlayerUserData.Single(x => x.ViewerId == ViewerId).ViewerId;

--- a/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/Services/Game/SavefileService.cs
@@ -476,7 +476,9 @@ public class SavefileService : ISavefileService
             .ExecuteDeleteAsync();
         await this.apiContext.PlayerPassiveAbilities.Where(x => x.ViewerId == viewerId)
             .ExecuteDeleteAsync();
-        await this.apiContext.PlayerDragonGifts.Where(x => x.ViewerId == viewerId)
+        await this.apiContext.PlayerDragonGifts.Where(
+            x => x.ViewerId == viewerId && x.DragonGiftId >= DragonGifts.FourLeafClover
+        )
             .ExecuteDeleteAsync();
         await this.apiContext.PlayerMissions.Where(x => x.ViewerId == viewerId)
             .ExecuteDeleteAsync();


### PR DESCRIPTION
Importing a save would previously delete all dragon gifts, leading to the returned list from /dragon/get_contact_data being empty until the next reset where gifts could be replenished.