### PR TITLE
Fix co-op tutorial

### DIFF
--- a/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -7,6 +7,7 @@ using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
 using DragaliaAPI.Shared.Definitions.Enums;
+using static DragaliaAPI.Services.Game.TutorialService;
 
 namespace DragaliaAPI.Features.Dungeon.Record;
 
@@ -97,6 +98,15 @@ public class DungeonRecordService(
             .Select(x => x.ToConvertedEntityList())
             .Merge()
             .ToList();
+
+        if (
+            session.QuestId == TutorialQuestIds.AvenueToPowerBeginner
+            && await tutorialService.GetCurrentTutorialStatus() == TutorialStatusIds.CoopTutorial
+        )
+        {
+            logger.LogDebug("Detected co-op tutorial: updating tutorial status");
+            await tutorialService.UpdateTutorialStatus(20501);
+        }
 
         return ingameResultData;
     }

--- a/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -10,11 +10,13 @@ using DragaliaAPI.Features.Reward;
 using DragaliaAPI.Features.Shop;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
+using DragaliaAPI.Services.Game;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.EntityFrameworkCore;
+using static DragaliaAPI.Services.Game.TutorialService;
 
 namespace DragaliaAPI.Features.Dungeon.Start;
 
@@ -33,7 +35,8 @@ public class DungeonStartService(
     ILogger<DungeonStartService> logger,
     IPaymentService paymentService,
     IEventService eventService,
-    IAutoRepeatService autoRepeatService
+    IAutoRepeatService autoRepeatService,
+    ITutorialService tutorialService
 ) : IDungeonStartService
 {
     public async Task<bool> ValidateStamina(int questId, StaminaType staminaType)
@@ -105,6 +108,15 @@ public class DungeonStartService(
         else
         {
             await autoRepeatService.ClearRepeatInfo();
+        }
+
+        if (
+            questId == TutorialQuestIds.AvenueToPowerBeginner
+            && await tutorialService.GetCurrentTutorialStatus() == TutorialStatusIds.CoopTutorial
+        )
+        {
+            logger.LogDebug("Detected co-op tutorial: setting is_bot_tutorial");
+            result.is_bot_tutorial = true;
         }
 
         return result;

--- a/DragaliaAPI/Services/Game/TutorialService.cs
+++ b/DragaliaAPI/Services/Game/TutorialService.cs
@@ -34,6 +34,9 @@ public class TutorialService : ITutorialService
         this.wallRepository = wallRepository;
     }
 
+    public Task<int> GetCurrentTutorialStatus() =>
+        this.userDataRepository.UserData.Select(x => x.TutorialStatus).FirstAsync();
+
     public async Task<int> UpdateTutorialStatus(int newStatus)
     {
         DbPlayerUserData userData = await userDataRepository.UserData.SingleAsync();
@@ -149,8 +152,14 @@ public class TutorialService : ITutorialService
         public const int Ch16Done = 1001613;
     }
 
+    public static class TutorialQuestIds
+    {
+        public const int AvenueToPowerBeginner = 201010101;
+    }
+
     internal static class TutorialStatusIds
     {
+        public const int CoopTutorial = 20402;
         public const int Dojos = 60999;
     }
 

--- a/DragaliaAPI/Services/ITutorialService.cs
+++ b/DragaliaAPI/Services/ITutorialService.cs
@@ -5,4 +5,5 @@ public interface ITutorialService
     public Task<int> UpdateTutorialStatus(int newStatus);
     public Task<List<int>> AddTutorialFlag(int flag);
     public Task OnStoryQuestRead(int storyId);
+    Task<int> GetCurrentTutorialStatus();
 }


### PR DESCRIPTION
- Fix co-op tutorial using your units instead of the bots, by setting `is_bot_tutorial` to true when it is in progress
- Fix co-op tutorial infinitely repeating by advancing tutorial status on record