### PR TITLE
Switch off of prerelease versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,9 +10,12 @@
     <PackageVersion Include="FluentRandomPicker" Version="3.5.0" />
     <PackageVersion Include="FluentValidation" Version="11.9.0" />
     <PackageVersion Include="JetBrains.Annotations" Version="2023.3.0" />
-    <PackageVersion Include="MessagePack" Version="2.6.100-alpha" />
-    <PackageVersion Include="MessagePack.AspNetCoreMvcFormatter" Version="2.6.100-alpha" />
-    <PackageVersion Include="MessagePackAnalyzer" Version="2.6.100-alpha" />
+    <PackageVersion Include="MessagePack" Version="2.5.140" />
+    <PackageVersion Include="MessagePack.AspNetCoreMvcFormatter" Version="2.5.140" />
+    <PackageVersion Include="MessagePackAnalyzer" Version="2.5.140">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
@@ -42,12 +45,12 @@
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.1" />
-    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.1-dev-00968" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="FluentAssertions" Version="7.0.0-alpha.2" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0-preview-23503-02" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="MockQueryable.Moq" Version="7.0.0" />
     <PackageVersion Include="Moq" Version="4.20.70" />
     <PackageVersion Include="xunit" Version="2.6.4" />

--- a/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="MessagePack" VersionOverride="2.5.108" />
+        <PackageReference Include="MessagePack" />
         <PackageReference Include="Newtonsoft.Json" />
     </ItemGroup>
 

--- a/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj
+++ b/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MessagePack" VersionOverride="2.5.108"/>
+		<PackageReference Include="MessagePack" />
 		<PackageReference Include="Redis.OM" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,18 +21,20 @@ services:
     env_file:
       - .env
 
-  # photonstatemanager:
-  #   hostname: photonstatemanager
-  #   image: ${DOCKER_REGISTRY-}photonstatemanager
-  #   build:
-  #       context: .
-  #       dockerfile: DragaliaAPI.Photon.StateManager/Dockerfile
-  #   environment:
-  #     - HTTP_PORTS=80
-  #   ports:
-  #     - "5001:80"
-  #   env_file:
-  #     - .env
+  photonstatemanager:
+    hostname: photonstatemanager
+    image: ${DOCKER_REGISTRY-}photonstatemanager
+    build:
+        context: .
+        dockerfile: DragaliaAPI.Photon.StateManager/Dockerfile
+    environment:
+      - HTTP_PORTS=80
+    ports:
+      - "5001:80"
+    env_file:
+      - .env
+    profiles:
+      - photon
 
   postgres:
     hostname: postgres


### PR DESCRIPTION
- Unify MessagePack version in solution (tested plugin still works)
- Stop using prereleases for Serilog.Sinks.File, FluentAssertions, and Microsoft.NET.Test.Sdk
- Add compose profile for statemanager as a better alternative to commenting out the service