### PR TITLE
Fix change tracker conflict with V15 and V18 updates

### DIFF
--- a/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
+++ b/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
@@ -316,4 +316,19 @@ public class V18UpdateTest : SavefileUpdateTestFixture
                 opts => opts.Excluding(x => x.ViewerId).Excluding(x => x.GroupId)
             );
     }
+
+    [Fact]
+    public async Task Update_DoesNotClashWithV15()
+    {
+        await this.AddToDatabase(
+            new DbPlayerStoryState()
+            {
+                StoryId = TutorialService.TutorialStoryIds.MercurialGauntlet,
+                StoryType = StoryTypes.Quest,
+                State = StoryState.Read,
+            }
+        );
+
+        await this.Invoking(x => x.LoadIndex()).Should().NotThrowAsync();
+    }
 }

--- a/DragaliaAPI/Features/Missions/IMissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/IMissionRepository.cs
@@ -36,4 +36,6 @@ public interface IMissionRepository
         DateTimeOffset? endTime = null,
         int? groupId = null
     );
+
+    Task<DbPlayerMission?> FindMissionByIdAsync(MissionType type, int id);
 }

--- a/DragaliaAPI/Features/Missions/MissionRepository.cs
+++ b/DragaliaAPI/Features/Missions/MissionRepository.cs
@@ -36,13 +36,19 @@ public class MissionRepository(
         return this.Missions.Where(x => x.Type == type);
     }
 
-    public async Task<DbPlayerMission> GetMissionByIdAsync(MissionType type, int id)
+    public async Task<DbPlayerMission?> FindMissionByIdAsync(MissionType type, int id)
     {
         return await this.apiContext.PlayerMissions.FindAsync(
-                this.playerIdentityService.ViewerId,
-                id,
-                type
-            ) ?? throw new DragaliaException(ResultCode.MissionIdNotFound, "Mission not found");
+            this.playerIdentityService.ViewerId,
+            id,
+            type
+        );
+    }
+
+    public async Task<DbPlayerMission> GetMissionByIdAsync(MissionType type, int id)
+    {
+        return await this.FindMissionByIdAsync(type, id)
+            ?? throw new DragaliaException(ResultCode.MissionIdNotFound, "Mission not found");
     }
 
     public async Task<ILookup<MissionType, DbPlayerMission>> GetActiveMissionsPerTypeAsync()

--- a/DragaliaAPI/Features/SavefileUpdate/V18Update.cs
+++ b/DragaliaAPI/Features/SavefileUpdate/V18Update.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using DragaliaAPI.Database;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Wall;
@@ -16,6 +17,7 @@ public class V18Update(
     IWallService wallService,
     IStoryRepository storyRepository,
     IMissionRepository missionRepository,
+    ApiContext context,
     IMissionService missionService,
     ILogger<V18Update> logger
 ) : ISavefileUpdate
@@ -43,9 +45,10 @@ public class V18Update(
         }
 
         if (
-            await this.missionRepository.Missions.AnyAsync(x =>
-                x.Type == MissionType.Normal && x.Id == ClearAnyMgMissionId
-            )
+            await this.missionRepository.FindMissionByIdAsync(
+                MissionType.Normal,
+                ClearAnyMgMissionId
+            ) != null
         )
         {
             this.logger.LogInformation("Player has already unlocked wall missions, skipping...");


### PR DESCRIPTION
.AnyAsync() doesn't return true if the mission is tracked but not yet saved, apparently