### PR TITLE
Handle story PK conflict when adding characters

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/packages.lock.json
@@ -1556,7 +1556,7 @@
           "Microsoft.IdentityModel.Tokens": "[7.3.1, )",
           "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.19.6, )",
           "Microsoft.VisualStudio.Web.CodeGeneration.Design": "[8.0.1, )",
-          "MudBlazor": "[6.16.0, )",
+          "MudBlazor": "[6.17.0, )",
           "Riok.Mapperly": "[3.5.0-next.1, )",
           "Serilog": "[3.1.1, )",
           "Serilog.AspNetCore": "[8.0.1, )",
@@ -1568,7 +1568,7 @@
           "Serilog.Sinks.File": "[5.0.0, )",
           "Serilog.Sinks.Seq": "[6.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.2.0, )",
-          "System.Text.Json": "[8.0.1, )"
+          "System.Text.Json": "[8.0.2, )"
         }
       },
       "dragaliaapi.database": {
@@ -1856,9 +1856,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[6.16.0, )",
-        "resolved": "6.16.0",
-        "contentHash": "xOgh6oPWXVcjJ+8tzPniXLlz64skRpPgh5x/jY5s54Xy0fy7/WVWI5YwKirvJgJAl8CvJzikvEpNXVXTAStCqA==",
+        "requested": "[6.17.0, )",
+        "resolved": "6.17.0",
+        "contentHash": "f5WmJxdqvKK9zdk/3s80OLxeA80qWzzXlTasy0NKZ1eUxH6SdRDvfURDKj9H1pJ6Simc78pMDxpZXdfxoOVy9A==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "8.0.2",
           "Microsoft.AspNetCore.Components.Web": "8.0.2",
@@ -2001,9 +2001,9 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "29KA2StjWDYp32FvREifawRtNpTziLE1xyuDV9pVQ+MsaE9bIcIieP0io/eZZeLMxR+Nx9zI55RtUtpVpEIdeg==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -138,5 +138,9 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbSummonTicket>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbPlayerStoryState>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IUnitRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IUnitRepository.cs
@@ -12,15 +12,11 @@ public interface IUnitRepository
     IQueryable<DbAbilityCrest> AbilityCrests { get; }
     IQueryable<DbTalisman> Talismans { get; }
 
-    Task<bool> CheckHasCharas(IEnumerable<Charas> idList);
-
-    Task<bool> CheckHasDragons(IEnumerable<Dragons> idList);
-
     Task<IEnumerable<(Charas id, bool isNew)>> AddCharas(IEnumerable<Charas> idList);
 
     Task<bool> AddCharas(Charas id);
 
-    Task<IEnumerable<(Dragons id, bool isNew)>> AddDragons(IEnumerable<Dragons> idList);
+    Task<IEnumerable<(Dragons Id, bool IsNew)>> AddDragons(IEnumerable<Dragons> idList);
 
     Task<bool> AddDragons(Dragons id);
 

--- a/DragaliaAPI/DragaliaAPI.Database/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Database/packages.lock.json
@@ -559,7 +559,7 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
+        "requested": "[8.0.2, )",
         "resolved": "8.0.0",
         "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
         "dependencies": {

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
@@ -2100,7 +2100,7 @@
           "Microsoft.IdentityModel.Tokens": "[7.3.1, )",
           "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.19.6, )",
           "Microsoft.VisualStudio.Web.CodeGeneration.Design": "[8.0.1, )",
-          "MudBlazor": "[6.16.0, )",
+          "MudBlazor": "[6.17.0, )",
           "Riok.Mapperly": "[3.5.0-next.1, )",
           "Serilog": "[3.1.1, )",
           "Serilog.AspNetCore": "[8.0.1, )",
@@ -2112,7 +2112,7 @@
           "Serilog.Sinks.File": "[5.0.0, )",
           "Serilog.Sinks.Seq": "[6.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.2.0, )",
-          "System.Text.Json": "[8.0.1, )"
+          "System.Text.Json": "[8.0.2, )"
         }
       },
       "dragaliaapi.database": {
@@ -2400,9 +2400,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[6.16.0, )",
-        "resolved": "6.16.0",
-        "contentHash": "xOgh6oPWXVcjJ+8tzPniXLlz64skRpPgh5x/jY5s54Xy0fy7/WVWI5YwKirvJgJAl8CvJzikvEpNXVXTAStCqA==",
+        "requested": "[6.17.0, )",
+        "resolved": "6.17.0",
+        "contentHash": "f5WmJxdqvKK9zdk/3s80OLxeA80qWzzXlTasy0NKZ1eUxH6SdRDvfURDKj9H1pJ6Simc78pMDxpZXdfxoOVy9A==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "8.0.2",
           "Microsoft.AspNetCore.Components.Web": "8.0.2",
@@ -2545,9 +2545,9 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "29KA2StjWDYp32FvREifawRtNpTziLE1xyuDV9pVQ+MsaE9bIcIieP0io/eZZeLMxR+Nx9zI55RtUtpVpEIdeg==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/packages.lock.json
@@ -1430,7 +1430,7 @@
           "Microsoft.IdentityModel.Tokens": "[7.3.1, )",
           "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.19.6, )",
           "Microsoft.VisualStudio.Web.CodeGeneration.Design": "[8.0.1, )",
-          "MudBlazor": "[6.16.0, )",
+          "MudBlazor": "[6.17.0, )",
           "Riok.Mapperly": "[3.5.0-next.1, )",
           "Serilog": "[3.1.1, )",
           "Serilog.AspNetCore": "[8.0.1, )",
@@ -1442,7 +1442,7 @@
           "Serilog.Sinks.File": "[5.0.0, )",
           "Serilog.Sinks.Seq": "[6.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.2.0, )",
-          "System.Text.Json": "[8.0.1, )"
+          "System.Text.Json": "[8.0.2, )"
         }
       },
       "dragaliaapi.database": {
@@ -1710,9 +1710,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[6.16.0, )",
-        "resolved": "6.16.0",
-        "contentHash": "xOgh6oPWXVcjJ+8tzPniXLlz64skRpPgh5x/jY5s54Xy0fy7/WVWI5YwKirvJgJAl8CvJzikvEpNXVXTAStCqA==",
+        "requested": "[6.17.0, )",
+        "resolved": "6.17.0",
+        "contentHash": "f5WmJxdqvKK9zdk/3s80OLxeA80qWzzXlTasy0NKZ1eUxH6SdRDvfURDKj9H1pJ6Simc78pMDxpZXdfxoOVy9A==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "8.0.2",
           "Microsoft.AspNetCore.Components.Web": "8.0.2",
@@ -1855,9 +1855,9 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "29KA2StjWDYp32FvREifawRtNpTziLE1xyuDV9pVQ+MsaE9bIcIieP0io/eZZeLMxR+Nx9zI55RtUtpVpEIdeg==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/DragaliaAPI/DragaliaAPI.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Test/packages.lock.json
@@ -1792,7 +1792,7 @@
           "Microsoft.IdentityModel.Tokens": "[7.3.1, )",
           "Microsoft.VisualStudio.Azure.Containers.Tools.Targets": "[1.19.6, )",
           "Microsoft.VisualStudio.Web.CodeGeneration.Design": "[8.0.1, )",
-          "MudBlazor": "[6.16.0, )",
+          "MudBlazor": "[6.17.0, )",
           "Riok.Mapperly": "[3.5.0-next.1, )",
           "Serilog": "[3.1.1, )",
           "Serilog.AspNetCore": "[8.0.1, )",
@@ -1804,7 +1804,7 @@
           "Serilog.Sinks.File": "[5.0.0, )",
           "Serilog.Sinks.Seq": "[6.0.0, )",
           "System.IdentityModel.Tokens.Jwt": "[7.2.0, )",
-          "System.Text.Json": "[8.0.1, )"
+          "System.Text.Json": "[8.0.2, )"
         }
       },
       "dragaliaapi.database": {
@@ -2107,9 +2107,9 @@
       },
       "MudBlazor": {
         "type": "CentralTransitive",
-        "requested": "[6.16.0, )",
-        "resolved": "6.16.0",
-        "contentHash": "xOgh6oPWXVcjJ+8tzPniXLlz64skRpPgh5x/jY5s54Xy0fy7/WVWI5YwKirvJgJAl8CvJzikvEpNXVXTAStCqA==",
+        "requested": "[6.17.0, )",
+        "resolved": "6.17.0",
+        "contentHash": "f5WmJxdqvKK9zdk/3s80OLxeA80qWzzXlTasy0NKZ1eUxH6SdRDvfURDKj9H1pJ6Simc78pMDxpZXdfxoOVy9A==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "8.0.2",
           "Microsoft.AspNetCore.Components.Web": "8.0.2",
@@ -2252,9 +2252,9 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "29KA2StjWDYp32FvREifawRtNpTziLE1xyuDV9pVQ+MsaE9bIcIieP0io/eZZeLMxR+Nx9zI55RtUtpVpEIdeg==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/RedoableSummonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/RedoableSummonController.cs
@@ -99,7 +99,7 @@ public class RedoableSummonController(
             cachedResult.Where(x => x.EntityType == EntityTypes.Chara).Select(x => (Charas)x.Id)
         );
 
-        IEnumerable<(Dragons id, bool isNew)> repositoryDragonOutput =
+        IEnumerable<(Dragons Id, bool IsNew)> repositoryDragonOutput =
             await unitRepository.AddDragons(
                 cachedResult
                     .Where(x => x.EntityType == EntityTypes.Dragon)
@@ -116,11 +116,11 @@ public class RedoableSummonController(
                 EntityId = (int)x.id
             });
         IEnumerable<AtgenDuplicateEntityList> newDragons = repositoryDragonOutput
-            .Where(x => x.isNew)
+            .Where(x => x.IsNew)
             .Select(x => new AtgenDuplicateEntityList()
             {
                 EntityType = EntityTypes.Dragon,
-                EntityId = (int)x.id
+                EntityId = (int)x.Id
             });
 
         return this.Ok(

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
@@ -256,8 +256,8 @@ public class SummonController(
                     .Select(x => (Dragons)x.Id)
             )
         )
-            .Where(x => x.isNew)
-            .Select(x => x.id)
+            .Where(x => x.IsNew)
+            .Select(x => x.Id)
             .ToList();
 
         List<Charas> newCharas = (

--- a/DragaliaAPI/DragaliaAPI/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI/packages.lock.json
@@ -197,9 +197,9 @@
       },
       "MudBlazor": {
         "type": "Direct",
-        "requested": "[6.16.0, )",
-        "resolved": "6.16.0",
-        "contentHash": "xOgh6oPWXVcjJ+8tzPniXLlz64skRpPgh5x/jY5s54Xy0fy7/WVWI5YwKirvJgJAl8CvJzikvEpNXVXTAStCqA==",
+        "requested": "[6.17.0, )",
+        "resolved": "6.17.0",
+        "contentHash": "f5WmJxdqvKK9zdk/3s80OLxeA80qWzzXlTasy0NKZ1eUxH6SdRDvfURDKj9H1pJ6Simc78pMDxpZXdfxoOVy9A==",
         "dependencies": {
           "Microsoft.AspNetCore.Components": "8.0.2",
           "Microsoft.AspNetCore.Components.Web": "8.0.2",
@@ -317,9 +317,9 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "7AWk2za1hSEJBppe/Lg+uDcam2TrDqwIKa9XcPssSwyjC2xa39EKEGul3CO5RWNF+hMuZG4zlBDrvhBdDTg4lg==",
+        "requested": "[8.0.2, )",
+        "resolved": "8.0.2",
+        "contentHash": "29KA2StjWDYp32FvREifawRtNpTziLE1xyuDV9pVQ+MsaE9bIcIieP0io/eZZeLMxR+Nx9zI55RtUtpVpEIdeg==",
         "dependencies": {
           "System.Text.Encodings.Web": "8.0.0"
         }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/packages.lock.json
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/packages.lock.json
@@ -914,7 +914,7 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
+        "requested": "[8.0.2, )",
         "resolved": "8.0.0",
         "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
         "dependencies": {

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/packages.lock.json
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/packages.lock.json
@@ -486,7 +486,7 @@
       },
       "System.Text.Json": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
+        "requested": "[8.0.2, )",
         "resolved": "8.0.0",
         "contentHash": "OdrZO2WjkiEG6ajEFRABTRCi/wuXQPxeV6g8xvUJqdxMvvuCCEk86zPla8UiIQJz3durtUEbNyY/3lIhS0yZvQ==",
         "dependencies": {


### PR DESCRIPTION
When adding a character, if it is not already owned by the player a story will always be added. This is not a problem for normal gameplay logic, but several players have run into issues after removing characters from their save and leaving their stories behind.

Fix this by adding an extra check for a story in the UnitRepository. Also misc. tidying up since that code is oold