### PR TITLE
Fix "invalid repeat key" warning spam

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
@@ -4,6 +4,7 @@ using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 
@@ -50,33 +51,35 @@ public class AutoRepeatService(
         UpdateDataList updateDataList
     )
     {
-        RepeatInfo? info;
+        RepeatInfo? info = null;
+
+        /*
+         * The repeat_key is null on the first auto-repeat iteration before the client knows the repeat_key.
+         * During the first auto repeat, it may have been configured in /dungeon_start/start, or during the quest.
+         *
+         * In the former case, we need to retrieve the pre-configured settings from the start request,
+         * and in the latter case we need to create default settings.
+         *
+         * Additionally, the client may also send a stale repeat key on the first iteration instead of a null value.
+         * This then fails to find any data. We treat this the same as not having provided a key in the first place.
+         */
 
         if (repeatKey != null)
         {
             info = await this.GetRepeatInfo(Guid.Parse(repeatKey));
-            if (info == null)
-            {
-                logger.LogWarning("Invalid repeat key: {@key}", repeatKey);
-                return null;
-            }
-
-            logger.LogTrace("Found repeat info: {@info}", info);
+            logger.LogTrace("Repeat key {Key} found: {@Info}", repeatKey, info);
         }
-        else
+
+        if (info == null)
         {
-            /*
-             * The repeat_key is null on the first auto-repeat iteration before the client knows the repeat_key.
-             * During the first auto repeat, it may have been configured in /dungeon_start/start, or during the quest.
-             *
-             * In the former case, we need to retrieve the pre-configured settings from the start request,
-             * and in the latter case we need to create default settings.
-             */
-
             info = await this.GetRepeatInfo();
-            logger.LogTrace("Repeat key was null, found repeat info {@info}", info);
+            logger.LogTrace("Repeat key lookup failed. Viewer ID lookup found: {@Info}", info);
+        }
 
+        if (info == null)
+        {
             info ??= CreateDefaultRepeatInfo();
+            logger.LogTrace("Both lookups failed. Default data initialized.");
         }
 
         info.CurrentCount += 1;

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
@@ -78,7 +78,7 @@ public class AutoRepeatService(
 
         if (info == null)
         {
-            info ??= CreateDefaultRepeatInfo();
+            info = CreateDefaultRepeatInfo();
             logger.LogTrace("Both lookups failed. Default data initialized.");
         }
 


### PR DESCRIPTION
This appears to be caused by the client sending a stale repeat key, instead of null, if you auto repeat a quest and then auto repeat another quest after ending the first auto repeat.

<img src="https://github.com/SapiensAnatis/Dawnshard/assets/5047192/08e3eb16-b3b0-45e0-97fa-f8ea0f9e20e1" width="60%" />


Change the handling so that when we receive a repeat key which is invalid, we act in the same way as if we had received null on a first clear, and go to the viewer ID lookup.