### PR TITLE
Remove empty request models

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/AbilityCrestTest.cs
@@ -529,8 +529,7 @@ public class AbilityCrestTest : TestFixture
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
             await this.Client.PostMsgpack<AbilityCrestGetAbilityCrestSetListResponse>(
-                "ability_crest/get_ability_crest_set_list",
-                new AbilityCrestGetAbilityCrestSetListRequest()
+                "ability_crest/get_ability_crest_set_list"
             )
         ).Data!;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -201,13 +201,8 @@ public class DragonTest : TestFixture
     [Fact]
     public async Task DragonGetContactData_ReturnsValidData()
     {
-        DragonGetContactDataRequest request = new DragonGetContactDataRequest();
-
         DragonGetContactDataResponse? response = (
-            await this.Client.PostMsgpack<DragonGetContactDataResponse>(
-                "dragon/get_contact_data",
-                request
-            )
+            await this.Client.PostMsgpack<DragonGetContactDataResponse>("dragon/get_contact_data")
         ).Data;
 
         response.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
@@ -12,10 +12,7 @@ public class EulaTest : TestFixture
     public async Task EulaGetVersionList_ReturnsAllVersions()
     {
         EulaGetVersionListResponse response = (
-            await this.Client.PostMsgpack<EulaGetVersionListResponse>(
-                "eula/get_version_list",
-                new EulaGetVersionListRequest()
-            )
+            await this.Client.PostMsgpack<EulaGetVersionListResponse>("eula/get_version_list")
         ).Data;
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
@@ -10,8 +10,7 @@ public class GetDeployVersionTest : TestFixture
     {
         DeployGetDeployVersionResponse response = (
             await this.Client.PostMsgpack<DeployGetDeployVersionResponse>(
-                "deploy/get_deploy_version",
-                new DeployGetDeployVersionRequest()
+                "deploy/get_deploy_version"
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/RedoableSummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/RedoableSummonTest.cs
@@ -12,10 +12,7 @@ public class RedoableSummonTest : TestFixture
     public async Task RedoableSummonGetData_ReturnsData()
     {
         RedoableSummonGetDataResponse response = (
-            await this.Client.PostMsgpack<RedoableSummonGetDataResponse>(
-                "redoable_summon/get_data",
-                new RedoableSummonGetDataRequest()
-            )
+            await this.Client.PostMsgpack<RedoableSummonGetDataResponse>("redoable_summon/get_data")
         ).Data;
 
         response.Should().NotBeNull();
@@ -44,10 +41,7 @@ public class RedoableSummonTest : TestFixture
         );
 
         RedoableSummonFixExecResponse response = (
-            await this.Client.PostMsgpack<RedoableSummonFixExecResponse>(
-                "redoable_summon/fix_exec",
-                new RedoableSummonFixExecRequest()
-            )
+            await this.Client.PostMsgpack<RedoableSummonFixExecResponse>("redoable_summon/fix_exec")
         ).Data;
 
         IEnumerable<int> newCharaIds = response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
@@ -67,8 +67,7 @@ public class SummonTest : TestFixture
 
         SummonGetSummonHistoryResponse response = (
             await this.Client.PostMsgpack<SummonGetSummonHistoryResponse>(
-                "summon/get_summon_history",
-                new SummonGetSummonHistoryRequest()
+                "summon/get_summon_history"
             )
         ).Data;
 
@@ -103,10 +102,7 @@ public class SummonTest : TestFixture
         );
 
         SummonGetSummonListResponse response = (
-            await this.Client.PostMsgpack<SummonGetSummonListResponse>(
-                "summon/get_summon_list",
-                new SummonGetSummonListRequest()
-            )
+            await this.Client.PostMsgpack<SummonGetSummonListResponse>("summon/get_summon_list")
         ).Data;
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
@@ -21,10 +21,7 @@ public class ToolTest : TestFixture
     public async Task ServiceStatus_ReturnsCorrectResponse()
     {
         ToolGetServiceStatusResponse response = (
-            await this.Client.PostMsgpack<ToolGetServiceStatusResponse>(
-                "tool/get_service_status",
-                new ToolGetServiceStatusRequest()
-            )
+            await this.Client.PostMsgpack<ToolGetServiceStatusResponse>("tool/get_service_status")
         ).Data;
 
         response.ServiceStatus.Should().Be(1);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -19,12 +19,7 @@ public class UserTest : TestFixture
 
         UserData expectedUserData = this.Mapper.Map<UserData>(dbUserData);
 
-        (
-            await this.Client.PostMsgpack<UserLinkedNAccountResponse>(
-                "/user/linked_n_account",
-                new UserLinkedNAccountRequest()
-            )
-        )
+        (await this.Client.PostMsgpack<UserLinkedNAccountResponse>("/user/linked_n_account"))
             .Data.Should()
             .BeEquivalentTo(
                 new UserLinkedNAccountResponse()
@@ -38,12 +33,7 @@ public class UserTest : TestFixture
     [Fact]
     public async Task GetNAccountInfo_ReturnsExpectedResponse()
     {
-        (
-            await this.Client.PostMsgpack<UserGetNAccountInfoResponse>(
-                "/user/get_n_account_info",
-                new UserGetNAccountInfoRequest()
-            )
-        )
+        (await this.Client.PostMsgpack<UserGetNAccountInfoResponse>("/user/get_n_account_info"))
             .Data.Should()
             .BeEquivalentTo(
                 new UserGetNAccountInfoResponse()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -15,10 +15,7 @@ public class DmodeTest : TestFixture
     public async Task GetData_ReturnsData()
     {
         DragaliaResponse<DmodeGetDataResponse> resp =
-            await Client.PostMsgpack<DmodeGetDataResponse>(
-                "dmode/get_data",
-                new DmodeGetDataRequest()
-            );
+            await Client.PostMsgpack<DmodeGetDataResponse>("dmode/get_data");
 
         resp.Data.DmodeInfo.IsEntry.Should().BeTrue();
         resp.Data.DmodeCharaList.Should().NotBeNull();
@@ -183,8 +180,7 @@ public class DmodeTest : TestFixture
 
         DragaliaResponse<DmodeExpeditionForceFinishResponse> finishResp =
             await this.Client.PostMsgpack<DmodeExpeditionForceFinishResponse>(
-                "dmode/expedition_force_finish",
-                new DmodeExpeditionForceFinishRequest() { }
+                "dmode/expedition_force_finish"
             );
 
         finishResp
@@ -251,10 +247,7 @@ public class DmodeTest : TestFixture
         this.MockDateTimeProvider.Setup(x => x.UtcNow).Returns(DateTimeOffset.UtcNow);
 
         DragaliaResponse<DmodeExpeditionFinishResponse> finishResp =
-            await this.Client.PostMsgpack<DmodeExpeditionFinishResponse>(
-                "dmode/expedition_finish",
-                new DmodeExpeditionFinishRequest() { }
-            );
+            await this.Client.PostMsgpack<DmodeExpeditionFinishResponse>("dmode/expedition_finish");
 
         finishResp
             .Data.DmodeExpedition.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
@@ -63,10 +63,7 @@ public class DmodeDungeonTest : TestFixture
             }
         );
 
-        await this.Client.PostMsgpack<DmodeDungeonFloorSkipResponse>(
-            "dmode_dungeon/floor_skip",
-            new DmodeDungeonFloorSkipRequest() { }
-        );
+        await this.Client.PostMsgpack<DmodeDungeonFloorSkipResponse>("dmode_dungeon/floor_skip");
 
         (await this.GetDungeonState()).Should().Be(DungeonState.WaitingSkipEnd);
 
@@ -114,20 +111,14 @@ public class DmodeDungeonTest : TestFixture
             }
         );
 
-        await this.Client.PostMsgpack<DmodeDungeonUserHaltResponse>(
-            "dmode_dungeon/user_halt",
-            new DmodeDungeonUserHaltRequest() { }
-        );
+        await this.Client.PostMsgpack<DmodeDungeonUserHaltResponse>("dmode_dungeon/user_halt");
 
         this.ApiContext.PlayerDmodeDungeons.AsNoTracking()
             .First(x => x.ViewerId == ViewerId)
             .State.Should()
             .Be(DungeonState.Halting);
 
-        await this.Client.PostMsgpack<DmodeDungeonRestartResponse>(
-            "dmode_dungeon/restart",
-            new DmodeDungeonRestartRequest() { }
-        );
+        await this.Client.PostMsgpack<DmodeDungeonRestartResponse>("dmode_dungeon/restart");
 
         (await this.GetDungeonState()).Should().Be(DungeonState.RestartEnd);
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
@@ -137,7 +137,7 @@ public class AutoRepeatTest : TestFixture
         ).Data;
 
         RepeatEndResponse repeatEndResponse = (
-            await Client.PostMsgpack<RepeatEndResponse>("repeat/end", new RepeatEndRequest())
+            await Client.PostMsgpack<RepeatEndResponse>("repeat/end")
         ).Data;
 
         repeatEndResponse.RepeatData.Should().BeEquivalentTo(recordResponse2.RepeatData);
@@ -234,7 +234,7 @@ public class AutoRepeatTest : TestFixture
         ).Data;
 
         RepeatEndResponse repeatEndResponse = (
-            await Client.PostMsgpack<RepeatEndResponse>("repeat/end", new RepeatEndRequest())
+            await Client.PostMsgpack<RepeatEndResponse>("repeat/end")
         ).Data;
 
         int expectedPoints =
@@ -301,7 +301,7 @@ public class AutoRepeatTest : TestFixture
         ).Data;
 
         MypageInfoResponse mypageResponse = (
-            await Client.PostMsgpack<MypageInfoResponse>("mypage/info", new MypageInfoRequest() { })
+            await Client.PostMsgpack<MypageInfoResponse>("mypage/info")
         ).Data;
 
         mypageResponse.RepeatData.Should().BeEquivalentTo(recordResponse.RepeatData);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/MemoryEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/MemoryEventTest.cs
@@ -36,10 +36,7 @@ public class MemoryEventTest : TestFixture
         );
 
         MissionGetMissionListResponse missionListResponse = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list",
-                new MissionGetMissionListRequest() { }
-            )
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
         ).Data;
 
         missionListResponse

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -39,12 +39,7 @@ public class FortTest : TestFixture
         );
         await this.ApiContext.SaveChangesAsync();
 
