### PR TITLE
Fix dragon gift reset

### DIFF
--- a/.github/workflows/test-report.yaml
+++ b/.github/workflows/test-report.yaml
@@ -22,6 +22,6 @@ jobs:
       - name: Generate report
         uses: dorny/test-reporter@v1
         with:
-          name: test report
+          name: ${{ github.event.workflow_run.name }} report
           path: "*.trx"
           reporter: dotnet-trx

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,6 +23,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="8.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.3" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.3.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.2" />

--- a/DragaliaAPI/DragaliaAPI.Database.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/packages.lock.json
@@ -32,11 +32,11 @@
       },
       "MockQueryable.Moq": {
         "type": "Direct",
-        "requested": "[7.0.0, )",
-        "resolved": "7.0.0",
-        "contentHash": "1NWkaZui2eNXEHxzQUWJkuJjKCnayJ6T7mRVpDLWX0RHnr5MGlP/2LTFWa9xG6ym5G/+nein/iVmwsx2yt5l8Q==",
+        "requested": "[7.0.1, )",
+        "resolved": "7.0.1",
+        "contentHash": "QjnZUJAxycebM2Hdy3BdAxtZspSOS9K+CVpYrUNKKneo2b5IArqyxcVmymAGfbaoUQoBEkY6dd6Q/OiWrKrucw==",
         "dependencies": {
-          "MockQueryable.EntityFrameworkCore": "7.0.0",
+          "MockQueryable.EntityFrameworkCore": "7.0.1",
           "Moq": "4.8.0"
         }
       },
@@ -802,8 +802,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -828,20 +828,20 @@
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },
@@ -1086,16 +1086,16 @@
       },
       "MockQueryable.Core": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "uLMBgYeUgaHLiUemXO7mNmyngY/a/uK1O0EsLK9jmeKwsq/0+aFjjdtotTpy7a/3LyPrEsJT7B855QUeZ69lYA=="
+        "resolved": "7.0.1",
+        "contentHash": "FDJW6C2o5y74uGOvf/WXYg3GhMymUyvFk+yuRsMQBgofiVRVhUczCR2LfDokWHouO8BBmQmPFQBDp18CxyoeLA=="
       },
       "MockQueryable.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "T4VhG4T8gHuERxOM/HlR6MvU8/GHpOVZzIlNTXb4ranJGt9O8N8KkR76wNPYX8ZDWp3zqs5L4A0HnzLIfHIRRg==",
+        "resolved": "7.0.1",
+        "contentHash": "b7SMcPxacVuzWOCdXjUgtGKEIzQB6bBj9tbV0mEXNqRAdlZou5V4H0XHZZfz3jh+5jP5FWScOkNak1cXpQiE5A==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "7.0.0",
-          "MockQueryable.Core": "7.0.0"
+          "MockQueryable.Core": "7.0.1"
         }
       },
       "Mono.TextTemplating": {
@@ -1565,10 +1565,10 @@
           "DragaliaAPI.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": "[8.0.2, )",
           "Microsoft.AspNetCore.TestHost": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.1, )",
+          "Microsoft.EntityFrameworkCore": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.2, )",
           "Serilog": "[3.1.1, )"
         }
@@ -1703,27 +1703,27 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
@@ -1740,11 +1740,11 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -142,5 +142,9 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbPlayerStoryState>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbPlayerDragonGift>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
@@ -19,10 +19,4 @@ public interface IInventoryRepository
 
     Task<bool> CheckQuantity(IEnumerable<KeyValuePair<Materials, int>> quantityMap);
     Task<bool> CheckQuantity(Materials materialId, int quantity);
-
-    DbPlayerDragonGift AddDragonGift(DragonGifts giftId, int quantity);
-
-    Task<DbPlayerDragonGift?> GetDragonGift(DragonGifts materialId);
-
-    Task RefreshPurchasableDragonGiftCounts();
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IInventoryRepository.cs
@@ -7,8 +7,6 @@ public interface IInventoryRepository
 {
     IQueryable<DbPlayerMaterial> Materials { get; }
 
-    IQueryable<DbPlayerDragonGift> DragonGifts { get; }
-
     DbPlayerMaterial AddMaterial(Materials type);
 
     Task<DbPlayerMaterial?> GetMaterial(Materials materialId);

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -30,11 +30,6 @@ public class InventoryRepository : IInventoryRepository
             storage.ViewerId == this.playerIdentityService.ViewerId
         );
 
