### PR TITLE
Use mapperly for /load/index re-attempt

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayer.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayer.cs
@@ -19,96 +19,75 @@ public class DbPlayer
 
     public int SavefileVersion { get; set; }
 
-    public virtual DbPlayerUserData? UserData { get; set; }
+    public DbPlayerUserData? UserData { get; set; }
 
-    public virtual ICollection<DbAbilityCrest> AbilityCrestList { get; set; } =
-        new List<DbAbilityCrest>();
+    public List<DbAbilityCrest> AbilityCrestList { get; set; } = [];
 
-    public virtual ICollection<DbAbilityCrestSet> AbilityCrestSetList { get; set; } =
-        new List<DbAbilityCrestSet>();
+    public List<DbAbilityCrestSet> AbilityCrestSetList { get; set; } = [];
 
-    public virtual ICollection<DbFortBuild> BuildList { get; set; } = new List<DbFortBuild>();
+    public List<DbFortBuild> BuildList { get; set; } = [];
 
-    public virtual ICollection<DbParty> PartyList { get; set; } = new List<DbParty>();
+    public List<DbParty> PartyList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerBannerData> UserSummonList { get; set; } =
-        new List<DbPlayerBannerData>();
+    public List<DbPlayerBannerData> UserSummonList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerCharaData> CharaList { get; set; } =
-        new List<DbPlayerCharaData>();
+    public List<DbPlayerCharaData> CharaList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerDragonData> DragonList { get; set; } =
-        new List<DbPlayerDragonData>();
+    public List<DbPlayerDragonData> DragonList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerDragonGift> DragonGiftList { get; set; } =
-        new List<DbPlayerDragonGift>();
+    public List<DbPlayerDragonGift> DragonGiftList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerDragonReliability> DragonReliabilityList { get; set; } =
-        new List<DbPlayerDragonReliability>();
+    public List<DbPlayerDragonReliability> DragonReliabilityList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerMaterial> MaterialList { get; set; } =
-        new List<DbPlayerMaterial>();
+    public List<DbPlayerMaterial> MaterialList { get; set; } = [];
 
-    public virtual ICollection<DbSetUnit> UnitSets { get; set; } = new List<DbSetUnit>();
+    public List<DbSetUnit> UnitSets { get; set; } = [];
 
-    public virtual ICollection<DbPlayerStoryState> StoryStates { get; set; } =
-        new List<DbPlayerStoryState>();
+    public List<DbPlayerStoryState> StoryStates { get; set; } = [];
 
-    public virtual ICollection<DbPlayerSummonHistory> SummonHistory { get; set; } =
-        new List<DbPlayerSummonHistory>();
+    public List<DbPlayerSummonHistory> SummonHistory { get; set; } = [];
 
-    public virtual ICollection<DbQuest> QuestList { get; set; } = new List<DbQuest>();
+    public List<DbQuest> QuestList { get; set; } = [];
 
-    public virtual ICollection<DbWeaponBody> WeaponBodyList { get; set; } =
-        new List<DbWeaponBody>();
+    public List<DbWeaponBody> WeaponBodyList { get; set; } = [];
 
-    public virtual ICollection<DbTalisman> TalismanList { get; set; } = new List<DbTalisman>();
+    public List<DbTalisman> TalismanList { get; set; } = [];
 
-    public virtual ICollection<DbWeaponSkin> WeaponSkinList { get; set; } =
-        new List<DbWeaponSkin>();
+    public List<DbWeaponSkin> WeaponSkinList { get; set; } = [];
 
-    public virtual ICollection<DbWeaponPassiveAbility> WeaponPassiveAbilityList { get; set; } =
-        new List<DbWeaponPassiveAbility>();
+    public List<DbWeaponPassiveAbility> WeaponPassiveAbilityList { get; set; } = [];
 
-    public virtual DbFortDetail? FortDetail { get; set; }
+    public DbFortDetail? FortDetail { get; set; }
 
