### PR TITLE
Implement summon ticket usage

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Shop/PaymentService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shop/PaymentService.cs
@@ -123,7 +123,7 @@ public class PaymentService(
                 break;
             case EntityTypes.SummonTicket:
                 DbSummonTicket? ticket = await ticketRepository.Tickets.SingleOrDefaultAsync(x =>
-                    x.KeyId == entity.Id
+                    x.SummonTicketId == (SummonTickets)entity.Id
                 );
                 quantity = ticket?.Quantity;
                 // NOTE: Maybe remove here once quantity == 0?


### PR DESCRIPTION
The changes in #674 caused the summoning menu to start showing the available summoning tickets - however, if you have any tickets, the game forces you to use them, and this is not working at the minute.

This pr adds a basic implementation of summoning ticket consumption to address this issue