### PR TITLE
Fix "Problem with received data" error on tutorial summon

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -9546,7 +9546,6 @@ public partial class OddsRateList
 public partial class OddsUnitDetail
 {
     [Key("pickup")]
-    [MessagePackFormatter(typeof(BoolToIntFormatter))]
     public bool Pickup { get; set; }
 
     [Key("rarity")]


### PR DESCRIPTION
`Pickup` was being incorrectly serialized as an integer