### PR TITLE
Fix change tracker error with rotating gifts

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
@@ -34,6 +34,8 @@ public class DragonGiftResetAction(
                 };
 
                 apiContext.PlayerDragonGifts.Add(dbGift);
+
+                dbGifts[giftId] = dbGift;
             }
 
             dbGift.Quantity = 1;
@@ -56,6 +58,8 @@ public class DragonGiftResetAction(
                 };
 
                 apiContext.PlayerDragonGifts.Add(dbGift);
+
+                dbGifts[dailyGiftId] = dbGift;
             }
 
             if (dayNo == (int)todayDayOfWeek)


### PR DESCRIPTION
Golden chalice appears twice in the rotating gift list, so we must continually update the dict as we go along