-    public virtual ICollection<DbEquippedStamp> EquippedStampList { get; set; } =
-        new List<DbEquippedStamp>();
+    public List<DbEquippedStamp> EquippedStampList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerPresent> Presents { get; set; } =
-        new List<DbPlayerPresent>();
+    public List<DbPlayerPresent> Presents { get; set; } = [];
 
-    public virtual ICollection<DbPlayerPresentHistory> PresentHistory { get; set; } =
-        new List<DbPlayerPresentHistory>();
+    public List<DbPlayerPresentHistory> PresentHistory { get; set; } = [];
 
-    public virtual ICollection<DbPlayerDmodeChara> DmodeCharas { get; set; } =
-        new List<DbPlayerDmodeChara>();
+    public List<DbPlayerDmodeChara> DmodeCharas { get; set; } = [];
 
-    public virtual DbPlayerDmodeDungeon? DmodeDungeon { get; set; }
+    public DbPlayerDmodeDungeon? DmodeDungeon { get; set; }
 
-    public virtual DbPlayerDmodeExpedition? DmodeExpedition { get; set; }
+    public DbPlayerDmodeExpedition? DmodeExpedition { get; set; }
 
-    public virtual DbPlayerDmodeInfo? DmodeInfo { get; set; }
+    public DbPlayerDmodeInfo? DmodeInfo { get; set; }
 
-    public virtual ICollection<DbPlayerDmodeServitorPassive> DmodeServitorPassives { get; set; } =
-        new List<DbPlayerDmodeServitorPassive>();
+    public List<DbPlayerDmodeServitorPassive> DmodeServitorPassives { get; set; } = [];
 
-    public virtual DbPlayerShopInfo? ShopInfo { get; set; }
+    public DbPlayerShopInfo? ShopInfo { get; set; }
 
-    public virtual ICollection<DbQuestEvent> QuestEvents { get; set; } = new List<DbQuestEvent>();
+    public List<DbQuestEvent> QuestEvents { get; set; } = [];
 
-    public virtual DbPartyPower? PartyPower { get; set; }
+    public DbPartyPower? PartyPower { get; set; }
 
-    public virtual ICollection<DbQuestTreasureList> QuestTreasureList { get; set; } =
-        new List<DbQuestTreasureList>();
+    public List<DbQuestTreasureList> QuestTreasureList { get; set; } = [];
 
-    public virtual ICollection<DbPlayerQuestWall> QuestWalls { get; set; } =
-        new List<DbPlayerQuestWall>();
+    public List<DbPlayerQuestWall> QuestWalls { get; set; } = [];
 
-    public virtual ICollection<DbPlayerTrade> Trades { get; set; } = new List<DbPlayerTrade>();
+    public List<DbPlayerTrade> Trades { get; set; } = [];
 
-    public virtual ICollection<DbSummonTicket> SummonTickets { get; set; } =
-        new List<DbSummonTicket>();
+    public List<DbSummonTicket> SummonTickets { get; set; } = [];
 
-    public virtual ICollection<DbEmblem> Emblems { get; set; } = new List<DbEmblem>();
+    public List<DbEmblem> Emblems { get; set; } = [];
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -56,8 +56,6 @@ public class WeaponBodyTest : TestFixture
                         UnlockWeaponPassiveAbilityNoList = Enumerable.Repeat(0, 15),
                         IsNew = false,
                         GetTime = DateTimeOffset.UtcNow,
-                        SkillNo = 1,
-                        SkillLevel = 1,
                     }
                 }
             );