-    public IQueryable<DbPlayerDragonGift> DragonGifts =>
-        this.apiContext.PlayerDragonGifts.Where(gifts =>
-            gifts.ViewerId == this.playerIdentityService.ViewerId
-        );
-
     public DbPlayerMaterial AddMaterial(Materials type)
     {
         return apiContext

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -144,45 +144,4 @@ public class InventoryRepository : IInventoryRepository
 
         return true;
     }
-
-    public DbPlayerDragonGift AddDragonGift(DragonGifts giftId, int quantity) =>
-        apiContext
-            .PlayerDragonGifts.Add(
-                new DbPlayerDragonGift()
-                {
-                    ViewerId = this.playerIdentityService.ViewerId,
-                    DragonGiftId = giftId,
-                    Quantity = quantity
-                }
-            )
-            .Entity;
-
-    public async Task<DbPlayerDragonGift?> GetDragonGift(DragonGifts giftId)
-    {
-        return await this.apiContext.PlayerDragonGifts.FindAsync(
-            this.playerIdentityService.ViewerId,
-            giftId
-        );
-    }
-
-    public async Task RefreshPurchasableDragonGiftCounts()
-    {
-        Dictionary<DragonGifts, DbPlayerDragonGift> dbGifts = await DragonGifts.ToDictionaryAsync(
-            x => x.DragonGiftId
-        );
-        foreach (
-            DragonGifts gift in Enum.GetValues<DragonGifts>()
-                .Where(x => x < DragonGiftsEnum.FourLeafClover)
-        )
-        {
-            if (dbGifts.TryGetValue(gift, out DbPlayerDragonGift? dbGift))
-            {
-                dbGift.Quantity = 1;
-            }
-            else
-            {
-                this.AddDragonGift(gift, 1);
-            }
-        }
-    }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Database/packages.lock.json
@@ -23,27 +23,27 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "Direct",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "Direct",
@@ -60,11 +60,11 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
@@ -193,28 +193,28 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/DragaliaAPI.Integration.Test.csproj
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/DragaliaAPI.Integration.Test.csproj
@@ -5,6 +5,7 @@
         <PackageReference Include="MartinCostello.Logging.XUnit"/>
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"/>
         <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
         <PackageReference Include="Microsoft.NET.Test.Sdk"/>
         <PackageReference Include="Moq"/>
         <PackageReference Include="Respawn"/>

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -52,7 +52,7 @@ public class LoginTest : TestFixture
             .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 100));
 
         this.MockTimeProvider.SetUtcNow(
-            new DateTimeOffset(2024, 03, 18, 23, 13, 59, TimeSpan.Zero)
+            new DateTimeOffset(2049, 03, 15, 23, 13, 59, TimeSpan.Zero)
         ); // Monday
 
         await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -39,101 +39,51 @@ public class LoginTest : TestFixture
             .ApiContext.PlayerDragonGifts.Where(x => x.ViewerId == ViewerId)
             .ExecuteUpdateAsync(entity => entity.SetProperty(x => x.Quantity, 0));
 
-        (await this.GetDragonGifts()).Should().AllSatisfy(x => x.Quantity.Should().Be(0));
+        await this
+            .ApiContext.PlayerDragonGifts.Where(x =>
+                x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.GoldenChalice
+            )
+            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 1));
+
+        await this
+            .ApiContext.PlayerDragonGifts.Where(x =>
+                x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.FourLeafClover
+            )
+            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 100));
+
+        this.MockTimeProvider.SetUtcNow(
+            new DateTimeOffset(2024, 03, 18, 23, 13, 59, TimeSpan.Zero)
+        ); // Monday
 
         await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
 
-        (await this.GetDragonGifts())
+        List<DbPlayerDragonGift> dbPlayerDragonGifts = await this.GetDragonGifts();
+
+        dbPlayerDragonGifts
+            .Where(x => x.DragonGiftId <= DragonGifts.HeartyStew)
             .Should()
-            .BeEquivalentTo(
-                new List<DbPlayerDragonGift>()
-                {
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.FreshBread,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.TastyMilk,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.StrawberryTart,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.HeartyStew,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.Kaleidoscope,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.FloralCirclet,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.CompellingBook,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.JuicyMeat,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.ManaEssence,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.GoldenChalice,
-                        Quantity = 1
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.FourLeafClover,
-                        Quantity = 0
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.DragonyuleCake,
-                        Quantity = 0
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.ValentinesCard,
-                        Quantity = 0
-                    },
-                    new()
-                    {
-                        ViewerId = ViewerId,
-                        DragonGiftId = DragonGifts.PupGrub,
-                        Quantity = 0
-                    }
-                }
+            .AllSatisfy(
+                x => x.Quantity.Should().Be(1),
+                because: "purchasable gifts should be reset"
             );
