### PR TITLE
Remove extra references indirect references from photon plugin

### DIFF
--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin.Test/DragaliaAPI.Photon.Plugin.Test.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin.Test/DragaliaAPI.Photon.Plugin.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <IsPackable>false</IsPackable>
         <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <Nullable>disable</Nullable>
         <ImplicitUsings>disable</ImplicitUsings>
         <LangVersion>7.3</LangVersion>
         <PlatformTarget>x64</PlatformTarget>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-        <AssemblyVersion>3.1.0</AssemblyVersion>
+        <AssemblyVersion>3.2.1</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Shared/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj
+++ b/Shared/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj
@@ -7,8 +7,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="MessagePack" />
-		<PackageReference Include="Redis.OM" />
-		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
 
 </Project>

--- a/Shared/DragaliaAPI.Photon.Shared/Models/ApiGame.cs
+++ b/Shared/DragaliaAPI.Photon.Shared/Models/ApiGame.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace DragaliaAPI.Photon.Shared.Models
+﻿namespace DragaliaAPI.Photon.Shared.Models
 {
     /// <summary>
     /// An object representing an open game with additional derived properties,
@@ -58,7 +56,6 @@ namespace DragaliaAPI.Photon.Shared.Models
             MatchingType = gameBase.MatchingType;
         }
 
-        [JsonConstructor]
         public ApiGame() { }
     }
 }


### PR DESCRIPTION
Remove extra unneeded packages from shared project, which almost halves the number of assemblies included with the plugin build.

Had to retarget the photon plugin due to the following error: `CSC: Error CS1705 : Assembly 'MessagePack' with identity 'MessagePack, Version=2.5.0.0, Culture=neutral, PublicKeyToken=b4a0369545f0a1be' uses 'System.Memory, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' which has a higher version than referenced assembly 'System.Memory' with identity 'System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51'`

Most likely S.T.J reference was upgrading the project somehow? But not sure. Re-adding that fixes the issue, but we don't want to keep it.

Still appears to work fine on net 4.7.2, plugin is loaded and breakpoints are hit. JsonConstructor attribute being removed still allows the API to deserialize ApiGame classes.