### PR TITLE
Default-initialize reward record and grow record

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -50,8 +50,6 @@ public class DungeonRecordService(
                 TotalPlayDamage = playRecord.TotalPlayDamage,
                 ClearTime = playRecord.Time,
                 IsClear = true,
-                RewardRecord = new(),
-                GrowRecord = new(),
             };
 
         await this.ProcessStaminaConsumption(session);

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -8977,12 +8977,6 @@ public partial class IngameResultData
     [Key("quest_id")]
     public int QuestId { get; set; }
 
-    [Key("reward_record")]
-    public RewardRecord RewardRecord { get; set; }
-
-    [Key("grow_record")]
-    public GrowRecord GrowRecord { get; set; }
-
     [Key("start_time")]
     public DateTimeOffset StartTime { get; set; }
 

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/IngameResultData.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/IngameResultData.cs
@@ -1,0 +1,12 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class IngameResultData
+{
+    [Key("reward_record")]
+    public RewardRecord RewardRecord { get; set; } = new();
+
+    [Key("grow_record")]
+    public GrowRecord GrowRecord { get; set; } = new();
+}


### PR DESCRIPTION
This was being done before #676, and with it removed and placed in a service, we started seeing NullReferenceExceptions in /dungeon_record/record.

Let's try reverting it back to exactly how it was before...