+
+        dbPlayerDragonGifts
+            .Should()
+            .Contain(x => x.DragonGiftId == DragonGifts.GoldenChalice)
+            .Which.Quantity.Should()
+            .Be(0, because: "the previous day's rotating gift should no longer be available");
+
+        dbPlayerDragonGifts
+            .Should()
+            .Contain(x => x.DragonGiftId == DragonGifts.JuicyMeat)
+            .Which.Quantity.Should()
+            .Be(1, because: "the current day's rotating gift should be made available");
+
+        dbPlayerDragonGifts
+            .Should()
+            .Contain(x => x.DragonGiftId == DragonGifts.FourLeafClover)
+            .Which.Quantity.Should()
+            .Be(100, because: "the reset action should not affect stored gifts");
     }
 
     [Fact]
@@ -451,7 +401,7 @@ public class LoginTest : TestFixture
                 .FirstAsync(x => x.ViewerId == ViewerId)
         ).DailySummonCount;
 
-    private async Task<IEnumerable<DbPlayerDragonGift>> GetDragonGifts() =>
+    private async Task<List<DbPlayerDragonGift>> GetDragonGifts() =>
         await this
             .ApiContext.PlayerDragonGifts.AsNoTracking()
             .Where(x => x.ViewerId == ViewerId)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
@@ -53,6 +53,15 @@
           "System.IO.Pipelines": "8.0.0"
         }
       },
+      "Microsoft.Extensions.TimeProvider.Testing": {
+        "type": "Direct",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "t6iLSj9LwVaNA/Em4PS8mAMqg87HVFD6PhBS2gF3f1oouVF+xPLPtGS0dalTeLlulMCB4Dq1xx6U/Zjly5mIgg==",
+        "dependencies": {
+          "Microsoft.Bcl.TimeProvider": "8.0.1"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[17.8.0, )",
@@ -802,6 +811,11 @@
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "3aeMZ1N0lJoSyzqiP03hqemtb1BijhsJADdobn/4nsMJ8V1H+CrpuduUe4hlRdx+ikBQju1VGjMD1GJ3Sk05Eg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "C7kWHJnMRY7EvJev2S8+yJHZ1y7A4ZlLbA4NE+O23BDIAN5mHeqND1m+SKv1ChRS5YlCDW7yAMUe7lttRsJaAA=="
       },
       "Microsoft.Build": {
         "type": "Transitive",

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/packages.lock.json
@@ -984,8 +984,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -1010,20 +1010,20 @@
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },
@@ -2123,10 +2123,10 @@
           "DragaliaAPI.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": "[8.0.2, )",
           "Microsoft.AspNetCore.TestHost": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.1, )",
+          "Microsoft.EntityFrameworkCore": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.2, )",
           "Serilog": "[3.1.1, )"
         }
@@ -2261,27 +2261,27 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
@@ -2298,11 +2298,11 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/packages.lock.json
@@ -760,8 +760,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -786,20 +786,20 @@
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },
@@ -1451,10 +1451,10 @@
           "DragaliaAPI.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": "[8.0.2, )",
           "Microsoft.AspNetCore.TestHost": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.1, )",
+          "Microsoft.EntityFrameworkCore": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.2, )",
           "Serilog": "[3.1.1, )"
         }
@@ -1578,27 +1578,27 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
@@ -1615,11 +1615,11 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Login/LoginControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Login/LoginControllerTest.cs
@@ -63,10 +63,10 @@ public class LoginControllerTest
 
         this.mockDailyResetAction.Setup(x => x.Apply()).Returns(Task.CompletedTask);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync())
+        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default(CancellationToken)))
             .ReturnsAsync(new UpdateDataList());
 
-        await this.loginController.Index();
+        await this.loginController.Index(default(CancellationToken));
 
         this.mockDateTimeProvider.VerifyAll();
         this.mockRewardService.VerifyAll();
@@ -85,10 +85,10 @@ public class LoginControllerTest
         this.mockResetHelper.SetupGet(x => x.LastDailyReset)
             .Returns(DateTimeOffset.UtcNow.AddHours(-1));
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync())
+        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default(CancellationToken)))
             .ReturnsAsync(new UpdateDataList());
 