--- a/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
@@ -10,4 +10,10 @@ public static partial class CharaMapper
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
     [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
     public static partial CharaList ToCharaList(this DbPlayerCharaData dbModel);
+
+    [MapperRequiredMapping(RequiredMappingStrategy.Target)]
+    [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
+    public static partial IQueryable<CharaList> ProjectToCharaList(
+        this IQueryable<DbPlayerCharaData> query
+    );
 }

--- a/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
@@ -10,10 +10,4 @@ public static partial class CharaMapper
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
     [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
     public static partial CharaList ToCharaList(this DbPlayerCharaData dbModel);
-
-    [MapperRequiredMapping(RequiredMappingStrategy.Target)]
-    [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
-    public static partial IQueryable<CharaList> ProjectToCharaList(
-        this IQueryable<DbPlayerCharaData> query
-    );
 }

--- a/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/PartyMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/PartyMapper.cs
@@ -8,25 +8,9 @@ namespace DragaliaAPI.Mapping.Mapperly;
 public static partial class PartyMapper
 {
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
-    [MapProperty(
-        nameof(DbParty.Units),
-        nameof(PartyList.PartySettingList),
-        Use = nameof(MapToPartySettingListArray)
-    )]
+    [MapProperty(nameof(DbParty.Units), nameof(PartyList.PartySettingList))]
     public static partial PartyList ToPartyList(this DbParty dbEntity);
 
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
-    public static partial PartySettingList MapToPartySettingList(this DbPartyUnit dbEntity);
-
-    private static PartySettingList[] MapToPartySettingListArray(ICollection<DbPartyUnit> source)
-    {
-        PartySettingList[] target = new PartySettingList[source.Count];
-        int i = 0;
-        foreach (DbPartyUnit item in source)
-        {
-            target[i] = MapToPartySettingList(item);
-            i++;
-        }
-        return target;
-    }
+    public static partial PartySettingList? MapToPartySettingList(this DbPartyUnit dbEntity);
 }

--- a/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/WeaponBodyMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/WeaponBodyMapper.cs
@@ -4,10 +4,9 @@ using Riok.Mapperly.Abstractions;
 
 namespace DragaliaAPI.Mapping.Mapperly;
 
-[Mapper]
+[Mapper(IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Target)]
 public static partial class WeaponBodyMapper
 {
     [MapperRequiredMapping(RequiredMappingStrategy.Target)]
-    [MapProperty(nameof(DbWeaponBody.Ability2Level), nameof(WeaponBodyList.Ability2Levell))]
     public static partial WeaponBodyList ToWeaponBodyList(this DbWeaponBody dbEntity);
 }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -12158,9 +12158,6 @@ public partial class UserData
     [Key("tutorial_flag_list")]
     public IEnumerable<int> TutorialFlagList { get; set; } = [];
 
-    [Key("prologue_end_time")]
-    public DateTimeOffset PrologueEndTime { get; set; }
-
     [Key("fort_open_time")]
     public DateTimeOffset FortOpenTime { get; set; }
 

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -12589,18 +12589,6 @@ public partial class WeaponBodyList
     [Key("gettime")]
     public DateTimeOffset GetTime { get; set; }
 
-    [Key("skill_no")]
-    public int SkillNo { get; set; }
-
-    [Key("skill_level")]
-    public int SkillLevel { get; set; }
-
-    [Key("ability_1_level")]
-    public int Ability1Level { get; set; }
-
-    [Key("ability_2_levell")]
-    public int Ability2Levell { get; set; }
-
     public WeaponBodyList(
         WeaponBodies weaponBodyId,
         int buildupCount,

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/UserData.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/UserData.cs
@@ -1,4 +1,5 @@
 using MessagePack;
+using Microsoft.IdentityModel.Tokens;
 
 namespace DragaliaAPI.Models.Generated;
 
@@ -11,4 +12,7 @@ public partial class UserData
     [Key("max_amulet_quantity")]
     [Obsolete]
     public int MaxAmuletQuantity { get; set; }
+
+    [Key("prologue_end_time")]
+    public DateTimeOffset PrologueEndTime { get; set; } = DateTimeOffset.UnixEpoch;
 }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/WeaponBodyList.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/WeaponBodyList.cs
@@ -1,0 +1,24 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class WeaponBodyList
+{
+    /* These properties are not sent by the server, judging by the endgame_savefile.json in the API docs. */
+
+    [Obsolete]
+    [Key("skill_no")]
+    public int SkillNo { get; set; }
+
+    [Obsolete]
+    [Key("skill_level")]
+    public int SkillLevel { get; set; }
+
+    [Obsolete]
+    [Key("ability_1_level")]
+    public int Ability1Level { get; set; }
+
+    [Obsolete]
+    [Key("ability_2_levell")]
+    public int Ability2Levell { get; set; }
+}

--- a/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
@@ -229,6 +229,5 @@ public static partial class LoadMapper
     [MapProperty(nameof(DbAbilityCrest.AbilityLevel), nameof(AbilityCrestList.Ability2Level))]
     private static partial AbilityCrestList Map(DbAbilityCrest abilityCrest);
 
-    [MapProperty(nameof(DbWeaponBody.Ability2Level), nameof(WeaponBodyList.Ability2Levell))]
     private static partial WeaponBodyList Map(DbWeaponBody weaponBody);
 }

--- a/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
@@ -18,116 +18,217 @@ using Microsoft.Extensions.Options;
 namespace DragaliaAPI.Services.Game;
 
 public class LoadService(
-    ISavefileService savefileService,
     ApiContext apiContext,
     IBonusService bonusService,
-    IMapper mapper,
     ILogger<LoadService> logger,
     IOptionsMonitor<PhotonOptions> photonOptions,
     IMissionService missionService,
     IPresentService presentService,
     ITradeService tradeService,
-    IShopRepository shopRepository,
     IUserService userService,
-    IWallService wallService,
     TimeProvider timeProvider
 ) : ILoadService
 {
+    private static readonly DateTimeOffset QuestBonusStackBaseTime =
+        new(2021, 04, 07, 06, 00, 00, TimeSpan.Zero); // 7. April 2017
+
     public async Task<LoadIndexResponse> BuildIndexData()
     {
         Stopwatch stopwatch = new();
         stopwatch.Start();
 
-        DbPlayer savefile = await savefileService.Load().AsNoTracking().FirstAsync();
+        Savefile savefile = await apiContext
+            .Players.ProjectToSavefile()
+            .AsSplitQuery()
+            .AsNoTracking()
+            .FirstAsync();
 
         logger.LogInformation("{time} ms: Load query complete", stopwatch.ElapsedMilliseconds);
-
-        FortBonusList bonusList = await bonusService.GetBonusList();
-
-        logger.LogInformation("{time} ms: Bonus list acquired", stopwatch.ElapsedMilliseconds);
 
         // TODO/NOTE: special shop purchase list is not set here. maybe change once that fully works?
 
         LoadIndexResponse data =
             new()
             {
-                BuildList = savefile.BuildList.Select(mapper.Map<BuildList>),
-                UserData = mapper.Map<UserData>(savefile.UserData),
-                CharaList = savefile.CharaList.Select(mapper.Map<CharaList>),
-                DragonList = savefile.DragonList.Select(mapper.Map<DragonList>),
-                DragonReliabilityList = savefile.DragonReliabilityList.Select(
-                    mapper.Map<DragonReliabilityList>
+                BuildList = savefile.BuildList,
+                UserData = savefile.UserData,
+                CharaList = savefile.CharaList,
+                DragonList = savefile.DragonList,
+                DragonReliabilityList = savefile.DragonReliabilityList,
+                AbilityCrestList = savefile.AbilityCrestList,
+                TalismanList = savefile.TalismanList,
+                WeaponBodyList = savefile.WeaponBodyList,
+                PartyList = savefile.PartyList,
+                QuestList = savefile.QuestList,
+                QuestEventList = savefile.QuestEvents,
+                QuestTreasureList = savefile.QuestTreasureList,
+                QuestWallList = savefile.QuestWalls,
+                MaterialList = savefile.MaterialList,
+                WeaponSkinList = savefile.WeaponSkinList,
+                WeaponPassiveAbilityList = savefile.WeaponPassiveAbilityList,
+                PartyPowerData = savefile.PartyPower,
+                EquipStampList = savefile.EquippedStampList,
+                SummonTicketList = savefile.SummonTickets,
+
+                DragonGiftList = savefile.DragonGiftList.Where(x =>
+                    x.DragonGiftId > DragonGifts.GoldenChalice
                 ),
-                AbilityCrestList = savefile.AbilityCrestList.Select(mapper.Map<AbilityCrestList>),
-                DragonGiftList = savefile
-                    .DragonGiftList.Where(x => x.DragonGiftId > DragonGifts.GoldenChalice)
-                    .Select(mapper.Map<DragonGiftList>),
-                TalismanList = savefile.TalismanList.Select(mapper.Map<TalismanList>),
-                WeaponBodyList = savefile.WeaponBodyList.Select(mapper.Map<WeaponBodyList>),
-                PartyList = savefile.PartyList.Select(mapper.Map<PartyList>),
                 QuestStoryList = savefile
                     .StoryStates.Where(x => x.StoryType == StoryTypes.Quest)
-                    .Select(mapper.Map<QuestStoryList>),
+                    .Select(x => x.MapToQuestStoryList()),
                 UnitStoryList = savefile
-                    .StoryStates.Where(x =>
-                        x.StoryType == StoryTypes.Chara || x.StoryType == StoryTypes.Dragon
-                    )
-                    .Select(mapper.Map<UnitStoryList>),
+                    .StoryStates.Where(x => x.StoryType is StoryTypes.Chara or StoryTypes.Dragon)
+                    .Select(x => x.MapToUnitStoryList()),
                 CastleStoryList = savefile
                     .StoryStates.Where(x => x.StoryType == StoryTypes.Castle)
-                    .Select(mapper.Map<CastleStoryList>),
-                QuestList = savefile.QuestList.Select(mapper.Map<QuestList>),
-                QuestEventList = savefile.QuestEvents.Select(mapper.Map<QuestEventList>),
-                QuestTreasureList = savefile.QuestTreasureList.Select(
-                    mapper.Map<QuestTreasureList>
-                ),
-                MaterialList = savefile.MaterialList.Select(mapper.Map<MaterialList>),
-                WeaponSkinList = savefile.WeaponSkinList.Select(mapper.Map<WeaponSkinList>),
-                WeaponPassiveAbilityList = savefile.WeaponPassiveAbilityList.Select(
-                    mapper.Map<WeaponPassiveAbilityList>
-                ),
-                FortBonusList = bonusList,
-                PartyPowerData = mapper.Map<PartyPowerData>(savefile.PartyPower),
+                    .Select(x => x.MapToCastleStoryList()),
+                UserTreasureTradeList = savefile
+                    .Trades.Where(x => x.Type == TradeType.Treasure)
+                    .Select(x => x.MapToUserTreasureTradeList()),
+
                 FriendNotice = new(0, 0),
-                PresentNotice = await presentService.GetPresentNotice(),
+                ShopNotice = new ShopNotice(savefile.ShopInfo?.DailySummonCount != 0),
                 GuildNotice = new(0, false, false, false, false),
-                //fort_plant_list = buildSummary,
-                ServerTime = timeProvider.GetUtcNow(),
                 StaminaMultiSystemMax = userService.StaminaMultiMax,
                 StaminaMultiUserMax = 12,
+                QuestBonusStackBaseTime = QuestBonusStackBaseTime,
                 QuestSkipPointSystemMax = userService.QuestSkipPointMax,
                 QuestSkipPointUseLimitMax = 30,
-                FunctionalMaintenanceList = new List<FunctionalMaintenanceList>(),
+                QuestEntryConditionList = await missionService.GetEntryConditions(),
                 MultiServer = new()
                 {
                     Host = photonOptions.CurrentValue.ServerUrl,
                     AppId = string.Empty
                 },
-                MissionNotice = await missionService.GetMissionNotice(null),
-                EquipStampList = savefile
-                    .EquippedStampList.Select(mapper.Map<DbEquippedStamp, EquipStampList>)
-                    .OrderBy(x => x.Slot),
-                QuestEntryConditionList = await missionService.GetEntryConditions(),
-                UserTreasureTradeList = await tradeService.GetUserTreasureTradeList(),
+                ServerTime = timeProvider.GetUtcNow(),
                 TreasureTradeAllList = tradeService.GetCurrentTreasureTradeList(),
-                ShopNotice = new ShopNotice(await shopRepository.GetDailySummonCountAsync() == 0),
-                SummonTicketList = await apiContext
-                    .PlayerSummonTickets.ProjectToSummonTicketList()
-                    .ToListAsync(),
-                QuestBonusStackBaseTime = new DateTimeOffset(
-                    2021,
-                    04,
-                    07,
-                    06,
-                    00,
-                    00,
-                    TimeSpan.Zero
-                ), // 7. April 2017
-                AlbumDragonList = Enumerable.Empty<AlbumDragonData>(),
-                QuestWallList = await wallService.GetQuestWallList()
+                MissionNotice = await missionService.GetMissionNotice(null),
+                FortBonusList = await bonusService.GetBonusList(),
+                PresentNotice = await presentService.GetPresentNotice(),
+                FunctionalMaintenanceList = [],
             };
 
         logger.LogInformation("{time} ms: Mapping complete", stopwatch.ElapsedMilliseconds);
         return data;
     }
+}
+
+public class Savefile
+{
+    public required UserData UserData { get; set; }
+
+    public required PartyPowerData PartyPower { get; set; }
+
+    public IEnumerable<PartyList> PartyList { get; set; } = [];
+
+    public IEnumerable<CharaList> CharaList { get; set; } = [];
+
+    public IEnumerable<DragonList> DragonList { get; set; } = [];
+
+    public IEnumerable<QuestList> QuestList { get; set; } = [];
+
+    public IEnumerable<QuestEventList> QuestEvents { get; set; } = [];
+
+    public IEnumerable<MaterialList> MaterialList { get; set; } = [];
+
+    public IEnumerable<WeaponSkinList> WeaponSkinList { get; set; } = [];
+
+    public IEnumerable<WeaponBodyList> WeaponBodyList { get; set; } = [];
+
+    public IEnumerable<WeaponPassiveAbilityList> WeaponPassiveAbilityList { get; set; } = [];
+
+    public IEnumerable<AbilityCrestList> AbilityCrestList { get; set; } = [];
+
+    public IEnumerable<TalismanList> TalismanList { get; set; } = [];
+
+    public IEnumerable<DragonReliabilityList> DragonReliabilityList { get; set; } = [];
+
+    public IEnumerable<DragonGiftList> DragonGiftList { get; set; } = [];
+
+    public IEnumerable<EquipStampList> EquippedStampList { get; set; } = [];
+
+    public IEnumerable<GenericStory> StoryStates { get; set; } = [];
+
+    public IEnumerable<QuestTreasureList> QuestTreasureList { get; set; } = [];
+
+    public IEnumerable<QuestWallList> QuestWalls { get; set; } = [];
+
+    public IEnumerable<BuildList> BuildList { get; set; } = [];
+
+    public IEnumerable<SummonTicketList> SummonTickets { get; set; } = [];
+
+    public IEnumerable<GenericTrade> Trades { get; set; } = [];
+
+    public DbPlayerShopInfo? ShopInfo { get; set; }
+}
+
+public class GenericStory
+{
+    public int StoryId { get; set; }
+
+    public StoryTypes StoryType { get; set; }
+
+    public StoryState State { get; set; }
+}
+
+public class GenericTrade
+{
+    public TradeType Type { get; set; }
+
+    public required int Id { get; set; }
+
+    public int Count { get; set; }
+
+    public DateTimeOffset LastTradeTime { get; set; } = DateTimeOffset.UnixEpoch;
+}
+
+[Mapper(
+    RequiredMappingStrategy = RequiredMappingStrategy.Target,
+    IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Target
+)]
+public static partial class LoadMapper
+{
+    public static partial IQueryable<Savefile> ProjectToSavefile(this IQueryable<DbPlayer> query);
+
+    public static UnitStoryList MapToUnitStoryList(this GenericStory story) =>
+        new() { UnitStoryId = story.StoryId, IsRead = story.State == StoryState.Read, };
+
+    public static QuestStoryList MapToQuestStoryList(this GenericStory story) =>
+        new() { QuestStoryId = story.StoryId, State = story.State };
+
+    public static CastleStoryList MapToCastleStoryList(this GenericStory story) =>
+        new() { CastleStoryId = story.StoryId, IsRead = story.State == StoryState.Read };
+
+    public static UserTreasureTradeList MapToUserTreasureTradeList(this GenericTrade trade) =>
+        new()
+        {
+            TreasureTradeId = trade.Id,
+            TradeCount = trade.Count,
+            LastResetTime = trade.LastTradeTime
+        };
+
+    [MapProperty(nameof(DbPlayerDragonData.Level), nameof(DragonReliabilityList.ReliabilityLevel))]
+    [MapProperty(nameof(DbPlayerDragonData.Exp), nameof(DragonReliabilityList.ReliabilityTotalExp))]
+    private static partial DragonReliabilityList Map(this DbPlayerDragonReliability dbEntity);
+
+    [MapProperty(nameof(DbParty.Units), nameof(PartyList.PartySettingList))]
+    private static partial PartyList Map(this DbParty dbEntity);
+
+    [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
+    private static partial CharaList Map(DbPlayerCharaData playerCharaData);
+
+    [MapperIgnoreTarget(nameof(UserData.AgeGroup))]
+    [MapperIgnoreTarget(nameof(UserData.IsOptin))]
+    [MapperIgnoreTarget(nameof(UserData.PrologueEndTime))]
+    private static partial UserData Map(DbPlayerUserData userData);
+
+    [MapperIgnoreTarget(nameof(DragonList.StatusPlusCount))]
+    private static partial DragonList Map(DbPlayerDragonData dragonData);
+
+    [MapProperty(nameof(DbAbilityCrest.AbilityLevel), nameof(AbilityCrestList.Ability1Level))]
+    [MapProperty(nameof(DbAbilityCrest.AbilityLevel), nameof(AbilityCrestList.Ability2Level))]
+    private static partial AbilityCrestList Map(DbAbilityCrest abilityCrest);
+
+    [MapProperty(nameof(DbWeaponBody.Ability2Level), nameof(WeaponBodyList.Ability2Levell))]
+    private static partial WeaponBodyList Map(DbWeaponBody weaponBody);
 }

--- a/DragaliaAPI/DragaliaAPI/Services/Game/SavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/SavefileService.cs
@@ -551,34 +551,6 @@ public class SavefileService : ISavefileService
         await this.Create();
     }
 
-    public IQueryable<DbPlayer> Load()
-    {
-        return this
-            .apiContext.Players.Where(x => x.AccountId == this.playerIdentityService.AccountId)
-            .Include(x => x.UserData)
-            .Include(x => x.AbilityCrestList)
-            .Include(x => x.CharaList)
-            .Include(x => x.DragonList)
-            .Include(x => x.DragonReliabilityList)
-            .Include(x => x.DragonGiftList)
-            .Include(x => x.BuildList)
-            .Include(x => x.QuestList)
-            .Include(x => x.StoryStates)
-            .Include(x => x.PartyList)
-            .ThenInclude(x => x.Units.OrderBy(x => x.UnitNo))
-            .Include(x => x.TalismanList)
-            .Include(x => x.WeaponBodyList)
-            .Include(x => x.MaterialList)
-            .Include(x => x.WeaponSkinList)
-            .Include(x => x.WeaponPassiveAbilityList)
-            .Include(x => x.EquippedStampList)
-            .Include(x => x.QuestEvents)
-            .Include(x => x.PartyPower)
-            .Include(x => x.QuestTreasureList)
-            .Include(x => x.QuestWalls)
-            .AsSplitQuery();
-    }
-
     public async Task<DbPlayer> Create()
     {
         string deviceAccountId = this.playerIdentityService.AccountId;

--- a/DragaliaAPI/DragaliaAPI/Services/ISavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/ISavefileService.cs
@@ -7,7 +7,6 @@ public interface ISavefileService
 {
     Task ThreadSafeImport(LoadIndexResponse savefile);
     Task Import(LoadIndexResponse savefile);
-    IQueryable<DbPlayer> Load();
     Task Reset();
     Task<DbPlayer> Create();
     Task<DbPlayer> Create(string deviceAccountId);


### PR DESCRIPTION
This was merged in #714 but reverted because people were being kicked to the tutorial en masse. I think the issue was a missing `Where` in LoadService when accessing the players table :roll_eyes: Would explain why this worked fine in a test environment.