-        (
-            await this.Client.PostMsgpack<FortGetDataResponse>(
-                "/fort/get_data",
-                new FortGetDataRequest()
-            )
-        )
+        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
             .Data.BuildList.Should()
             .ContainEquivalentOf(
                 new BuildList()
@@ -77,12 +72,7 @@ public class FortTest : TestFixture
             )
             .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 1));
 
-        (
-            await this.Client.PostMsgpack<FortGetDataResponse>(
-                "/fort/get_data",
-                new FortGetDataRequest()
-            )
-        )
+        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
             .Data.DragonContactFreeGiftCount.Should()
             .Be(1);
 
@@ -92,12 +82,7 @@ public class FortTest : TestFixture
             )
             .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 0));
 
-        (
-            await this.Client.PostMsgpack<FortGetDataResponse>(
-                "/fort/get_data",
-                new FortGetDataRequest()
-            )
-        )
+        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
             .Data.DragonContactFreeGiftCount.Should()
             .Be(0);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
@@ -28,8 +28,7 @@ public class ItemTest : TestFixture
     public async Task GetList_ReturnsItemList()
     {
         DragaliaResponse<ItemGetListResponse> resp = await Client.PostMsgpack<ItemGetListResponse>(
-            "item/get_list",
-            new ItemGetListRequest()
+            "item/get_list"
         );
 
         resp.Data.ItemList.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Maintenance/MaintenanceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Maintenance/MaintenanceTest.cs
@@ -24,7 +24,6 @@ public class MaintenanceTest : TestFixture
         DragaliaResponse<ResultCodeResponse> response =
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "load/index",
-                new LoadIndexRequest(),
                 ensureSuccessHeader: false
             );
 