-        await this.loginController.Index();
+        await this.loginController.Index(default(CancellationToken));
 
         this.mockDateTimeProvider.VerifyAll();
         this.mockRewardService.VerifyAll();

--- a/DragaliaAPI/DragaliaAPI.Test/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI.Test/packages.lock.json
@@ -52,11 +52,11 @@
       },
       "MockQueryable.Moq": {
         "type": "Direct",
-        "requested": "[7.0.0, )",
-        "resolved": "7.0.0",
-        "contentHash": "1NWkaZui2eNXEHxzQUWJkuJjKCnayJ6T7mRVpDLWX0RHnr5MGlP/2LTFWa9xG6ym5G/+nein/iVmwsx2yt5l8Q==",
+        "requested": "[7.0.1, )",
+        "resolved": "7.0.1",
+        "contentHash": "QjnZUJAxycebM2Hdy3BdAxtZspSOS9K+CVpYrUNKKneo2b5IArqyxcVmymAGfbaoUQoBEkY6dd6Q/OiWrKrucw==",
         "dependencies": {
-          "MockQueryable.EntityFrameworkCore": "7.0.0",
+          "MockQueryable.EntityFrameworkCore": "7.0.1",
           "Moq": "4.8.0"
         }
       },
@@ -847,8 +847,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -873,20 +873,20 @@
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },
@@ -1322,16 +1322,16 @@
       },
       "MockQueryable.Core": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "uLMBgYeUgaHLiUemXO7mNmyngY/a/uK1O0EsLK9jmeKwsq/0+aFjjdtotTpy7a/3LyPrEsJT7B855QUeZ69lYA=="
+        "resolved": "7.0.1",
+        "contentHash": "FDJW6C2o5y74uGOvf/WXYg3GhMymUyvFk+yuRsMQBgofiVRVhUczCR2LfDokWHouO8BBmQmPFQBDp18CxyoeLA=="
       },
       "MockQueryable.EntityFrameworkCore": {
         "type": "Transitive",
-        "resolved": "7.0.0",
-        "contentHash": "T4VhG4T8gHuERxOM/HlR6MvU8/GHpOVZzIlNTXb4ranJGt9O8N8KkR76wNPYX8ZDWp3zqs5L4A0HnzLIfHIRRg==",
+        "resolved": "7.0.1",
+        "contentHash": "b7SMcPxacVuzWOCdXjUgtGKEIzQB6bBj9tbV0mEXNqRAdlZou5V4H0XHZZfz3jh+5jP5FWScOkNak1cXpQiE5A==",
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "7.0.0",
-          "MockQueryable.Core": "7.0.0"
+          "MockQueryable.Core": "7.0.1"
         }
       },
       "Mono.TextTemplating": {
@@ -1801,10 +1801,10 @@
           "DragaliaAPI.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": "[8.0.2, )",
           "Microsoft.AspNetCore.TestHost": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.1, )",
+          "Microsoft.EntityFrameworkCore": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.2, )",
           "Serilog": "[3.1.1, )"
         }
@@ -1819,7 +1819,7 @@
           "FluentAssertions": "[6.12.0, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[8.0.2, )",
           "Microsoft.NET.Test.Sdk": "[17.8.0, )",
-          "MockQueryable.Moq": "[7.0.0, )",
+          "MockQueryable.Moq": "[7.0.1, )",
           "Moq": "[4.20.70, )",
           "xunit": "[2.7.0, )"
         }
@@ -1945,27 +1945,27 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
@@ -1991,11 +1991,11 @@
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },

--- a/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
@@ -1,18 +1,71 @@
-using DragaliaAPI.Database.Repositories;
+using System.Collections.Frozen;
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Utils;
+using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Features.Login;
 
