### PR TITLE
Fix quest first clear bonuses

### DIFF
--- a/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
@@ -1,4 +1,5 @@
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Dungeon;
 using DragaliaAPI.Features.Dungeon.Record;
 using DragaliaAPI.Features.Event;
@@ -19,6 +20,7 @@ public class DungeonRecordRewardServiceTest
     private readonly Mock<IAbilityCrestMultiplierService> mockAbilityCrestMultiplierService;
     private readonly Mock<IEventDropService> mockEventDropService;
     private readonly Mock<IMissionProgressionService> mockMissionProgressionService;
+    private readonly Mock<IQuestRepository> mockQuestRepository;
     private readonly Mock<ILogger<DungeonRecordRewardService>> mockLogger;
 
     private readonly IDungeonRecordRewardService dungeonRecordRewardService;
@@ -30,6 +32,7 @@ public class DungeonRecordRewardServiceTest
         this.mockAbilityCrestMultiplierService = new(MockBehavior.Strict);
         this.mockEventDropService = new(MockBehavior.Strict);
         this.mockMissionProgressionService = new(MockBehavior.Strict);
+        this.mockQuestRepository = new(MockBehavior.Strict);
         this.mockLogger = new(MockBehavior.Loose);
 
         this.dungeonRecordRewardService = new DungeonRecordRewardService(
@@ -38,6 +41,7 @@ public class DungeonRecordRewardServiceTest
             this.mockAbilityCrestMultiplierService.Object,
             this.mockEventDropService.Object,
             this.mockMissionProgressionService.Object,
+            this.mockQuestRepository.Object,
             this.mockLogger.Object
         );
     }
@@ -78,6 +82,8 @@ public class DungeonRecordRewardServiceTest
                 new List<AtgenFirstClearSet>()
             );
 
+        this.mockQuestRepository.Setup(x => x.GetQuestDataAsync(questId)).ReturnsAsync(questEntity);
+
         this.mockQuestCompletionService.Setup(
             x => x.CompleteQuestMissions(session, new[] { false, false, false }, playRecord)
         )
@@ -85,13 +91,7 @@ public class DungeonRecordRewardServiceTest
         this.mockQuestCompletionService.Setup(x => x.GrantFirstClearRewards(questId))
             .ReturnsAsync(firstClearRewards);
 
-        (
-            await this.dungeonRecordRewardService.ProcessQuestMissionCompletion(
-                playRecord,
-                session,
-                questEntity
-            )
-        )
+        (await this.dungeonRecordRewardService.ProcessQuestMissionCompletion(playRecord, session))
             .Should()
             .Be((status, firstClearRewards));
 

--- a/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
+++ b/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
@@ -164,7 +164,7 @@ public class DungeonRecordServiceTest
         int takeBoostAccumulatePoint = 40;
 
         this.mockQuestService.Setup(x => x.ProcessQuestCompletion(session, playRecord))
-            .ReturnsAsync((mockQuest, true, new List<AtgenFirstClearSet>()));
+            .ReturnsAsync((true, new List<AtgenFirstClearSet>()));
 
         this.mockUserService.Setup(x => x.RemoveStamina(StaminaType.Single, 40))
             .Returns(Task.CompletedTask);
@@ -172,7 +172,7 @@ public class DungeonRecordServiceTest
             .ReturnsAsync(new PlayerLevelResult(true, 100, 50));
 
         this.mockDungeonRewardService.Setup(
-            x => x.ProcessQuestMissionCompletion(playRecord, session, mockQuest)
+            x => x.ProcessQuestMissionCompletion(playRecord, session)
         )
             .ReturnsAsync((missionStatus, firstClearSets));
         this.mockDungeonRewardService.Setup(x => x.ProcessEnemyDrops(playRecord, session))

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -1,10 +1,12 @@
 ﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Event;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Reward;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.MasterAsset.Models;
 
 namespace DragaliaAPI.Features.Dungeon.Record;
 
