### PR TITLE
Allow abandoning Kaleidoscape run if redis data retrieval fails

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -304,6 +304,8 @@ public class TestFixture : IAsyncLifetime
 
     private async Task SeedCache()
     {
+        this.factory.ResetCache();
+
         IDistributedCache cache = this.Services.GetRequiredService<IDistributedCache>();
 
         Session session =


### PR DESCRIPTION
Closes #485. Adds an exception handler to the finish endpoint to still
return a response if no Redis data is found, allowing bugged runs to
be abandoned so that the Kaleidoscape can still be accessed