### PR TITLE
Fix material item list removing all items

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Models/Generated/EventTradeGetListResponse.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/EventTradeGetListResponse.cs
@@ -1,0 +1,9 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class EventTradeGetListResponse
+{
+    [Key("material_list")]
+    public IEnumerable<MaterialList> MaterialList { get; set; }
+}

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/EventTradeTradeResponse.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/EventTradeTradeResponse.cs
@@ -1,0 +1,9 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class EventTradeTradeResponse
+{
+    [Key("material_list")]
+    public IEnumerable<MaterialList> MaterialList { get; set; }
+}

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
@@ -51,8 +51,6 @@ public partial class AbilityCrestBuildupPlusCountRequest
     public AbilityCrestBuildupPlusCountRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class AbilityCrestResetPlusCountRequest
 {
@@ -119,8 +117,6 @@ public partial class AbilityCrestSetFavoriteRequest
     public AbilityCrestSetFavoriteRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class AbilityCrestTradeTradeRequest
 {
@@ -159,8 +155,6 @@ public partial class AbilityCrestUpdateAbilityCrestSetNameRequest
 
     public AbilityCrestUpdateAbilityCrestSetNameRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class AmuletBuildupRequest
@@ -254,8 +248,6 @@ public partial class AmuletSetLockRequest
 
     public AmuletSetLockRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class AmuletTradeTradeRequest
@@ -425,8 +417,6 @@ public partial class BattleRoyalStartMultiRequest
     public BattleRoyalStartMultiRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class BuildEventEntryRequest
 {
@@ -482,8 +472,6 @@ public partial class BuildEventReceiveDailyBonusRequest
 
     public BuildEventReceiveDailyBonusRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class CastleStoryReadRequest
@@ -589,8 +577,6 @@ public partial class CharaGetCharaUnitSetRequest
 
     public CharaGetCharaUnitSetRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class CharaLimitBreakAndBuildupManaRequest
@@ -934,8 +920,6 @@ public partial class CraftResetNewRequest
     public CraftResetNewRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class DmodeBuildupServitorPassiveRequest
 {
@@ -981,10 +965,6 @@ public partial class DmodeDungeonFloorRequest
     public DmodeDungeonFloorRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class DmodeDungeonStartRequest
 {
@@ -1016,16 +996,6 @@ public partial class DmodeDungeonStartRequest
     public DmodeDungeonStartRequest() { }
 }
 
-
-
-
-
-
-
-
-
-
-
 [MessagePackObject]
 public partial class DmodeExpeditionStartRequest
 {
@@ -1043,8 +1013,6 @@ public partial class DmodeExpeditionStartRequest
 
     public DmodeExpeditionStartRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class DmodeReadStoryRequest
@@ -1119,8 +1087,6 @@ public partial class DragonBuyGiftToSendRequest
 
     public DragonBuyGiftToSendRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class DragonLimitBreakRequest
@@ -1701,8 +1667,6 @@ public partial class EarnEventReceiveEventPointRewardRequest
     public EarnEventReceiveEventPointRewardRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class EmblemSetRequest
 {
@@ -1757,8 +1721,6 @@ public partial class EulaAgreeAgreeRequest
 
     public EulaAgreeAgreeRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class EulaGetVersionRequest
@@ -2102,8 +2064,6 @@ public partial class FortBuildStartRequest
     public FortBuildStartRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class FortGetMultiIncomeRequest
 {
@@ -2214,12 +2174,6 @@ public partial class FortSetNewFortPlantRequest
     public FortSetNewFortPlantRequest() { }
 }
 
-
-
-
-
-
-
 [MessagePackObject]
 public partial class FriendDeleteRequest
 {
@@ -2234,10 +2188,6 @@ public partial class FriendDeleteRequest
     public FriendDeleteRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class FriendGetSupportCharaDetailRequest
 {
@@ -2251,8 +2201,6 @@ public partial class FriendGetSupportCharaDetailRequest
 
     public FriendGetSupportCharaDetailRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class FriendIdSearchRequest
@@ -2299,8 +2247,6 @@ public partial class FriendRequestCancelRequest
 
     public FriendRequestCancelRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class FriendRequestRequest
@@ -2612,10 +2558,6 @@ public partial class GuildGetGuildMemberDataRequest
 
     public GuildGetGuildMemberDataRequest() { }
 }
-
-
-
-
 
 [MessagePackObject]
 public partial class GuildInviteGetGuildInviteSendDataRequest
@@ -3132,8 +3074,6 @@ public partial class InquiryTopRequest
     public InquiryTopRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class ItemUseRecoveryStaminaRequest
 {
@@ -3147,8 +3087,6 @@ public partial class ItemUseRecoveryStaminaRequest
 
     public ItemUseRecoveryStaminaRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class LoginIndexRequest
@@ -3434,10 +3372,6 @@ public partial class MemoryEventActivateRequest
     public MemoryEventActivateRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class MissionReceiveAlbumRewardRequest
 {
@@ -3599,10 +3533,6 @@ public partial class MissionUnlockMainStoryGroupRequest
     public MissionUnlockMainStoryGroupRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class OptionSetOptionRequest
 {
@@ -3616,8 +3546,6 @@ public partial class OptionSetOptionRequest
 
     public OptionSetOptionRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class PartySetMainPartyNoRequest
@@ -3687,8 +3615,6 @@ public partial class PartyUpdatePartyNameRequest
 
     public PartyUpdatePartyNameRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class PresentGetHistoryListRequest
@@ -3805,8 +3731,6 @@ public partial class QuestGetQuestClearPartyRequest
 
     public QuestGetQuestClearPartyRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class QuestOpenTreasureRequest
@@ -4037,10 +3961,6 @@ public partial class RaidEventReceiveRaidPointRewardRequest
     public RaidEventReceiveRaidPointRewardRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class RedoableSummonPreExecRequest
 {
@@ -4054,8 +3974,6 @@ public partial class RedoableSummonPreExecRequest
 
     public RedoableSummonPreExecRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class ShopChargeCancelRequest
@@ -4103,10 +4021,6 @@ public partial class ShopGetDreamSelectUnitListRequest
     public ShopGetDreamSelectUnitListRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class ShopItemSummonExecRequest
 {
@@ -4124,8 +4038,6 @@ public partial class ShopItemSummonExecRequest
 
     public ShopItemSummonExecRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class ShopMaterialShopPurchaseRequest
@@ -4261,8 +4173,6 @@ public partial class SimpleEventGetEventDataRequest
     public SimpleEventGetEventDataRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class StampSetEquipStampRequest
 {
@@ -4294,8 +4204,6 @@ public partial class StoryReadRequest
 
     public StoryReadRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class SuggestionGetCategoryListRequest
@@ -4414,10 +4322,6 @@ public partial class SummonGetOddsDataRequest
     public SummonGetOddsDataRequest() { }
 }
 
-
-
-
-
 [MessagePackObject]
 public partial class SummonGetSummonPointTradeRequest
 {
@@ -4519,8 +4423,6 @@ public partial class TalismanSetLockRequest
     public TalismanSetLockRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class TimeAttackRankingReceiveTierRewardRequest
 {
@@ -4552,10 +4454,6 @@ public partial class ToolAuthRequest
 
     public ToolAuthRequest() { }
 }
-
-
-
-
 
 [MessagePackObject]
 public partial class ToolReauthRequest
@@ -4636,8 +4534,6 @@ public partial class ToolSignupRequest
     public ToolSignupRequest() { }
 }
 
-
-
 [MessagePackObject]
 public partial class TransitionTransitionByNAccountRequest
 {
@@ -4655,8 +4551,6 @@ public partial class TransitionTransitionByNAccountRequest
 
     public TransitionTransitionByNAccountRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class TreasureTradeGetListRequest
@@ -4772,12 +4666,6 @@ public partial class UpdateResetNewRequest
     public UpdateResetNewRequest() { }
 }
 
-
-
-
-
-
-
 [MessagePackObject]
 public partial class UserOptInSettingRequest
 {
@@ -4818,8 +4706,6 @@ public partial class UserRecoverStaminaByStoneRequest
 
     public UserRecoverStaminaByStoneRequest() { }
 }
-
-
 
 [MessagePackObject]
 public partial class VersionGetResourceVersionRequest

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
@@ -2892,11 +2892,7 @@ public partial class EventTradeTradeResponse
     [Key("update_data_list")]
     public UpdateDataList UpdateDataList { get; set; }
 
-    [Key("entity_result")]
-    public EntityResult EntityResult { get; set; }
-
-    [Key("material_list")]
-    public IEnumerable<MaterialList> MaterialList { get; set; } = [];
+    [Key("entity_result")] public EntityResult EntityResult { get; set; }
 
     [Key("user_event_item_data")]
     public UserEventItemData UserEventItemData { get; set; }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
@@ -2889,7 +2889,8 @@ public partial class EventTradeTradeResponse
     [Key("update_data_list")]
     public UpdateDataList UpdateDataList { get; set; }
 
-    [Key("entity_result")] public EntityResult EntityResult { get; set; }
+    [Key("entity_result")]
+    public EntityResult EntityResult { get; set; }
 
     [Key("user_event_item_data")]
     public UserEventItemData UserEventItemData { get; set; }
@@ -4788,7 +4789,6 @@ public partial class LoadIndexResponse
     [Key("quest_skip_point_use_limit_max")]
     public int QuestSkipPointUseLimitMax { get; set; }
 
-
     [Key("server_time")]
     public DateTimeOffset ServerTime { get; set; }
 
@@ -4797,7 +4797,6 @@ public partial class LoadIndexResponse
 
     [Key("quest_bonus")]
     public IEnumerable<AtgenQuestBonus> QuestBonus { get; set; } = [];
-
 
     [Key("walker_data")]
     public AtgenWalkerData WalkerData { get; set; }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Responses.cs
@@ -2858,9 +2858,6 @@ public partial class EventTradeGetListResponse
     [Key("event_trade_list")]
     public IEnumerable<EventTradeList> EventTradeList { get; set; } = [];
 
-    [Key("material_list")]
-    public IEnumerable<MaterialList> MaterialList { get; set; } = [];
-
     [Key("user_event_item_data")]
     public UserEventItemData UserEventItemData { get; set; }
 


### PR DESCRIPTION
Cause appears to be a previously always-null `material_list` property in two of the event trade responses, which with #676 was now being default initialized to an empty list, causing the game to think its material inventory is empty.