### PR TITLE
Delete daily mission data on save import

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -205,6 +205,20 @@ public class SavefileImportTest : TestFixture
     }
 
     [Fact]
+    public async Task Import_DeletesDailyMissions()
+    {
+        this.ApiContext.CompletedDailyMissions.Add(
+            new() { ViewerId = this.ViewerId, Progress = 1, }
+        );
+
+        HttpContent content = PrepareSavefileRequest();
+        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+
+        this.ApiContext.CompletedDailyMissions.Should()
+            .NotContain(x => x.ViewerId == this.ViewerId);
+    }
+
+    [Fact]
     public async Task Import_IsIdempotent()
     {
         long viewerId = this.ApiContext.PlayerUserData.Single(x => x.ViewerId == ViewerId).ViewerId;

--- a/DragaliaAPI/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/SavefileService.cs
@@ -540,6 +540,9 @@ public class SavefileService : ISavefileService
         await this
             .apiContext.PlayerQuestWalls.Where(x => x.ViewerId == viewerId)
             .ExecuteDeleteAsync();
+        await this
+            .apiContext.CompletedDailyMissions.Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
     }
 
     public async Task Reset()


### PR DESCRIPTION
Prevents an issue where attempting to claim a historical daily endeavour after a save import will throw a server error, since the corresponding mission row is missing