@@ -39,7 +38,6 @@ public class MaintenanceTest : TestFixture
         DragaliaResponse<ToolGetServiceStatusResponse> response =
             await this.Client.PostMsgpack<ToolGetServiceStatusResponse>(
                 "tool/get_service_status",
-                new ToolGetServiceStatusRequest(),
                 ensureSuccessHeader: false
             );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
@@ -350,8 +350,7 @@ public class MissionTest : TestFixture
 
         DragaliaResponse<MissionGetMissionListResponse> response =
             await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list",
-                new MissionGetMissionListRequest()
+                "mission/get_mission_list"
             );
 
         response
@@ -431,8 +430,7 @@ public class MissionTest : TestFixture
 
         MissionGetDrillMissionListResponse response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list",
-                new MissionGetDrillMissionListRequest()
+                "mission/get_drill_mission_list"
             )
         ).Data;
 
@@ -446,8 +444,7 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list",
-                new MissionGetDrillMissionListRequest()
+                "mission/get_drill_mission_list"
             )
         ).Data;
 
@@ -461,8 +458,7 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list",
-                new MissionGetDrillMissionListRequest()
+                "mission/get_drill_mission_list"
             )
         ).Data;
 
@@ -478,8 +474,7 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list",
-                new MissionGetDrillMissionListRequest()
+                "mission/get_drill_mission_list"
             )
         ).Data;
 
@@ -510,10 +505,7 @@ public class MissionTest : TestFixture
         );
 
         MissionGetMissionListResponse response = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list",
-                new MissionGetMissionListRequest()
-            )
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
         ).Data;
 
         response
@@ -566,10 +558,7 @@ public class MissionTest : TestFixture
         );
 
         MissionGetMissionListResponse response = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list",
-                new MissionGetMissionListRequest()
-            )
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
         ).Data;
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -27,7 +27,7 @@ public abstract class SavefileUpdateTestFixture : TestFixture
 
     protected async Task LoadIndex()
     {
-        await this.Client.PostMsgpack<LoadIndexResponse>("load/index", new LoadIndexRequest());
+        await this.Client.PostMsgpack<LoadIndexResponse>("load/index");
     }
 
     protected override async Task Setup() =>

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -23,7 +23,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.TheHalidom);
@@ -48,7 +48,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.Smithy);
@@ -73,7 +73,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.FlameDracolith);
@@ -92,7 +92,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.SwordDojo);
@@ -113,7 +113,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         await this.ApiContext.PlayerStoryState.ExecuteDeleteAsync();
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         data.BuildList.Should().BeEmpty();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
@@ -12,7 +12,7 @@ public class V2UpdateTest : SavefileUpdateTestFixture
     public async Task V2Update_AddsStampList()
     {
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
         ).Data;
 
         List<EquipStampList> expectedStampList =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
@@ -17,10 +17,7 @@ public class ShopTest : TestFixture
         await this.ApiContext.SaveChangesAsync();
 
         DragaliaResponse<ShopGetListResponse> resp =
-            await this.Client.PostMsgpack<ShopGetListResponse>(
-                "shop/get_list",
-                new ShopGetListRequest()
-            );
+            await this.Client.PostMsgpack<ShopGetListResponse>("shop/get_list");
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
         resp.Data.MaterialShopPurchase.Should().BeEmpty();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