-public class DragonGiftResetAction : IDailyResetAction
+public class DragonGiftResetAction(
+    ApiContext apiContext,
+    TimeProvider timeProvider,
+    IPlayerIdentityService playerIdentityService
+) : IDailyResetAction
 {
-    private readonly IInventoryRepository inventoryRepository;
-
-    public DragonGiftResetAction(IInventoryRepository inventoryRepository)
-    {
-        this.inventoryRepository = inventoryRepository;
-    }
+    private static readonly FrozenSet<DragonGifts> AlwaysPurchasableGifts =
+        Enum.GetValues<DragonGifts>().Where(x => x < DragonGifts.JuicyMeat).ToFrozenSet();
 
     public async Task Apply()
     {
-        await this.inventoryRepository.RefreshPurchasableDragonGiftCounts();
+        Dictionary<DragonGifts, DbPlayerDragonGift> dbGifts = await apiContext
+            .PlayerDragonGifts.AsTracking()
+            .ToDictionaryAsync(x => x.DragonGiftId);
+
+        foreach (DragonGifts giftId in AlwaysPurchasableGifts)
+        {
+            if (!dbGifts.TryGetValue(giftId, out DbPlayerDragonGift? dbGift))
+            {
+                dbGift = new DbPlayerDragonGift()
+                {
+                    ViewerId = playerIdentityService.ViewerId,
+                    DragonGiftId = giftId,
+                };
+
+                apiContext.PlayerDragonGifts.Add(dbGift);
+            }
+
+            dbGift.Quantity = 1;
+        }
+
+        DayOfWeek todayDayOfWeek = timeProvider.GetUtcNow().DayOfWeek;
+
+        foreach (
+            (DragonGifts dailyGiftId, int dayNo) in DragonConstants.RotatingGifts.Select(
+                (x, index) => (x, index)
+            )
+        )
+        {
+            if (!dbGifts.TryGetValue(dailyGiftId, out DbPlayerDragonGift? dbGift))
+            {
+                dbGift = new DbPlayerDragonGift()
+                {
+                    ViewerId = playerIdentityService.ViewerId,
+                    DragonGiftId = dailyGiftId,
+                };
+
+                apiContext.PlayerDragonGifts.Add(dbGift);
+            }
+
+            if (dayNo == (int)todayDayOfWeek)
+            {
+                dbGift.Quantity = 1;
+            }
+            else
+            {
+                dbGift.Quantity = 0;
+            }
+        }
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Login/LoginController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/LoginController.cs
@@ -59,7 +59,7 @@ public class LoginController : DragaliaControllerBase
 
     [HttpPost]
     [Route("index")]
-    public async Task<DragaliaResult> Index()
+    public async Task<DragaliaResult> Index(CancellationToken cancellationToken)
     {
         LoginIndexResponse resp = new();
 
@@ -86,7 +86,7 @@ public class LoginController : DragaliaControllerBase
         resp.LoginLotteryRewardList = Enumerable.Empty<AtgenLoginLotteryRewardList>();
         resp.ExchangeSummomPointList = Enumerable.Empty<AtgenExchangeSummomPointList>();
         resp.MonthlyWallReceiveList = Enumerable.Empty<AtgenMonthlyWallReceiveList>();
-        resp.UpdateDataList = await this.updateDataService.SaveChangesAsync();
+        resp.UpdateDataList = await this.updateDataService.SaveChangesAsync(cancellationToken);
         resp.EntityResult = this.rewardService.GetEntityResult();
         resp.ServerTime = DateTimeOffset.UtcNow;
 

--- a/DragaliaAPI/DragaliaAPI/packages.lock.json
+++ b/DragaliaAPI/DragaliaAPI/packages.lock.json
@@ -1047,8 +1047,8 @@
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "s8C8xbwMb79EqzTaIhwiBrYtbv6ATnUW19pJed4fKVgN5K4VPQ7JUGqBLztknvD6EJIMKrfRnINGTjnZghrDGw==",
+        "resolved": "8.0.3",
+        "contentHash": "1euU97SivROH7nVIh2c/V63e0nQ73Txr/YlysB7fJuTV8LcfeL9WO1gdiJWcRIDoq8/McxcTc7evY6JJ1pD95w==",
         "dependencies": {
           "SQLitePCLRaw.core": "2.1.6"
         }
@@ -1073,20 +1073,20 @@
       },
       "Microsoft.EntityFrameworkCore.Relational": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "NoGfcq2OPw0z8XAPf74YFwGlTKjedWdsIEJqq4SvKcPjcu+B+/XDDNrDRxTvILfz4Ug8POSF49s1jz1JvUqTAg==",
+        "resolved": "8.0.3",
+        "contentHash": "8JnVZHWaNFkrrD/FC0O4jekiHIYey8y6TQ4Co3OzLz0wd5Dm1cwJfTp++1TvaVu0BBd4bVDtiktppa5epuoPrA==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore": "8.0.2",
+          "Microsoft.EntityFrameworkCore": "8.0.3",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Sqlite.Core": {
         "type": "Transitive",
-        "resolved": "8.0.1",
-        "contentHash": "kmNSZbVxbRFn1tRySkzRJFa2lNE1olgGyCB1FzcReua6jMkyRxr6v9rTv/idNVkSGHSnHitlu4DvZ//y1YFzjA==",
+        "resolved": "8.0.3",
+        "contentHash": "6DvYtnLdpViXgA5F2Z/cIJfWIv31Eby5j2YqUzr+sgJulKtCX+ypvmfooXlYnCwJDlcmIaMY27TMnlrCcUvZmA==",
         "dependencies": {
-          "Microsoft.Data.Sqlite.Core": "8.0.1",
-          "Microsoft.EntityFrameworkCore.Relational": "8.0.1",
+          "Microsoft.Data.Sqlite.Core": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.3",
           "Microsoft.Extensions.DependencyModel": "8.0.0"
         }
       },
@@ -1697,10 +1697,10 @@
           "DragaliaAPI.Shared": "[1.0.0, )",
           "Microsoft.AspNetCore.DataProtection.EntityFrameworkCore": "[8.0.2, )",
           "Microsoft.AspNetCore.TestHost": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.2, )",
