### PR TITLE
Don't return out of date missions from /mission/get_mission_list

### DIFF
--- a/DragaliaAPI/Features/Missions/IMissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/IMissionRepository.cs
@@ -11,9 +11,9 @@ public interface IMissionRepository
     IQueryable<DbPlayerMission> GetMissionsByType(MissionType type);
 
     Task<DbPlayerMission> GetMissionByIdAsync(MissionType type, int id);
-    Task<ILookup<MissionType, DbPlayerMission>> GetAllMissionsPerTypeAsync();
+    Task<ILookup<MissionType, DbPlayerMission>> GetActiveMissionsPerTypeAsync();
 
-    Task<DbPlayerMission> AddMissionAsync(
+    DbPlayerMission AddMission(
         MissionType type,
         int id,
         DateTimeOffset? startTime = null,

--- a/DragaliaAPI/Features/Missions/MissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/MissionRepository.cs
@@ -49,7 +49,11 @@ public class MissionRepository(
     {
         return (
             await Missions
-                .Where(x => x.Start < resetHelper.UtcNow && x.End > resetHelper.UtcNow)
+                .Where(
+                    x =>
+                        (x.Start == DateTimeOffset.UnixEpoch || x.Start < resetHelper.UtcNow)
+                        && (x.End == DateTimeOffset.UnixEpoch || x.End > resetHelper.UtcNow)
+                )
                 .ToListAsync()
         )
             .Where(HasProgressionInfo)

--- a/DragaliaAPI/Features/Missions/MissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/MissionRepository.cs
@@ -45,14 +45,18 @@ public class MissionRepository(
             ) ?? throw new DragaliaException(ResultCode.MissionIdNotFound, "Mission not found");
     }
 
-    public async Task<ILookup<MissionType, DbPlayerMission>> GetAllMissionsPerTypeAsync()
+    public async Task<ILookup<MissionType, DbPlayerMission>> GetActiveMissionsPerTypeAsync()
     {
-        return (await Missions.Where(x => x.Type != MissionType.Daily).ToListAsync())
+        return (
+            await Missions
+                .Where(x => x.Start < resetHelper.UtcNow && x.End > resetHelper.UtcNow)
+                .ToListAsync()
+        )
             .Where(HasProgressionInfo)
             .ToLookup(x => x.Type);
     }
 
-    public async Task<DbPlayerMission> AddMissionAsync(
+    public DbPlayerMission AddMission(
         MissionType type,
         int id,
         DateTimeOffset? startTime = null,


### PR DESCRIPTION
If you return a mission whose `end_date` is in the past, the game will repeatedly refresh the mission window on the assumption the data is stale.

Also includes misc. refactoring of some mission code