@@ -13,10 +13,7 @@ public class StampTest : TestFixture
     public async Task GetStamp_ReturnsStamps()
     {
         StampGetStampResponse data = (
-            await this.Client.PostMsgpack<StampGetStampResponse>(
-                $"{Controller}/get_stamp",
-                new StampGetStampRequest()
-            )
+            await this.Client.PostMsgpack<StampGetStampResponse>($"{Controller}/get_stamp")
         ).Data;
 
         data.StampList.Should().HaveCount(123);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
@@ -16,8 +16,7 @@ public class TimeAttackRankingTest : TestFixture
     {
         (
             await this.Client.PostMsgpack<TimeAttackRankingGetDataResponse>(
-                "/time_attack_ranking/get_data",
-                new TimeAttackRankingGetDataRequest() { }
+                "/time_attack_ranking/get_data"
             )
         )
             .Data.RankingTierRewardList.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -17,10 +17,7 @@ public class TreasureTradeTest : TestFixture
         await this.ApiContext.SaveChangesAsync();
 
         TreasureTradeGetListAllResponse response = (
-            await Client.PostMsgpack<TreasureTradeGetListAllResponse>(
-                "treasure_trade/get_list_all",
-                new TreasureTradeGetListAllRequest()
-            )
+            await Client.PostMsgpack<TreasureTradeGetListAllResponse>("treasure_trade/get_list_all")
         ).Data;
 
         response.UserTreasureTradeList.Should().BeEmpty();
@@ -43,10 +40,7 @@ public class TreasureTradeTest : TestFixture
         );
 
         TreasureTradeGetListAllResponse response = (
-            await Client.PostMsgpack<TreasureTradeGetListAllResponse>(
-                "treasure_trade/get_list_all",
-                new TreasureTradeGetListAllRequest()
-            )
+            await Client.PostMsgpack<TreasureTradeGetListAllResponse>("treasure_trade/get_list_all")
         ).Data;
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Version/VersionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Version/VersionTest.cs
@@ -37,7 +37,6 @@ public class VersionTest : TestFixture
         (
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "fort/get_data",
-                new FortGetDataRequest(),
                 ensureSuccessHeader: false
             )
         )
@@ -54,7 +53,6 @@ public class VersionTest : TestFixture
         (
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "tool/get_service_status",
-                new FortGetDataRequest(),
                 ensureSuccessHeader: false
             )
         )

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -263,10 +263,7 @@ public class WallRecordTest : TestFixture
             .BeEquivalentTo([flameLv6MissionId, clearAllLv6MissionId]);
 
         MissionGetMissionListResponse missionList = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list",
-                new MissionGetMissionListRequest()
-            )
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
         ).Data;
 
         missionList.NormalMissionList.Should().Contain(x => x.NormalMissionId == flameLv7MissionId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -40,6 +40,28 @@ public static class HttpClientExtensions
         return deserialized;
     }
 
+    public static async Task<DragaliaResponse<TResponse>> PostMsgpack<TResponse>(
+        this HttpClient client,
+        string endpoint,
+        bool ensureSuccessHeader = true
+    )
+        where TResponse : class
+    {
+        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), null);
+
+        response.EnsureSuccessStatusCode();
+
+        byte[] body = await response.Content.ReadAsByteArrayAsync();
+        DragaliaResponse<TResponse> deserialized = MessagePackSerializer.Deserialize<
+            DragaliaResponse<TResponse>
+        >(body, CustomResolver.Options);
+
+        if (ensureSuccessHeader)
+            deserialized.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+
+        return deserialized;
+    }
+
     public static async Task PostMsgpack(
         this HttpClient client,
         string endpoint,

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -75,7 +75,7 @@ public class SavefileImportTest : TestFixture
             .BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
 
         LoadIndexResponse storedSavefile = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("load/index", new LoadIndexRequest())
+            await this.Client.PostMsgpack<LoadIndexResponse>("load/index")
         ).Data;
 
         storedSavefile

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/AbilityCrestControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/AbilityCrestControllerTest.cs
@@ -259,9 +259,7 @@ public class AbilityCrestControllerTest
             .Returns(new List<DbAbilityCrestSet>().AsQueryable().BuildMock());
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
-            await this.abilityCrestController.GetAbilityCrestSetList(
-                new AbilityCrestGetAbilityCrestSetListRequest()
-            )
+            await this.abilityCrestController.GetAbilityCrestSetList()
         ).GetData<AbilityCrestGetAbilityCrestSetListResponse>()!;
 
         int setNo = 1;
@@ -317,9 +315,7 @@ public class AbilityCrestControllerTest
             );
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
-            await this.abilityCrestController.GetAbilityCrestSetList(
-                new AbilityCrestGetAbilityCrestSetListRequest()
-            )
+            await this.abilityCrestController.GetAbilityCrestSetList()
         ).GetData<AbilityCrestGetAbilityCrestSetListResponse>()!;
 
         int setNo = 1;

--- a/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
@@ -72,9 +72,7 @@ public class DragonServiceTest
             out List<DbPlayerDragonReliability> dragonRels,
             out List<DbPlayerStoryState> stories
         );
-        DragonGetContactDataResponse responseData = await dragonService.DoDragonGetContactData(
-            new DragonGetContactDataRequest()
-        );
+        DragonGetContactDataResponse responseData = await dragonService.DoDragonGetContactData();
 
         responseData.Should().NotBeNull();
         responseData.ShopGiftList.Should().NotBeNullOrEmpty();
