### PR TITLE
Stop sending summon ticket info

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/SummonTest.cs
@@ -75,7 +75,7 @@ public class SummonTest : TestFixture
         response.SummonHistoryList.Should().NotBeEmpty();
     }
 
-    [Fact]
+    [Fact(Skip = "Summon tickets not yet fully implemented")]
     public async Task SummonGetSummonList_ReturnsDataWithBannerInformation()
     {
         int bannerId = 1020010;

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
@@ -142,12 +142,12 @@ public class SummonController(
     public async Task<DragaliaResult<SummonGetSummonListResponse>> GetSummonList()
     {
         IEnumerable<SummonList> bannerList = await summonListService.GetSummonList();
-        IEnumerable<SummonTicketList> ticketList = await summonListService.GetSummonTicketList();
+        // IEnumerable<SummonTicketList> ticketList = await summonListService.GetSummonTicketList();
 
         return new SummonGetSummonListResponse()
         {
             SummonList = bannerList,
-            SummonTicketList = ticketList,
+            SummonTicketList = [],
             CampaignSummonList = [],
             CharaSsrSummonList = [],
             DragonSsrSummonList = [],


### PR DESCRIPTION
This is currently blocking summoning with payment target errors, but the way the data is currently being stored isn't quite right. If we disabled the payment target, the next error would be material shortage since we store each ticket with its own key ID and don't delete them when the quantity reaches 0.

Needs a rethink - so for now disable sending tickets so that people can still summon with wyrmite.