### PR TITLE
Fix golden chalice

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
@@ -43,11 +43,7 @@ public class DragonGiftResetAction(
 
         DayOfWeek todayDayOfWeek = timeProvider.GetUtcNow().DayOfWeek;
 
-        foreach (
-            (DragonGifts dailyGiftId, int dayNo) in DragonConstants.RotatingGifts.Select(
-                (x, index) => (x, index)
-            )
-        )
+        foreach (DragonGifts dailyGiftId in DragonConstants.RotatingGifts)
         {
             if (!dbGifts.TryGetValue(dailyGiftId, out DbPlayerDragonGift? dbGift))
             {
@@ -62,7 +58,7 @@ public class DragonGiftResetAction(
                 dbGifts[dailyGiftId] = dbGift;
             }
 
-            if (dayNo == (int)todayDayOfWeek)
+            if (DragonConstants.RotatingGifts[(int)todayDayOfWeek] == dailyGiftId)
             {
                 dbGift.Quantity = 1;
             }


### PR DESCRIPTION
New dragon gift reset algorithm in #728 will wipe the golden chalice on Saturdays because it sees that it's also Sundays gift