@@ -102,21 +100,21 @@ public class DragonServiceTest
         DateTimeOffset wednesday = new DateTimeOffset(2023, 12, 27, 19, 49, 23, TimeSpan.Zero);
         this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(wednesday);
 
-        (await this.dragonService.DoDragonGetContactData(new DragonGetContactDataRequest() { }))
+        (await this.dragonService.DoDragonGetContactData())
             .ShopGiftList.Should()
             .Contain(x => x.DragonGiftId == (int)DragonGifts.FloralCirclet);
 
         DateTimeOffset thuBeforeReset = new DateTimeOffset(2023, 12, 28, 01, 49, 23, TimeSpan.Zero);
         this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(thuBeforeReset);
 
-        (await this.dragonService.DoDragonGetContactData(new DragonGetContactDataRequest() { }))
+        (await this.dragonService.DoDragonGetContactData())
             .ShopGiftList.Should()
             .Contain(x => x.DragonGiftId == (int)DragonGifts.FloralCirclet);
 
         DateTimeOffset thursday = new DateTimeOffset(2023, 12, 28, 09, 49, 23, TimeSpan.Zero);
         this.mockTimeProvider.Setup(x => x.GetUtcNow()).Returns(thursday);
 
-        (await this.dragonService.DoDragonGetContactData(new DragonGetContactDataRequest() { }))
+        (await this.dragonService.DoDragonGetContactData())
             .ShopGiftList.Should()
             .Contain(x => x.DragonGiftId == (int)DragonGifts.CompellingBook);
     }

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/AbilityCrestController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/AbilityCrestController.cs
@@ -155,9 +155,7 @@ public class AbilityCrestController : DragaliaControllerBase
 
     [Route("get_ability_crest_set_list")]
     [HttpPost]
-    public async Task<DragaliaResult> GetAbilityCrestSetList(
-        AbilityCrestGetAbilityCrestSetListRequest request
-    )
+    public async Task<DragaliaResult> GetAbilityCrestSetList()
     {
         List<DbAbilityCrestSet> dbAbilityCrestSets = await abilityCrestRepository
             .AbilityCrestSets.OrderBy(x => x.AbilityCrestSetNo)

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/DragonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/DragonController.cs
@@ -40,11 +40,9 @@ public class DragonController : DragaliaControllerBase
 
     [Route("get_contact_data")]
     [HttpPost]
-    public async Task<DragaliaResult> DragonGetContactData(
-        [FromBody] DragonGetContactDataRequest request
-    )
+    public async Task<DragaliaResult> DragonGetContactData()
     {
-        return Ok(await dragonService.DoDragonGetContactData(request));
+        return Ok(await dragonService.DoDragonGetContactData());
     }
 
     [Route("buy_gift_to_send_multiple")]

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/UserController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/UserController.cs
@@ -27,7 +27,7 @@ public class UserController : DragaliaControllerBase
     }
 
     [HttpPost("linked_n_account")]
-    public async Task<DragaliaResult> LinkedNAccount(UserLinkedNAccountRequest request)
+    public async Task<DragaliaResult> LinkedNAccount()
     {
         // This controller is meant to be used to set the 'Link a Nintendo Account' mission as complete
         DbPlayerUserData userData = await this.userDataRepository.UserData.SingleAsync();
@@ -39,7 +39,7 @@ public class UserController : DragaliaControllerBase
     }
 
     [HttpPost("get_n_account_info")]
-    public DragaliaResult GetNAccountInfo(UserGetNAccountInfoRequest request)
+    public DragaliaResult GetNAccountInfo()
     {
         // TODO: Replace this with an API call to BaaS to return actual information
         return this.Ok(

--- a/DragaliaAPI/DragaliaAPI/Features/TimeAttack/TimeAttackController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/TimeAttack/TimeAttackController.cs
@@ -16,9 +16,7 @@ public class TimeAttackController(
 {
     [Route("get_data")]
     [HttpPost]
-    public DragaliaResult<TimeAttackRankingGetDataResponse> GetData(
-        TimeAttackRankingGetDataRequest request
-    )
+    public DragaliaResult<TimeAttackRankingGetDataResponse> GetData()
     {
         IEnumerable<RankingTierRewardList> rewardList = timeAttackService
             .GetRewards()

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
@@ -51,8 +51,7 @@ public partial class AbilityCrestBuildupPlusCountRequest
     public AbilityCrestBuildupPlusCountRequest() { }
 }
 
-[MessagePackObject]
-public partial class AbilityCrestGetAbilityCrestSetListRequest { }
+
 
 [MessagePackObject]
 public partial class AbilityCrestResetPlusCountRequest
@@ -120,8 +119,7 @@ public partial class AbilityCrestSetFavoriteRequest
     public AbilityCrestSetFavoriteRequest() { }
 }
 
-[MessagePackObject]
-public partial class AbilityCrestTradeGetListRequest { }
+
 
 [MessagePackObject]
 public partial class AbilityCrestTradeTradeRequest
@@ -162,8 +160,7 @@ public partial class AbilityCrestUpdateAbilityCrestSetNameRequest
     public AbilityCrestUpdateAbilityCrestSetNameRequest() { }
 }
 
-[MessagePackObject]
-public partial class AlbumIndexRequest { }
+
 
 [MessagePackObject]
 public partial class AmuletBuildupRequest
@@ -258,8 +255,7 @@ public partial class AmuletSetLockRequest
     public AmuletSetLockRequest() { }
 }
 
-[MessagePackObject]
-public partial class AmuletTradeGetListRequest { }
+
 
 [MessagePackObject]
 public partial class AmuletTradeTradeRequest
@@ -429,8 +425,7 @@ public partial class BattleRoyalStartMultiRequest
     public BattleRoyalStartMultiRequest() { }
 }
 