-          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.1, )",
+          "Microsoft.EntityFrameworkCore": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Abstractions": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Analyzers": "[8.0.3, )",
+          "Microsoft.EntityFrameworkCore.Sqlite": "[8.0.3, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[8.0.2, )",
           "Serilog": "[3.1.1, )"
         }
@@ -1733,35 +1733,35 @@
       },
       "Microsoft.EntityFrameworkCore": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "6QlvBx4rdawW3AkkCsGVV+8qRLk34aknV5JD40s1hbVR18vKmT2KDl2DW83nHcPX7f4oebQ3BD1UMNCI/gkE0g==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "QUPQbeq4yCjgIL/6PzkhfwhljXmai3CNOsErWFJ/WJ1Z41V8+At0Bi4PT8/2pX25kPgf83g0CUKIZd0QbeKT4A==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.2",
-          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.2",
+          "Microsoft.EntityFrameworkCore.Abstractions": "8.0.3",
+          "Microsoft.EntityFrameworkCore.Analyzers": "8.0.3",
           "Microsoft.Extensions.Caching.Memory": "8.0.0",
           "Microsoft.Extensions.Logging": "8.0.0"
         }
       },
       "Microsoft.EntityFrameworkCore.Abstractions": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "DjDKp++BTKFZmX+xLTow7grQTY+pImKfhGW68Zf8myiL3zyJ3b8RZbnLsWGNCqKQIF6hJIz/zA/zmERobFwV0A=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "cW+SKdx34wZ25ZVKCpk/6+6z27wrZlQ1qXyx7UWpy34s9CyAojH0QiYlV/2owNOGSAH67rm+LxAjUOicsqlGzQ=="
       },
       "Microsoft.EntityFrameworkCore.Analyzers": {
         "type": "CentralTransitive",
-        "requested": "[8.0.2, )",
-        "resolved": "8.0.2",
-        "contentHash": "LI7awhc0fiAKvcUemsqxXUWqzAH9ywTSyM1rpC1un4p5SE1bhr5nRLvyRVbKRzKakmnNNY3to8NPDnoySEkxVw=="
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "3csRAzz5O5Gn+GQBMyLn26OICtEo2/U2iDDygQhKb3LnC78bAUvutkMqvb0Ek5A6uHrBcZQrKQJfkgfnRT5XZw=="
       },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "CentralTransitive",
-        "requested": "[8.0.1, )",
-        "resolved": "8.0.1",
-        "contentHash": "9OF1gaBzZy/eYwogfNCXkkA0t6jy/Wcno6o9dzT27P1yZ3bdKSR45OqOLsa2+lN+QLJaiv8pJSIWymugfdLQyA==",
+        "requested": "[8.0.3, )",
+        "resolved": "8.0.3",
+        "contentHash": "mdHNwlJkV71pKJU1MzIbjHWyjLw03S2kCO6mnuZL6V7uDv5ZxncoT5OELUiv7wRAYxnBucrl7ZPT76hwhBKBFw==",
         "dependencies": {
-          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.1",
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.3",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },


### PR DESCRIPTION
On daily reset:
- Only grant today's rotating gift
- Clear expired rotating gifts

In general:
- Remove repo methods in favour of global query filters