### PR TITLE
Add ImplicitPropertyAttribute to MissionDesigner

### DIFF
--- a/DragaliaAPI.MissionDesigner/Missions/PermanentDailies.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/PermanentDailies.cs
@@ -5,13 +5,11 @@ using JetBrains.Annotations;
 namespace DragaliaAPI.MissionDesigner.Missions;
 
 [ContainsMissionList]
-[UsedImplicitly]
 public static class PermanentDailies
 {
     private const int ProgressionGroupId = 15070;
 
-    [MissionList(Type = MissionType.Daily)]
-    [UsedImplicitly]
+    [MissionType(MissionType.Daily)]
     public static List<Mission> Missions { get; } =
         [
             // Perform an Item Summon

--- a/DragaliaAPI.MissionDesigner/Missions/StarryDragonyule.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/StarryDragonyule.cs
@@ -6,18 +6,17 @@ using JetBrains.Annotations;
 namespace DragaliaAPI.MissionDesigner.Missions;
 
 [ContainsMissionList]
-[UsedImplicitly]
 public static class StarryDragonyule
 {
     private const int EventId = 22903;
     private const int DailyProgressionGroupId = 2290301;
 
-    [MissionList(Type = MissionType.Period)]
-    [UsedImplicitly]
+    [MissionType(MissionType.Period)]
+    [EventId(EventId)]
     public static List<Mission> PeriodMissions { get; } =
         [
             // Participate in the Event
-            new EventParticipationMission() { MissionId = 11650101, EventId = EventId },
+            new EventParticipationMission() { MissionId = 11650101 },
             // Clear All of the Event's Story Quests
             new ReadQuestStoryMission()
             {
@@ -25,134 +24,121 @@ public static class StarryDragonyule
                 QuestStoryId = 2290306 // Final story ID; cannot progress with all 5 as _CompleteValue = 1
             },
             // Collect 1,000 Heroism in One Invasion
-            new EventPointCollectionRecordMission() { MissionId = 11650301, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 11650301 },
             // Collect 2,000 Heroism in One Invasion
-            new EventPointCollectionRecordMission() { MissionId = 11650302, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 11650302 },
             // Collect 3,000 Heroism in One Invasion
-            new EventPointCollectionRecordMission() { MissionId = 11650303, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 11650303 },
             // Collect 4,000 Heroism in One Invasion
-            new EventPointCollectionRecordMission() { MissionId = 11650304, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 11650304, },
             // Collect 5,000 Heroism in One Invasion
-            new EventPointCollectionRecordMission() { MissionId = 11650305, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 11650305, },
             // Defeat 1,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650401, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650401, },
             // Defeat 2,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650402, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650402, },
             // Defeat 5,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650403, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650403, },
             // Defeat 7,500 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650404, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650404 },
             // Defeat 10,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650405, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650405 },
             // Defeat 12,500 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650406, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650406 },
             // Defeat 15,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650407, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650407 },
             // Defeat 17,500 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650408, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650408 },
             // Defeat 20,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650409, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650409 },
             // Defeat 25,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650410, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650410 },
             // Defeat 30,000 Enemies in Invasions
-            new EarnEnemiesKilledMission() { MissionId = 11650411, EventId = EventId },
+            new EarnEnemiesKilledMission() { MissionId = 11650411 },
             // Clear an Invasion on Standard
             new EventRegularBattleClearMission()
             {
                 MissionId = 11650501,
-                EventId = EventId,
                 VariationType = VariationTypes.Normal
             },
             // Clear an Invasion on Expert
             new EventRegularBattleClearMission()
             {
                 MissionId = 11650601,
-                EventId = EventId,
                 VariationType = VariationTypes.Hard
             },
             // Collect 7,500 Heroism in One Invasion on Master
             new EventPointCollectionRecordMission()
             {
                 MissionId = 11650701,
-                EventId = EventId,
                 VariationType = VariationTypes.VeryHard
             },
             // Clear a "One Starry Dragonyule" Trial on Standard
             new EventTrialClearMission()
             {
                 MissionId = 11650801,
-                EventId = EventId,
                 VariationType = VariationTypes.Normal
             },
             // Clear a "One Starry Dragonyule" Trial on Expert
             new EventTrialClearMission()
             {
                 MissionId = 11650901,
-                EventId = EventId,
                 VariationType = VariationTypes.Hard
             },
             // Clear a "One Starry Dragonyule" Trial on Master
             new EventTrialClearMission()
             {
                 MissionId = 11651001,
-                EventId = EventId,
                 VariationType = VariationTypes.VeryHard
             },
             // Clear A Dragonyule Miracle
             new ClearQuestMission() { MissionId = 11651101, QuestId = 229030401, }
         ];
 
-    [MissionList(Type = MissionType.Daily)]
-    [UsedImplicitly]
+    [MissionType(MissionType.Daily)]
+    [EventId(EventId)]
     public static List<Mission> DailyMissions { get; } =
         [
             // Collect 1,000 Heroism
             new EventPointCollectionMission()
             {
                 MissionId = 11190101,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Collect 1,500 Heroism
             new EventPointCollectionMission()
             {
                 MissionId = 11190102,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Collect 2,000 Heroism
             new EventPointCollectionMission()
             {
                 MissionId = 11190103,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Collect 2,500 Heroism
             new EventPointCollectionMission()
             {
                 MissionId = 11190104,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Collect 3,000 Heroism
             new EventPointCollectionMission()
             {
                 MissionId = 11190105,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Clear an Invasion
             new EventRegularBattleClearMission()
             {
                 MissionId = 11190201,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Clear Five Invasions
             new EventRegularBattleClearMission()
             {
                 MissionId = 11190202,
-                EventId = EventId,
                 ProgressionGroupId = DailyProgressionGroupId
             },
             // Clear All Daily Event Endeavours

--- a/DragaliaAPI.MissionDesigner/Missions/TollOfTheDeep.cs
+++ b/DragaliaAPI.MissionDesigner/Missions/TollOfTheDeep.cs
@@ -6,66 +6,63 @@ using JetBrains.Annotations;
 namespace DragaliaAPI.MissionDesigner.Missions;
 
 [ContainsMissionList]
-[UsedImplicitly]
 public static class TollOfTheDeep
 {
     private const int EventId = 20845;
 
-    [MissionList(Type = MissionType.MemoryEvent)]
-    [UsedImplicitly]
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(EventId)]
     public static List<Mission> Missions { get; } =
         new()
         {
             // Participate In The Event
-            new EventParticipationMission { MissionId = 10220101, EventId = EventId, },
+            new EventParticipationMission { MissionId = 10220101, },
             // Clear a Boss Battle
-            new EventRegularBattleClearMission { MissionId = 10220201, EventId = EventId },
+            new EventRegularBattleClearMission { MissionId = 10220201 },
             // Clear a "Toll of the Deep" Quest with Having a Summer Ball Equipped
             new EventQuestClearWithCrestMission()
             {
                 MissionId = 10220401,
-                EventId = EventId,
                 Crest = AbilityCrests.HavingaSummerBall
             },
             // Collect 100 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220501, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220501 },
             // Collect 500 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220502, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220502 },
             // Collect 1,500 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220503, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220503 },
             // Collect 4,000 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220504, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220504 },
             // Collect 6,000 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220505, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220505 },
             // Collect 7,000 Oceanic Resonance in One Go
-            new EventPointCollectionRecordMission() { MissionId = 10220506, EventId = EventId },
+            new EventPointCollectionRecordMission() { MissionId = 10220506 },
             // Clear Five Boss Battles
-            new EventRegularBattleClearMission() { MissionId = 10220601, EventId = EventId },
+            new EventRegularBattleClearMission() { MissionId = 10220601 },
             // Clear 10 Boss Battles
-            new EventRegularBattleClearMission() { MissionId = 10220602, EventId = EventId },
+            new EventRegularBattleClearMission() { MissionId = 10220602 },
             // Clear 15 Boss Battles
-            new EventRegularBattleClearMission() { MissionId = 10220603, EventId = EventId },
+            new EventRegularBattleClearMission() { MissionId = 10220603 },
             // Clear 20 Boss Battles
-            new EventRegularBattleClearMission() { MissionId = 10220604, EventId = EventId },
+            new EventRegularBattleClearMission() { MissionId = 10220604 },
             // Clear 30 Boss Battles
-            new EventRegularBattleClearMission() { MissionId = 10220605, EventId = EventId },
+            new EventRegularBattleClearMission() { MissionId = 10220605 },
             // Clear Three Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220801, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220801 },
             // Clear Six Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220802, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220802 },
             // Clear 10 Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220803, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220803 },
             // Clear 15 Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220804, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220804 },
             // Clear 20 Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220805, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220805 },
             // Clear 25 Challenge Battles
-            new EventChallengeBattleClearMission() { MissionId = 10220806, EventId = EventId },
+            new EventChallengeBattleClearMission() { MissionId = 10220806 },
             // Completely Clear a Challenge Battle on Expert
             new EventChallengeBattleClearMission()
             {
                 MissionId = 10220901,
-                EventId = EventId,
                 QuestId = 208450501,
                 FullClear = true,
             },
@@ -73,7 +70,6 @@ public static class TollOfTheDeep
             new EventChallengeBattleClearMission()
             {
                 MissionId = 10221001,
-                EventId = EventId,
                 QuestId = 208450502,
                 FullClear = true,
             },
@@ -81,14 +77,12 @@ public static class TollOfTheDeep
             new EventTrialClearMission()
             {
                 MissionId = 10221101,
-                EventId = EventId,
                 VariationType = VariationTypes.Hell,
             },
             // Clear a "Toll of the Deep" Trial on Expert
             new EventTrialClearMission()
             {
                 MissionId = 10221201,
-                EventId = EventId,
                 VariationType = VariationTypes.Variation6,
             },
             // Earn the "Light of the Deep" Epithet
@@ -96,7 +90,6 @@ public static class TollOfTheDeep
             new EventChallengeBattleClearMission()
             {
                 MissionId = 10221301,
-                EventId = EventId,
                 QuestId = 208450502,
                 FullClear = true,
             },

--- a/DragaliaAPI.MissionDesigner/Models/Attributes/ContainsMissionListAttribute.cs
+++ b/DragaliaAPI.MissionDesigner/Models/Attributes/ContainsMissionListAttribute.cs
@@ -1,4 +1,7 @@
+using JetBrains.Annotations;
+
 namespace DragaliaAPI.MissionDesigner.Models.Attributes;
 
+[MeansImplicitUse]
 [AttributeUsage(AttributeTargets.Class)]
-public class ContainsMissionListAttribute : Attribute { }
+public sealed class ContainsMissionListAttribute : Attribute { }

--- a/DragaliaAPI.MissionDesigner/Models/Attributes/EventIdAttribute.cs
+++ b/DragaliaAPI.MissionDesigner/Models/Attributes/EventIdAttribute.cs
@@ -1,0 +1,10 @@
+namespace DragaliaAPI.MissionDesigner.Models.Attributes;
+
+public sealed class EventIdAttribute(int eventId) : ImplicitPropertyAttribute
+{
+    public int EventId { get; } = eventId;
+
+    public override string Property => "EventId";
+
+    public override object Value => EventId;
+}

--- a/DragaliaAPI.MissionDesigner/Models/Attributes/ImplicitPropertyAttribute.cs
+++ b/DragaliaAPI.MissionDesigner/Models/Attributes/ImplicitPropertyAttribute.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+
+namespace DragaliaAPI.MissionDesigner.Models.Attributes;
+
+[MeansImplicitUse]
+[AttributeUsage(AttributeTargets.Property)]
+public abstract class ImplicitPropertyAttribute : Attribute
+{
+    public abstract string Property { get; }
+
+    public abstract object Value { get; }
+}

--- a/DragaliaAPI.MissionDesigner/Models/Attributes/MissionListAttribute.cs
+++ b/DragaliaAPI.MissionDesigner/Models/Attributes/MissionListAttribute.cs
@@ -1,7 +1,0 @@
-namespace DragaliaAPI.MissionDesigner.Models.Attributes;
-
-[AttributeUsage(AttributeTargets.Property)]
-public class MissionListAttribute : Attribute
-{
-    public MissionType Type { get; set; }
-}

--- a/DragaliaAPI.MissionDesigner/Models/Attributes/MissionTypeAttribute.cs
+++ b/DragaliaAPI.MissionDesigner/Models/Attributes/MissionTypeAttribute.cs
@@ -1,0 +1,12 @@
+using JetBrains.Annotations;
+
+namespace DragaliaAPI.MissionDesigner.Models.Attributes;
+
+public sealed class MissionTypeAttribute(MissionType type) : ImplicitPropertyAttribute
+{
+    public MissionType Type { get; } = type;
+
+    public override string Property => "Type";
+
+    public override object? Value => this.Type;
+}

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EarnEnemiesKilledMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EarnEnemiesKilledMission.cs
@@ -2,7 +2,7 @@ namespace DragaliaAPI.MissionDesigner.Models.EventMission;
 
 public class EarnEnemiesKilledMission : Mission
 {
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     protected override MissionCompleteType CompleteType => MissionCompleteType.EarnEnemiesKilled;
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventChallengeBattleClearMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventChallengeBattleClearMission.cs
@@ -5,7 +5,7 @@ public class EventChallengeBattleClearMission : Mission
     protected override MissionCompleteType CompleteType =>
         MissionCompleteType.EventChallengeBattleClear;
 
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public int? QuestId { get; init; }
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventParticipationMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventParticipationMission.cs
@@ -4,7 +4,7 @@ public class EventParticipationMission : Mission
 {
     protected override MissionCompleteType CompleteType => MissionCompleteType.EventParticipation;
 
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     protected override int? Parameter => this.EventId;
 }

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionMission.cs
@@ -2,7 +2,7 @@ namespace DragaliaAPI.MissionDesigner.Models.EventMission;
 
 public class EventPointCollectionMission : Mission
 {
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public VariationTypes? VariationType { get; init; } = null;
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionRecordMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventPointCollectionRecordMission.cs
@@ -2,7 +2,7 @@ namespace DragaliaAPI.MissionDesigner.Models.EventMission;
 
 public class EventPointCollectionRecordMission : Mission
 {
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public VariationTypes? VariationType { get; init; }
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventQuestClearWithCrestMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventQuestClearWithCrestMission.cs
@@ -5,7 +5,7 @@ public class EventQuestClearWithCrestMission : Mission
     protected override MissionCompleteType CompleteType =>
         MissionCompleteType.EventQuestClearWithCrest;
 
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public required AbilityCrests Crest { get; init; }
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventRegularBattleClearMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventRegularBattleClearMission.cs
@@ -5,7 +5,7 @@ public class EventRegularBattleClearMission : Mission
     protected override MissionCompleteType CompleteType =>
         MissionCompleteType.EventRegularBattleClear;
 
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public VariationTypes? VariationType { get; init; }
 

--- a/DragaliaAPI.MissionDesigner/Models/EventMission/EventTrialClearMission.cs
+++ b/DragaliaAPI.MissionDesigner/Models/EventMission/EventTrialClearMission.cs
@@ -4,7 +4,7 @@ public class EventTrialClearMission : Mission
 {
     protected override MissionCompleteType CompleteType => MissionCompleteType.EventTrialClear;
 
-    public required int EventId { get; init; }
+    public int EventId { get; set; }
 
     public required VariationTypes VariationType { get; init; }
 

--- a/DragaliaAPI.MissionDesigner/Program.cs
+++ b/DragaliaAPI.MissionDesigner/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using DragaliaAPI.MissionDesigner;
 using DragaliaAPI.MissionDesigner.Missions;
-using DragaliaAPI.MissionDesigner.Models;
 using DragaliaAPI.MissionDesigner.Models.Attributes;
 using DragaliaAPI.Shared.Json;
 
@@ -20,29 +20,12 @@ foreach (Type type in types)
 {
     Console.WriteLine($"Processing type {type.Name}");
     IEnumerable<PropertyInfo> listProperties = type.GetProperties()
-        .Where(x => Attribute.IsDefined(x, typeof(MissionListAttribute)));
+        .Where(x => x.PropertyType.GetGenericTypeDefinition() == typeof(List<>));
 
     foreach (PropertyInfo listProperty in listProperties)
     {
         Console.WriteLine($"Found list {type.Name}.{listProperty.Name}");
-
-        MissionListAttribute attribute = (MissionListAttribute)
-            listProperty.GetCustomAttributes(typeof(MissionListAttribute)).First();
-
-        List<Mission> list = (List<Mission>)listProperty.GetValue(null, null)!;
-
-        if (list.DistinctBy(x => x.MissionId).Count() != list.Count)
-        {
-            int duplicateId = list.GroupBy(x => x.MissionId).First(x => x.Count() > 1).Key;
-            throw new InvalidOperationException($"List had duplicate mission ID: {duplicateId}");
-        }
-
-        foreach (Mission mission in list)
-        {
-            mission.Type = attribute.Type;
-            Console.WriteLine($" -> Processing mission {mission.MissionId}");
-            missions.Add(mission.ToMissionProgressionInfo());
-        }
+        missions.AddRange(ReflectionHelper.ProcessList(listProperty));
     }
 }
 

--- a/DragaliaAPI.MissionDesigner/ReflectionHelper.cs
+++ b/DragaliaAPI.MissionDesigner/ReflectionHelper.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+
+namespace DragaliaAPI.MissionDesigner;
+
+public static class ReflectionHelper
+{
+    public static IEnumerable<MissionProgressionInfo> ProcessList(PropertyInfo listProperty)
+    {
+        List<Mission> list = (List<Mission>)listProperty.GetValue(null, null)!;
+        ImplicitPropertyAttribute[] attributes = listProperty
+            .GetCustomAttributes<ImplicitPropertyAttribute>()
+            .ToArray();
+
+        if (list.DistinctBy(x => x.MissionId).Count() != list.Count)
+        {
+            int duplicateId = list.GroupBy(x => x.MissionId).First(x => x.Count() > 1).Key;
+            throw new InvalidOperationException($"List had duplicate mission ID: {duplicateId}");
+        }
+
+        foreach (Mission mission in list)
+        {
+            Console.WriteLine(
+                $" -> Processing mission {mission.MissionId} ({mission.GetType().Name})"
+            );
+            UpdateProperties(mission, attributes);
+            yield return mission.ToMissionProgressionInfo();
+        }
+    }
+
+    private static void UpdateProperties(Mission mission, ImplicitPropertyAttribute[] attributes)
+    {
+        Type missionType = mission.GetType();
+
+        foreach (ImplicitPropertyAttribute attribute in attributes)
+        {
+            PropertyInfo? prop = missionType.GetProperty(attribute.Property);
+            if (prop is null)
+            {
+                Console.WriteLine(
+                    $"    Skipping ImplicitPropertyAttribute for {attribute.Property}"
+                );
+                continue;
+            }
+
+            prop.SetValue(mission, attribute.Value);
+        }
+    }
+}


### PR DESCRIPTION
Adds `ImplicitPropertyAttribute`, which is a generic version of the way that `MissionListAttribute` sets the type for all missions in a list. This is used to additionally set the `EventId` for all missions in event lists.

If a property is attempted to be set which does not exist (for example a generic clear quest mission in an event mission list), it is skipped and a message is logged.

There are no changes to `MissionProgressionInfo.json` with this update.