-[MessagePackObject]
-public partial class BattleRoyalStartRoyalMultiRequest { }
+
 
 [MessagePackObject]
 public partial class BuildEventEntryRequest
@@ -488,8 +483,7 @@ public partial class BuildEventReceiveDailyBonusRequest
     public BuildEventReceiveDailyBonusRequest() { }
 }
 
-[MessagePackObject]
-public partial class CartoonLatestRequest { }
+
 
 [MessagePackObject]
 public partial class CastleStoryReadRequest
@@ -596,8 +590,7 @@ public partial class CharaGetCharaUnitSetRequest
     public CharaGetCharaUnitSetRequest() { }
 }
 
-[MessagePackObject]
-public partial class CharaGetListRequest { }
+
 
 [MessagePackObject]
 public partial class CharaLimitBreakAndBuildupManaRequest
@@ -941,8 +934,7 @@ public partial class CraftResetNewRequest
     public CraftResetNewRequest() { }
 }
 
-[MessagePackObject]
-public partial class DeployGetDeployVersionRequest { }
+
 
 [MessagePackObject]
 public partial class DmodeBuildupServitorPassiveRequest
@@ -989,11 +981,9 @@ public partial class DmodeDungeonFloorRequest
     public DmodeDungeonFloorRequest() { }
 }
 
-[MessagePackObject]
-public partial class DmodeDungeonFloorSkipRequest { }
 
-[MessagePackObject]
-public partial class DmodeDungeonRestartRequest { }
+
+
 
 [MessagePackObject]
 public partial class DmodeDungeonStartRequest
@@ -1026,20 +1016,15 @@ public partial class DmodeDungeonStartRequest
     public DmodeDungeonStartRequest() { }
 }
 
-[MessagePackObject]
-public partial class DmodeDungeonSystemHaltRequest { }
 
-[MessagePackObject]
-public partial class DmodeDungeonUserHaltRequest { }
 
-[MessagePackObject]
-public partial class DmodeEntryRequest { }
 
-[MessagePackObject]
-public partial class DmodeExpeditionFinishRequest { }
 
-[MessagePackObject]
-public partial class DmodeExpeditionForceFinishRequest { }
+
+
+
+
+
 
 [MessagePackObject]
 public partial class DmodeExpeditionStartRequest
@@ -1059,8 +1044,7 @@ public partial class DmodeExpeditionStartRequest
     public DmodeExpeditionStartRequest() { }
 }
 
-[MessagePackObject]
-public partial class DmodeGetDataRequest { }
+
 
 [MessagePackObject]
 public partial class DmodeReadStoryRequest
@@ -1136,8 +1120,7 @@ public partial class DragonBuyGiftToSendRequest
     public DragonBuyGiftToSendRequest() { }
 }
 
-[MessagePackObject]
-public partial class DragonGetContactDataRequest { }
+
 
 [MessagePackObject]
 public partial class DragonLimitBreakRequest
@@ -1718,8 +1701,7 @@ public partial class EarnEventReceiveEventPointRewardRequest
     public EarnEventReceiveEventPointRewardRequest() { }
 }
 
-[MessagePackObject]
-public partial class EmblemGetListRequest { }
+
 
 [MessagePackObject]
 public partial class EmblemSetRequest
@@ -1776,8 +1758,7 @@ public partial class EulaAgreeAgreeRequest
     public EulaAgreeAgreeRequest() { }
 }
 
-[MessagePackObject]
-public partial class EulaGetVersionListRequest { }
+
 
 [MessagePackObject]
 public partial class EulaGetVersionRequest
@@ -2121,8 +2102,7 @@ public partial class FortBuildStartRequest
     public FortBuildStartRequest() { }
 }
 
-[MessagePackObject]
-public partial class FortGetDataRequest { }
+
 
 [MessagePackObject]
 public partial class FortGetMultiIncomeRequest
@@ -2234,14 +2214,11 @@ public partial class FortSetNewFortPlantRequest
     public FortSetNewFortPlantRequest() { }
 }
 
-[MessagePackObject]
-public partial class FriendAllReplyDenyRequest { }
 
-[MessagePackObject]
-public partial class FriendApplyListRequest { }
 
-[MessagePackObject]
-public partial class FriendAutoSearchRequest { }
+
+
+
 
 [MessagePackObject]
 public partial class FriendDeleteRequest
@@ -2257,11 +2234,9 @@ public partial class FriendDeleteRequest
     public FriendDeleteRequest() { }
 }
 
-[MessagePackObject]
-public partial class FriendFriendIndexRequest { }
 
-[MessagePackObject]
-public partial class FriendFriendListRequest { }
+
+
 
 [MessagePackObject]
 public partial class FriendGetSupportCharaDetailRequest