@@ -14,19 +16,18 @@ public class DungeonRecordRewardService(
     IAbilityCrestMultiplierService abilityCrestMultiplierService,
     IEventDropService eventDropService,
     IMissionProgressionService missionProgressionService,
+    IQuestRepository questRepository,
     ILogger<DungeonRecordRewardService> logger
 ) : IDungeonRecordRewardService
 {
     public async Task<(
         QuestMissionStatus MissionStatus,
         IEnumerable<AtgenFirstClearSet> FirstClearRewards
-    )> ProcessQuestMissionCompletion(
-        PlayRecord playRecord,
-        DungeonSession session,
-        DbQuest questData
-    )
+    )> ProcessQuestMissionCompletion(PlayRecord playRecord, DungeonSession session)
     {
-        bool isFirstClear = questData.PlayCount == 0;
+        DbQuest questData = await questRepository.GetQuestDataAsync(session.QuestId);
+
+        bool isFirstClear = questData.State < 3;
 
         IEnumerable<AtgenFirstClearSet> firstClearRewards = isFirstClear
             ? await questCompletionService.GrantFirstClearRewards(questData.QuestId)

--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -53,24 +53,17 @@ public class DungeonRecordService(
 
         await this.ProcessStaminaConsumption(session);
 
-        (
-            DbQuest questData,
-            ingameResultData.is_best_clear_time,
-            ingameResultData.reward_record.quest_bonus_list
-        ) = await questService.ProcessQuestCompletion(session, playRecord);
+        (QuestMissionStatus missionStatus, IEnumerable<AtgenFirstClearSet>? firstClearSets) =
+            await dungeonRecordRewardService.ProcessQuestMissionCompletion(playRecord, session);
+
+        (ingameResultData.is_best_clear_time, ingameResultData.reward_record.quest_bonus_list) =
+            await questService.ProcessQuestCompletion(session, playRecord);
 
         await this.ProcessExperience(
             ingameResultData.grow_record,
             ingameResultData.reward_record,
             session
         );
-
-        (QuestMissionStatus missionStatus, IEnumerable<AtgenFirstClearSet>? firstClearSets) =
-            await dungeonRecordRewardService.ProcessQuestMissionCompletion(
-                playRecord,
-                session,
-                questData
-            );
 
         ingameResultData.reward_record.first_clear_set = firstClearSets;
         ingameResultData.reward_record.missions_clear_set = missionStatus.MissionsClearSet;

--- a/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
@@ -9,11 +9,7 @@ public interface IDungeonRecordRewardService
     Task<(
         QuestMissionStatus MissionStatus,
         IEnumerable<AtgenFirstClearSet> FirstClearRewards
-    )> ProcessQuestMissionCompletion(
-        PlayRecord playRecord,
-        DungeonSession session,
-        DbQuest questData
-    );
+    )> ProcessQuestMissionCompletion(PlayRecord playRecord, DungeonSession session);
 
     Task<(IEnumerable<AtgenDropAll> DropList, int ManaDrop, int CoinDrop)> ProcessEnemyDrops(
         PlayRecord playRecord,

--- a/DragaliaAPI/Features/Quest/IQuestService.cs
+++ b/DragaliaAPI/Features/Quest/IQuestService.cs
@@ -8,11 +8,10 @@ namespace DragaliaAPI.Features.Quest;
 public interface IQuestService
 {
     Task<int> GetQuestStamina(int questId, StaminaType type);
-    Task<(
-        DbQuest Quest,
-        bool BestClearTime,
-        IEnumerable<AtgenFirstClearSet> Bonus
-    )> ProcessQuestCompletion(DungeonSession session, PlayRecord playRecord);
+    Task<(bool BestClearTime, IEnumerable<AtgenFirstClearSet> Bonus)> ProcessQuestCompletion(
+        DungeonSession session,
+        PlayRecord playRecord
+    );
 
     Task<AtgenReceiveQuestBonus> ReceiveQuestBonus(int eventGroupId, bool isReceive, int count);
 }

--- a/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/Features/Quest/QuestService.cs
@@ -25,7 +25,6 @@ public class QuestService(
 ) : IQuestService
 {
     public async Task<(
-        DbQuest Quest,
         bool BestClearTime,
         IEnumerable<AtgenFirstClearSet> Bonus
     )> ProcessQuestCompletion(DungeonSession session, PlayRecord playRecord)
@@ -93,7 +92,7 @@ public class QuestService(
             this.ProcessEventQuestMissionProgression(questData, session, playRecord);
         }
 
-        return (quest, isBestClearTime, questEventRewards);
+        return (isBestClearTime, questEventRewards);
     }
 
     public async Task<int> GetQuestStamina(int questId, StaminaType type)


### PR DESCRIPTION
Quest bonuses are never received because the `isFirstClear` check will always return false, because `ProcessQuestMissionCompletion` is called after `ProcessQuestCompletion` in `DungeonRecordService` and so the quest entity will always have been marked as completed before this check is reached.

- Swap the order of the calls (removed unused `DbQuest` return of `ProcessQuestCompletion` as a result)
- Change the check to examine the `State` property instead of play count to not include failed attempts / make consistent with other checks
- Add a test for first clear rewards