### PR TITLE
Fix onslaught events not granting any glory

### DIFF
--- a/DragaliaAPI.Shared/MasterAsset/Models/QuestRewards/QuestScoreMissionData.cs
+++ b/DragaliaAPI.Shared/MasterAsset/Models/QuestRewards/QuestScoreMissionData.cs
@@ -29,5 +29,14 @@ public record QuestScoreMissionData(
         BaseScore10
     };
 
+    public int GetScore(int index)
+    {
+        // Onslaught battles only have one score value
+        if (this.Scores.Count(x => x != 0) == 1)
+            return this.Scores.First(x => x != 0);
+
+        return this.Scores[index];
+    }
+
     public int WaveCount => this.Scores.Count(x => x != 0);
 };

--- a/DragaliaAPI.Test/Services/DragonServiceTest.cs
+++ b/DragaliaAPI.Test/Services/DragonServiceTest.cs
@@ -63,6 +63,8 @@ public class DragonServiceTest
     [Fact]
     public async Task DoDragonGetContactData_ReturnsValidContactData()
     {
+        DateTimeOffset lastReset = new ResetHelper(this.mockTimeProvider.Object).LastDailyReset;
+
         SetupReliabilityMock(
             out List<DbPlayerDragonGift> gifts,
             out DbPlayerMaterial garudaEssence,
@@ -80,7 +82,7 @@ public class DragonServiceTest
         responseData.shop_gift_list.Count().Should().Be(5);
         ((DragonGifts)responseData.shop_gift_list.Last().dragon_gift_id)
             .Should()
-            .Be(DragonConstants.RotatingGifts[(int)DateTimeOffset.UtcNow.DayOfWeek]);
+            .Be(DragonConstants.RotatingGifts[(int)lastReset.DayOfWeek]);
     }
 
     [Fact]

--- a/DragaliaAPI/Features/Dungeon/IQuestCompletionService.cs
+++ b/DragaliaAPI/Features/Dungeon/IQuestCompletionService.cs
@@ -23,12 +23,5 @@ public interface IQuestCompletionService
         PlayRecord record
     );
 
-    public Task<bool> IsQuestMissionCompleted(
-        QuestCompleteType type,
-        int completionValue,
-        PlayRecord record,
-        DungeonSession session
-    );
-
     public Task<IEnumerable<AtgenFirstClearSet>> GrantFirstClearRewards(int questId);
 }

--- a/DragaliaAPI/Features/Dungeon/QuestCompletionService.cs
+++ b/DragaliaAPI/Features/Dungeon/QuestCompletionService.cs
@@ -145,9 +145,9 @@ public class QuestCompletionService(
         logger.LogDebug("Completed mission score missions {@missions}", missions);
 
         int questScoreMissionId = MasterAsset.QuestRewardData[questId].QuestScoreMissionId;
-        int baseQuantity = MasterAsset.QuestScoreMissionData[questScoreMissionId].Scores[
-            record.wave
-        ];
+        int baseQuantity = MasterAsset
+            .QuestScoreMissionData[questScoreMissionId]
+            .GetScore(record.wave);
 
         double obtainedAmount = baseQuantity * (multiplier / 100.0f);
         int rewardQuantity = (int)Math.Floor(obtainedAmount);

--- a/DragaliaAPI/Features/Reward/Handlers/FafnirMedalRewardHandler.cs
+++ b/DragaliaAPI/Features/Reward/Handlers/FafnirMedalRewardHandler.cs
@@ -1,0 +1,19 @@
+using System.Collections.Immutable;
+using DragaliaAPI.Shared.Definitions.Enums;
+using JetBrains.Annotations;
+
+namespace DragaliaAPI.Features.Reward.Handlers;
+
+[UsedImplicitly]
+public class FafnirMedalRewardHandler(ILogger<FafnirMedalRewardHandler> logger) : IRewardHandler
+{
+    private readonly ILogger<FafnirMedalRewardHandler> logger = logger;
+
+    public ImmutableArray<EntityTypes> SupportedTypes { get; } = [EntityTypes.FafnirMedal];
+
+    public Task<GrantReturn> Grant(Entity entity)
+    {
+        this.logger.LogInformation("Discarding fafnir medal entity: {@entity}", entity);
+        return Task.FromResult(new GrantReturn(RewardGrantResult.Discarded));
+    }
+}


### PR DESCRIPTION
Onslaught events e.g. Twinkling Twilight don't use the wave as the index into their `QuestScoreMissionData`; they instead only have one value set. However, they share `EventKindType.Combat` with defensive events, which _do_ use the wave.

Implement a slightly hacky conditional statement when looking up the base score to handle the case where the array has only one non-zero value, which should be returned instead of indexing.

Also add a stub reward handler for fafnir medals; fixes server error popups when receiving these (which you are sometimes forced to when claiming combat event rewards). 