@@ -2277,8 +2252,7 @@ public partial class FriendGetSupportCharaDetailRequest
     public FriendGetSupportCharaDetailRequest() { }
 }
 
-[MessagePackObject]
-public partial class FriendGetSupportCharaRequest { }
+
 
 [MessagePackObject]
 public partial class FriendIdSearchRequest
@@ -2326,8 +2300,7 @@ public partial class FriendRequestCancelRequest
     public FriendRequestCancelRequest() { }
 }
 
-[MessagePackObject]
-public partial class FriendRequestListRequest { }
+
 
 [MessagePackObject]
 public partial class FriendRequestRequest
@@ -2640,11 +2613,9 @@ public partial class GuildGetGuildMemberDataRequest
     public GuildGetGuildMemberDataRequest() { }
 }
 
-[MessagePackObject]
-public partial class GuildIndexRequest { }
 
-[MessagePackObject]
-public partial class GuildInviteGetGuildInviteReceiveDataRequest { }
+
+
 
 [MessagePackObject]
 public partial class GuildInviteGetGuildInviteSendDataRequest
@@ -3161,8 +3132,7 @@ public partial class InquiryTopRequest
     public InquiryTopRequest() { }
 }
 
-[MessagePackObject]
-public partial class ItemGetListRequest { }
+
 
 [MessagePackObject]
 public partial class ItemUseRecoveryStaminaRequest
@@ -3178,8 +3148,7 @@ public partial class ItemUseRecoveryStaminaRequest
     public ItemUseRecoveryStaminaRequest() { }
 }
 
-[MessagePackObject]
-public partial class LoadIndexRequest { }
+
 
 [MessagePackObject]
 public partial class LoginIndexRequest
@@ -3465,11 +3434,9 @@ public partial class MemoryEventActivateRequest
     public MemoryEventActivateRequest() { }
 }
 
-[MessagePackObject]
-public partial class MissionGetDrillMissionListRequest { }
 
-[MessagePackObject]
-public partial class MissionGetMissionListRequest { }
+
+
 
 [MessagePackObject]
 public partial class MissionReceiveAlbumRewardRequest
@@ -3632,11 +3599,9 @@ public partial class MissionUnlockMainStoryGroupRequest
     public MissionUnlockMainStoryGroupRequest() { }
 }
 
-[MessagePackObject]
-public partial class MypageInfoRequest { }
 
-[MessagePackObject]
-public partial class OptionGetOptionRequest { }
+
+
 
 [MessagePackObject]
 public partial class OptionSetOptionRequest
@@ -3652,8 +3617,7 @@ public partial class OptionSetOptionRequest
     public OptionSetOptionRequest() { }
 }
 
-[MessagePackObject]
-public partial class PartyIndexRequest { }
+
 
 [MessagePackObject]
 public partial class PartySetMainPartyNoRequest
@@ -3724,8 +3688,7 @@ public partial class PartyUpdatePartyNameRequest
     public PartyUpdatePartyNameRequest() { }
 }
 
-[MessagePackObject]
-public partial class PlatformAchievementGetPlatformAchievementListRequest { }
+
 
 [MessagePackObject]
 public partial class PresentGetHistoryListRequest
@@ -3843,8 +3806,7 @@ public partial class QuestGetQuestClearPartyRequest
     public QuestGetQuestClearPartyRequest() { }
 }
 
-[MessagePackObject]
-public partial class QuestGetSupportUserListRequest { }
+
 
 [MessagePackObject]
 public partial class QuestOpenTreasureRequest
@@ -4075,11 +4037,9 @@ public partial class RaidEventReceiveRaidPointRewardRequest
     public RaidEventReceiveRaidPointRewardRequest() { }
 }
 
-[MessagePackObject]
-public partial class RedoableSummonFixExecRequest { }
 
-[MessagePackObject]
-public partial class RedoableSummonGetDataRequest { }
+
+
 
 [MessagePackObject]
 public partial class RedoableSummonPreExecRequest
@@ -4095,8 +4055,7 @@ public partial class RedoableSummonPreExecRequest
     public RedoableSummonPreExecRequest() { }
 }
 
-[MessagePackObject]
-public partial class RepeatEndRequest { }
+
 
 [MessagePackObject]
 public partial class ShopChargeCancelRequest
@@ -4144,11 +4103,9 @@ public partial class ShopGetDreamSelectUnitListRequest
     public ShopGetDreamSelectUnitListRequest() { }
 }
 
-[MessagePackObject]
-public partial class ShopGetListRequest { }
 
-[MessagePackObject]
-public partial class ShopGetProductListRequest { }
+
+
 
 [MessagePackObject]
 public partial class ShopItemSummonExecRequest
@@ -4168,8 +4125,7 @@ public partial class ShopItemSummonExecRequest
     public ShopItemSummonExecRequest() { }
 }
 
-[MessagePackObject]
-public partial class ShopItemSummonOddRequest { }
+
 
 [MessagePackObject]
 public partial class ShopMaterialShopPurchaseRequest
@@ -4305,8 +4261,7 @@ public partial class SimpleEventGetEventDataRequest
     public SimpleEventGetEventDataRequest() { }
 }
 
-[MessagePackObject]
-public partial class StampGetStampRequest { }
+
 
 [MessagePackObject]
 public partial class StampSetEquipStampRequest
