### PR TITLE
Configure workflows to run on main

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -4,12 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - develop
-    paths-ignore:
-      - "**/*.yaml"
-      - "**/*.yml"
-      - "**/*.md"
+      - main
 
 env:
   HUSKY: 0

--- a/.github/workflows/publish-push.yaml
+++ b/.github/workflows/publish-push.yaml
@@ -3,7 +3,7 @@ name: publish-push
 on:
   push:
     branches:
-      - "develop"
+      - main
 
 env:
   HUSKY: 0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - develop
+      - main
 
 env:
   HUSKY: 0


### PR DESCRIPTION
I'm going to delete the `master` branch and rename `develop` to `main`.

We don't get a lot of use out of `master` because we don't do stable releases -- we have done in the past but these have never been deployed, and were more for the benefit of versioning the photon plugin / state manager.