### PR TITLE
Sort units in parties from /load/index

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.1" />
     <PackageVersion Include="MudBlazor" Version="6.17.0" />
-    <PackageVersion Include="Riok.Mapperly" Version="3.5.0-next.1" />
+    <PackageVersion Include="Riok.Mapperly" Version="3.5.0-next.3" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Expressions" Version="4.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.0" />

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Load/LoadIndexTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Load/LoadIndexTest.cs
@@ -1,0 +1,18 @@
+namespace DragaliaAPI.Integration.Test.Features.Load;
+
+public class LoadIndexTest : TestFixture
+{
+    public LoadIndexTest(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
+        : base(factory, testOutputHelper) { }
+
+    [Fact]
+    public async Task LoadIndex_ReturnsPartyUnitsInSortedOrder()
+    {
+        DragaliaResponse<LoadIndexResponse> resp = await this.Client.PostMsgpack<LoadIndexResponse>(
+            "/load/index"
+        );
+
+        resp.Data.PartyList.Should()
+            .AllSatisfy(x => x.PartySettingList.Should().BeInAscendingOrder(y => y.UnitNo));
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/LoadService.cs
@@ -217,6 +217,12 @@ public static partial class LoadMapper
     [MapProperty(nameof(DbParty.Units), nameof(PartyList.PartySettingList))]
     private static partial PartyList Map(this DbParty dbEntity);
 
+    private static partial PartySettingList Map(DbPartyUnit dbEntity);
+
+    private static IEnumerable<PartySettingList?> MapOrderedUnitList(
+        ICollection<DbPartyUnit> dbEntity
+    ) => dbEntity.OrderBy(x => x.UnitNo).Select(x => Map(x));
+
     [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
     private static partial CharaList Map(DbPlayerCharaData playerCharaData);
 


### PR DESCRIPTION
#744 appears to have introduced a regression where party units are not sorted when returned from /load/index, leading to players seeing strange "Your party data has been updated" messages.

Have upgraded to a prerelease mapperly as it allows us to inline the sorting as part of the db query. See https://next.mapperly.riok.app/docs/configuration/queryable-projections/#user-implemented-mapping-methods