@@ -4340,8 +4295,7 @@ public partial class StoryReadRequest
     public StoryReadRequest() { }
 }
 
-[MessagePackObject]
-public partial class StorySkipSkipRequest { }
+
 
 [MessagePackObject]
 public partial class SuggestionGetCategoryListRequest
@@ -4460,11 +4414,9 @@ public partial class SummonGetOddsDataRequest
     public SummonGetOddsDataRequest() { }
 }
 
-[MessagePackObject]
-public partial class SummonGetSummonHistoryRequest { }
 
-[MessagePackObject]
-public partial class SummonGetSummonListRequest { }
+
+
 
 [MessagePackObject]
 public partial class SummonGetSummonPointTradeRequest
@@ -4567,8 +4519,7 @@ public partial class TalismanSetLockRequest
     public TalismanSetLockRequest() { }
 }
 
-[MessagePackObject]
-public partial class TimeAttackRankingGetDataRequest { }
+
 
 [MessagePackObject]
 public partial class TimeAttackRankingReceiveTierRewardRequest
@@ -4602,11 +4553,9 @@ public partial class ToolAuthRequest
     public ToolAuthRequest() { }
 }
 
-[MessagePackObject]
-public partial class ToolGetMaintenanceTimeRequest { }
 
-[MessagePackObject]
-public partial class ToolGetServiceStatusRequest { }
+
+
 
 [MessagePackObject]
 public partial class ToolReauthRequest
@@ -4687,8 +4636,7 @@ public partial class ToolSignupRequest
     public ToolSignupRequest() { }
 }
 
-[MessagePackObject]
-public partial class TrackRecordUpdateProgressRequest { }
+
 
 [MessagePackObject]
 public partial class TransitionTransitionByNAccountRequest
@@ -4708,8 +4656,7 @@ public partial class TransitionTransitionByNAccountRequest
     public TransitionTransitionByNAccountRequest() { }
 }
 
-[MessagePackObject]
-public partial class TreasureTradeGetListAllRequest { }
+
 
 [MessagePackObject]
 public partial class TreasureTradeGetListRequest
@@ -4825,14 +4772,11 @@ public partial class UpdateResetNewRequest
     public UpdateResetNewRequest() { }
 }
 
-[MessagePackObject]
-public partial class UserGetNAccountInfoRequest { }
 
-[MessagePackObject]
-public partial class UserGetWalletBalanceRequest { }
 
-[MessagePackObject]
-public partial class UserLinkedNAccountRequest { }
+
+
+
 
 [MessagePackObject]
 public partial class UserOptInSettingRequest
@@ -4875,8 +4819,7 @@ public partial class UserRecoverStaminaByStoneRequest
     public UserRecoverStaminaByStoneRequest() { }
 }
 
-[MessagePackObject]
-public partial class UserWithdrawalRequest { }
+
 
 [MessagePackObject]
 public partial class VersionGetResourceVersionRequest

--- a/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
@@ -29,9 +29,7 @@ public class DragonService(
     IResetHelper resetHelper
 ) : IDragonService
 {
-    public async Task<DragonGetContactDataResponse> DoDragonGetContactData(
-        DragonGetContactDataRequest request
-    )
+    public async Task<DragonGetContactDataResponse> DoDragonGetContactData()
     {
         DragonGifts rotatingGift = DragonConstants.RotatingGifts[
             (int)resetHelper.LastDailyReset.DayOfWeek
@@ -466,7 +464,7 @@ public class DragonService(
             DragonContactFreeGiftCount = 0,
             DragonGiftRewardList = rewardObjList,
             EntityResult = null,
-            ShopGiftList = (await DoDragonGetContactData(new())).ShopGiftList,
+            ShopGiftList = (await DoDragonGetContactData()).ShopGiftList,
             UpdateDataList = updateDataList
         };
     }

--- a/DragaliaAPI/DragaliaAPI/Services/IDragonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/IDragonService.cs
@@ -10,7 +10,7 @@ public interface IDragonService
     Task<DragonSendGiftMultipleResponse> DoDragonSendGiftMultiple(
         DragonSendGiftMultipleRequest request
     );
-    Task<DragonGetContactDataResponse> DoDragonGetContactData(DragonGetContactDataRequest request);
+    Task<DragonGetContactDataResponse> DoDragonGetContactData();
     Task<DragonBuildupResponse> DoBuildup(DragonBuildupRequest request);
     Task<DragonResetPlusCountResponse> DoDragonResetPlusCount(DragonResetPlusCountRequest request);
     Task<DragonLimitBreakResponse> DoDragonLimitBreak(DragonLimitBreakRequest request);


### PR DESCRIPTION
Lots of MessagePack deserialization errors in the logs after #676.

```
MessagePack.MessagePackSerializationException: Failed to deserialize DragaliaAPI.Models.Generated.DragonGetContactDataRequest value.
 ---> MessagePack.MessagePackSerializationException: Unexpected msgpack code 128 (fixmap) encountered.
```

The common thread between them seems to be on endpoints with empty request bodies where we are trying to bind said empty request body. Possibly the fact that we are no longer setting keysAsPropertyNames = true is making MessagePack-CSharp think we expect an array of integer keys (as we have no properties to specify string keys on), but the game is still sending a map.