### PR TITLE
Fix Harle / Origa being unobtainable

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/UnitRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/UnitRepositoryTest.cs
@@ -28,39 +28,10 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
 
         this.unitRepository = new UnitRepository(
             fixture.ApiContext,
-            this.mockPlayerIdentityService.Object,
-            LoggerTestUtils.Create<UnitRepository>()
+            this.mockPlayerIdentityService.Object
         );
 
         this.fixture.ApiContext.ChangeTracker.Clear();
-    }
-
-    [Fact]
-    public async Task GetAllCharaData_ValidId_ReturnsData()
-    {
-        await this.fixture.AddToDatabase(new DbPlayerCharaData(1, Charas.Akasha));
-
-        (await this.unitRepository.Charas.ToListAsync()).Should().NotBeEmpty();
-    }
-
-    [Fact]
-    public async Task GetAllCharaData_InvalidId_ReturnsEmpty()
-    {
-        this.mockPlayerIdentityService.SetupGet(x => x.ViewerId).Returns(400);
-
-        await this.fixture.AddToDatabase(DbPlayerDragonDataFactory.Create(1, Dragons.Nyarlathotep));
-
-        (await this.unitRepository.Charas.ToListAsync()).Should().BeEmpty();
-    }
-
-    [Fact]
-    public async Task GetAllCharaData_ReturnsOnlyDataForGivenId()
-    {
-        await this.fixture.AddToDatabase(new DbPlayerCharaData(1, Charas.Ilia));
-
-        (await this.unitRepository.Charas.ToListAsync())
-            .Should()
-            .AllSatisfy(x => x.ViewerId.Should().Be(ViewerId));
     }
 
     [Fact]
@@ -81,10 +52,10 @@ public class UnitRepositoryTest : IClassFixture<DbTestFixture>
     [Fact]
     public async Task GetAllDragonData_ReturnsOnlyDataForGivenId()
     {
-        await this.fixture.AddToDatabase(new DbPlayerCharaData(ViewerId, Charas.Ilia));
-        await this.fixture.AddToDatabase(new DbPlayerCharaData(244, Charas.Ilia));
+        await this.fixture.AddToDatabase(DbPlayerDragonDataFactory.Create(ViewerId, Dragons.Agni));
+        await this.fixture.AddToDatabase(DbPlayerDragonDataFactory.Create(444, Dragons.Agni));
 
-        (await this.unitRepository.Charas.ToListAsync())
+        (await this.unitRepository.Dragons.ToListAsync())
             .Should()
             .AllSatisfy(x => x.ViewerId.Should().Be(ViewerId));
     }

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -136,6 +136,10 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder
+            .Entity<DbPlayerCharaData>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
             .Entity<DbSummonTicket>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
 
@@ -145,6 +149,10 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
 
         modelBuilder
             .Entity<DbPlayerDragonGift>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbPlayerStoryState>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IStoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IStoryRepository.cs
@@ -6,11 +6,6 @@ namespace DragaliaAPI.Database.Repositories;
 public interface IStoryRepository
 {
     /// <summary>
-    /// Gets the quest/unit stories for a user.
-    /// </summary>
-    IQueryable<DbPlayerStoryState> Stories { get; }
-
-    /// <summary>
     /// Gets the quests for a user.
     /// </summary>
     IQueryable<DbPlayerStoryState> QuestStories { get; }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IUnitRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IUnitRepository.cs
@@ -5,7 +5,6 @@ namespace DragaliaAPI.Database.Repositories;
 
 public interface IUnitRepository
 {
-    IQueryable<DbPlayerCharaData> Charas { get; }
     IQueryable<DbPlayerDragonData> Dragons { get; }
     IQueryable<DbPlayerDragonReliability> DragonReliabilities { get; }
     IQueryable<DbWeaponBody> WeaponBodies { get; }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/StoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/StoryRepository.cs
@@ -23,21 +23,16 @@ public class StoryRepository : IStoryRepository
         this.logger = logger;
     }
 
-    public IQueryable<DbPlayerStoryState> Stories =>
-        this.apiContext.PlayerStoryState.Where(x =>
-            x.ViewerId == this.playerIdentityService.ViewerId
-        );
-
     public IQueryable<DbPlayerStoryState> UnitStories =>
-        this.Stories.Where(x =>
+        this.apiContext.PlayerStoryState.Where(x =>
             x.StoryType == StoryTypes.Chara || x.StoryType == StoryTypes.Dragon
         );
 
     public IQueryable<DbPlayerStoryState> QuestStories =>
-        this.Stories.Where(x => x.StoryType == StoryTypes.Quest);
+        this.apiContext.PlayerStoryState.Where(x => x.StoryType == StoryTypes.Quest);
 
     public IQueryable<DbPlayerStoryState> DmodeStories =>
-        this.Stories.Where(x => x.StoryType == StoryTypes.DungeonMode);
+        this.apiContext.PlayerStoryState.Where(x => x.StoryType == StoryTypes.DungeonMode);
 
     public async Task<DbPlayerStoryState> GetOrCreateStory(StoryTypes storyType, int storyId)
     {

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/UnitRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/UnitRepository.cs
@@ -23,23 +23,12 @@ public class UnitRepository : IUnitRepository
 {
     private readonly ApiContext apiContext;
     private readonly IPlayerIdentityService playerIdentityService;
-    private readonly ILogger<UnitRepository> logger;
 
-    public UnitRepository(
-        ApiContext apiContext,
-        IPlayerIdentityService playerIdentityService,
-        ILogger<UnitRepository> logger
-    )
+    public UnitRepository(ApiContext apiContext, IPlayerIdentityService playerIdentityService)
     {
         this.apiContext = apiContext;
         this.playerIdentityService = playerIdentityService;
-        this.logger = logger;
     }
-
-    public IQueryable<DbPlayerCharaData> Charas =>
-        this.apiContext.PlayerCharaData.Where(x =>
-            x.ViewerId == this.playerIdentityService.ViewerId
-        );
 
     public IQueryable<DbPlayerDragonData> Dragons =>
         this.apiContext.PlayerDragonData.Where(x =>
@@ -107,8 +96,8 @@ public class UnitRepository : IUnitRepository
 
         // Generate result. The first occurrence of a character in the list should be new (if not in the DB)
         // but subsequent results should then not be labelled as new.
-        List<Charas> ownedCharas = await Charas
-            .Select(x => x.CharaId)
+        List<Charas> ownedCharas = await this
+            .apiContext.PlayerCharaData.Select(x => x.CharaId)
             .Where(x => enumeratedIdList.Contains(x))
             .ToListAsync();
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
@@ -69,8 +69,7 @@ public class CharaTest : TestFixture
         )
         {
             charaData = await this
-                .Services.GetRequiredService<IUnitRepository>()
-                .Charas.Where(x => x.CharaId == Charas.Celliera)
+                .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Celliera)
                 .FirstAsync();
 
             matQuantity = (

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/QuestReadStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/QuestReadStoryTest.cs
@@ -81,4 +81,20 @@ public class QuestReadStoryTest : TestFixture
 
         response.UpdateDataList.UserData.TutorialStatus.Should().Be(10600);
     }
+
+    [Theory]
+    [InlineData(2044303, Charas.Harle)]
+    [InlineData(2046203, Charas.Origa)]
+    [InlineData(2042704, Charas.Audric)]
+    public async Task ReadCompendiumStory_GrantsCharacter(int storyId, Charas expectedChara)
+    {
+        QuestReadStoryResponse response = (
+            await this.Client.PostMsgpack<QuestReadStoryResponse>(
+                "/quest/read_story",
+                new QuestReadStoryRequest() { QuestStoryId = storyId }
+            )
+        ).Data;
+
+        response.UpdateDataList.CharaList.Should().Contain(x => x.CharaId == expectedChara);
+    }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
@@ -124,7 +124,7 @@ public class GraphQlTest : GraphQlTestFixture
                     EntityLevel = 1,
                     EntityQuantity = 1,
                     ReceiveLimitTime = null,
-                    MessageId = PresentMessage.DragaliaLostTeam,
+                    MessageId = PresentMessage.DragaliaLostTeamMessage,
                 },
                 opts => opts.Excluding(x => x.CreateTime).Excluding(x => x.Owner)
             );

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
@@ -17,7 +17,7 @@ public class ISavefileUpdateTest : TestFixture
     public void ISavefileUpdate_HasExpectedCount()
     {
         // Update this test when adding a new update.
-        this.updates.Should().HaveCount(19);
+        this.updates.Should().HaveCount(20);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
@@ -1,0 +1,114 @@
+using DragaliaAPI.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
+
+public class V20UpdateTest : SavefileUpdateTestFixture
+{
+    private const int HarleStoryId = 2044303;
+    private const int OrigaStoryId = 2046203;
+
+    protected override int StartingVersion => 19;
+
+    public V20UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task V20Update_StoriesCompleted_AddsMissingCompendiumCharacters()
+    {
+        this.ApiContext.PlayerStoryState.AddRange(
+            [
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = HarleStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                },
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = OrigaStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                }
+            ]
+        );
+        await this.ApiContext.SaveChangesAsync();
+
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Harle);
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Origa);
+    }
+
+    [Fact]
+    public async Task V20Update_StoriesNotCompleted_DoesNotAddCharacters()
+    {
+        await this.AddRangeToDatabase(
+            [
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = HarleStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                },
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = OrigaStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                }
+            ]
+        );
+
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .NotContain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Harle);
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .NotContain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Origa);
+    }
+
+    [Fact]
+    public async Task V20Update_StoriesCompleted_CharactersOwned_DoesNotAddCharacters()
+    {
+        await this.AddRangeToDatabase(
+            [
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = HarleStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                },
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = OrigaStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                },
+                new DbPlayerCharaData(this.ViewerId, Charas.Harle),
+                new DbPlayerCharaData(this.ViewerId, Charas.Origa),
+            ]
+        );
+
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .NotContain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Harle);
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .NotContain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Origa);
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
@@ -16,39 +16,6 @@ public class V20UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V20Update_StoriesCompleted_AddsMissingCompendiumCharacters()
     {
-        this.ApiContext.PlayerStoryState.AddRange(
-            [
-                new DbPlayerStoryState()
-                {
-                    ViewerId = this.ViewerId,
-                    StoryId = HarleStoryId,
-                    StoryType = StoryTypes.Quest,
-                    State = StoryState.Read
-                },
-                new DbPlayerStoryState()
-                {
-                    ViewerId = this.ViewerId,
-                    StoryId = OrigaStoryId,
-                    StoryType = StoryTypes.Quest,
-                    State = StoryState.Read
-                }
-            ]
-        );
-        await this.ApiContext.SaveChangesAsync();
-
-        await this.LoadIndex();
-
-        this.ApiContext.PlayerPresents.AsNoTracking()
-            .Should()
-            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Harle);
-        this.ApiContext.PlayerPresents.AsNoTracking()
-            .Should()
-            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Origa);
-    }
-
-    [Fact]
-    public async Task V20Update_StoriesNotCompleted_DoesNotAddCharacters()
-    {
         await this.AddRangeToDatabase(
             [
                 new DbPlayerStoryState()
@@ -68,6 +35,38 @@ public class V20UpdateTest : SavefileUpdateTestFixture
             ]
         );
 
+        await this.LoadIndex();
+
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Harle);
+        this.ApiContext.PlayerPresents.AsNoTracking()
+            .Should()
+            .Contain(x => x.ViewerId == this.ViewerId && x.EntityId == (int)Charas.Origa);
+    }
+
+    [Fact]
+    public async Task V20Update_StoriesNotCompleted_DoesNotAddCharacters()
+    {
+        this.ApiContext.PlayerStoryState.AddRange(
+            [
+                new DbPlayerStoryState()
+                {
+                    Owner = new DbPlayer() { AccountId = "other player" },
+                    StoryId = HarleStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Read
+                },
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = OrigaStoryId,
+                    StoryType = StoryTypes.Quest,
+                    State = StoryState.Unlocked
+                }
+            ]
+        );
+        await this.ApiContext.SaveChangesAsync();
         await this.LoadIndex();
 
         this.ApiContext.PlayerPresents.AsNoTracking()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -121,7 +121,11 @@ public class TestFixture
     {
         foreach (IDbPlayerData entity in data)
         {
-            entity.ViewerId = this.ViewerId;
+            if (entity.ViewerId == default)
+            {
+                entity.ViewerId = this.ViewerId;
+            }
+
             this.ApiContext.Add(entity);
         }
 

--- a/DragaliaAPI/DragaliaAPI.Shared/Features/Presents/PresentMessage.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/Features/Presents/PresentMessage.cs
@@ -11,12 +11,21 @@ namespace DragaliaAPI.Shared.Features.Presents;
 /// </remarks>
 public enum PresentMessage
 {
+    None = 0,
+
+    /// <summary>
+    /// Title: A Gift from the Dragalia Lost Team
+    /// <br/>
+    /// A Gift from the Dragalia Lost Team
+    /// </summary>
+    DragaliaLostTeamGift = 1001000,
+
     /// <summary>
     /// Title: A Message from the Dragalia Lost Team
     /// <br/>
     /// Description: Accept this gift from the Dragalia Lost team as a thank-you for enjoying the game on a regular basis!
     /// </summary>
-    DragaliaLostTeam = 1003000,
+    DragaliaLostTeamMessage = 1003000,
 
     /// <summary>
     /// Title: Maintenance Gift

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/MasterAsset.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/MasterAsset.cs
@@ -1,4 +1,3 @@
-using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Definitions.Enums.EventItemTypes;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.MasterAsset.Models.Dmode;

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/MasterAssetData.cs
@@ -1,12 +1,9 @@
 ﻿using System.Collections.Frozen;
-using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Text.Json;
 using DragaliaAPI.Shared.Serialization;
 using MessagePack;
-using MessagePack.Resolvers;
 
 namespace DragaliaAPI.Shared.MasterAsset;
 

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeDungeonArea.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeDungeonArea.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.Dmode;
 

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeDungeonTheme.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeDungeonTheme.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace DragaliaAPI.Shared.MasterAsset.Models.Dmode;
+﻿namespace DragaliaAPI.Shared.MasterAsset.Models.Dmode;
 
 public record DmodeDungeonTheme(
     int Id,

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeWeapon.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Dmode/DmodeWeapon.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.Dmode;
 

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
@@ -30,8 +30,8 @@ public record EventData(
         int
     >()
     {
-        [20462] = 2046203, // Advent of the Origin    / Origa / Originally 2043803
         [20443] = 2044303, // Faith Forsaken Part One / Harle / Originally 2043803
+        [20462] = 2046203, // Advent of the Origin    / Origa / Originally 2043803
     }.ToFrozenDictionary();
 
     public int GetActualGuestJoinStoryId() =>

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
@@ -30,8 +30,8 @@ public record EventData(
         int
     >()
     {
-        [20462] = 2046203, // Advent of the Origin / Origa / Originally 2043803
-        [20443] = 2044303 // Faith Forsaken Part 1 / Harle / Originally 2043803
+        [20462] = 2046203, // Advent of the Origin    / Origa / Originally 2043803
+        [20443] = 2044303, // Faith Forsaken Part One / Harle / Originally 2043803
     }.ToFrozenDictionary();
 
     public int GetActualGuestJoinStoryId() =>

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Event/EventData.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Collections.Frozen;
 using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.Event;
@@ -20,4 +20,20 @@ public record EventData(
     int ViewEntityId5,
     Charas EventCharaId,
     int GuestJoinStoryId
-);
+)
+{
+    /// <summary>
+    /// Dictionary of [EventId, QuestStoryId] overrides for GuestJoinStoryId, where the master asset data is incorrect.
+    /// </summary>
+    private static readonly FrozenDictionary<int, int> OverrideGuestJoinStoryId = new Dictionary<
+        int,
+        int
+    >()
+    {
+        [20462] = 2046203, // Advent of the Origin / Origa / Originally 2043803
+        [20443] = 2044303 // Faith Forsaken Part 1 / Harle / Originally 2043803
+    }.ToFrozenDictionary();
+
+    public int GetActualGuestJoinStoryId() =>
+        OverrideGuestJoinStoryId.GetValueOrDefault(this.Id, this.GuestJoinStoryId);
+}

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Missions/MainStoryMissionGroupRewards.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Missions/MainStoryMissionGroupRewards.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.Missions;
 

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Missions/MissionProgressionInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/Missions/MissionProgressionInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Text.Json.Serialization;
-
-namespace DragaliaAPI.Shared.MasterAsset.Models.Missions;
+﻿namespace DragaliaAPI.Shared.MasterAsset.Models.Missions;
 
 public record MissionProgressionInfo(
     int Id,

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestData.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Photon.Shared.Enums;
+﻿using DragaliaAPI.Photon.Shared.Enums;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset.Models.Event;
 using MessagePack;

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestBonusReward.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestBonusReward.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
 

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestSchedule/QuestScheduleInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestSchedule/QuestScheduleInfo.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Serialization;
-using DragaliaAPI.Shared.Definitions.Enums;
+﻿using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestSchedule;
 

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/PartyControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/PartyControllerTest.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace DragaliaAPI.Test.Controllers;
 
-public class PartyControllerTest
+public class PartyControllerTest : RepositoryTestFixture
 {
     private readonly PartyController partyController;
 
@@ -42,7 +42,8 @@ public class PartyControllerTest
             this.mockLogger.Object,
             new Mock<IPartyPowerService>().Object,
             new Mock<IPartyPowerRepository>().Object,
-            this.mockMissionProgressionService.Object
+            this.mockMissionProgressionService.Object,
+            this.ApiContext
         );
         this.partyController.SetupMockContext();
     }

--- a/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
@@ -686,7 +686,6 @@ public class DragonServiceTest : RepositoryTestFixture
 
         stories = new List<DbPlayerStoryState>();
 
-        mockStoryRepository.SetupGet(x => x.Stories).Returns(stories.AsQueryable().BuildMock());
         mockStoryRepository
             .Setup(x =>
                 x.GetOrCreateStory(

--- a/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using DragaliaAPI.Controllers;
+using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Database.Utils;
@@ -28,7 +29,8 @@ public class CharaController(
     IPaymentService paymentService,
     IRewardService rewardService,
     TimeProvider timeProvider,
-    ICharaService charaService
+    ICharaService charaService,
+    ApiContext apiContext
 ) : DragaliaControllerBase
 {
     [HttpPost("awake")]
@@ -681,9 +683,9 @@ public class CharaController(
                     .StoryIds;
 
                 int nextStoryUnlockIndex =
-                    await storyRepository
-                        .Stories.Where(x => charaStories.Contains(x.StoryId))
-                        .CountAsync() + unlockedStories.Count;
+                    await apiContext.PlayerStoryState.CountAsync(x =>
+                        charaStories.Contains(x.StoryId)
+                    ) + unlockedStories.Count;
 
                 int nextStoryId = charaStories.ElementAtOrDefault(nextStoryUnlockIndex);
 

--- a/DragaliaAPI/DragaliaAPI/Features/DmodeDungeon/DmodeDungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/DmodeDungeon/DmodeDungeonService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Extensions;
@@ -18,10 +19,10 @@ namespace DragaliaAPI.Features.DmodeDungeon;
 public class DmodeDungeonService(
     IDmodeRepository dmodeRepository,
     IDmodeCacheService dmodeCacheService,
-    IUnitRepository unitRepository,
     IDmodeService dmodeService,
     ILogger<DmodeDungeonService> logger,
-    IRewardService rewardService
+    IRewardService rewardService,
+    ApiContext apiContext
 ) : IDmodeDungeonService
 {
     private const int MaxFloor = 60;
@@ -31,7 +32,7 @@ public class DmodeDungeonService(
         Charas charaId,
         int startFloor,
         int servitorId,
-        IEnumerable<Charas> editSkillCharaIds
+        IList<Charas> editSkillCharaIds
     )
     {
         DbPlayerDmodeDungeon dungeon = await dmodeRepository.GetDungeonAsync();
@@ -53,7 +54,7 @@ public class DmodeDungeonService(
         dungeon.IsPlayEnd = false;
         dungeon.QuestTime = 0;
 
-        DbPlayerCharaData chara = await unitRepository.Charas.SingleAsync(x =>
+        DbPlayerCharaData chara = await apiContext.PlayerCharaData.FirstAsync(x =>
             x.CharaId == charaId
         );
 

--- a/DragaliaAPI/DragaliaAPI/Features/DmodeDungeon/IDmodeDungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/DmodeDungeon/IDmodeDungeonService.cs
@@ -9,7 +9,7 @@ public interface IDmodeDungeonService
         Charas chara,
         int startFloor,
         int servitorId,
-        IEnumerable<Charas> editSkillCharaIds
+        IList<Charas> editSkillCharaIds
     );
 
     Task<(DungeonState State, DmodeIngameData IngameData)> RestartDungeon();

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/CharaMutations.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/CharaMutations.cs
@@ -52,9 +52,9 @@ public class CharaMutations : MutationBase
         db.SaveChanges();
 
         return (ctx) =>
-            ctx.PlayerCharaData.First(x =>
-                x.ViewerId == this.Player.ViewerId && x.CharaId == args.CharaId
-            );
+            ctx
+                .PlayerCharaData.IgnoreQueryFilters()
+                .First(x => x.ViewerId == this.Player.ViewerId && x.CharaId == args.CharaId);
     }
 
     [GraphQLArguments]

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/ImpersionationMutations.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/ImpersionationMutations.cs
@@ -40,7 +40,8 @@ public class ImpersionationMutations : MutationBase
 
         await this.sessionService.StartUserImpersonation(targetAccountId, targetViewerId);
 
-        return context => context.Players.First(x => x.AccountId == targetAccountId);
+        return context =>
+            context.Players.IgnoreQueryFilters().First(x => x.AccountId == targetAccountId);
     }
 
     [GraphQLMutation]

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/MissionMutations.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/MissionMutations.cs
@@ -156,7 +156,11 @@ public class MissionMutations : MutationBase
         DbPlayer player,
         MissionMutationArgs args
     ) =>
-        context.PlayerMissions.FirstOrDefault(x =>
-            x.Id == args.MissionId && x.Type == args.MissionType && x.ViewerId == player.ViewerId
-        ) ?? throw new InvalidOperationException("No mission found.");
+        context
+            .PlayerMissions.IgnoreQueryFilters()
+            .FirstOrDefault(x =>
+                x.Id == args.MissionId
+                && x.Type == args.MissionType
+                && x.ViewerId == player.ViewerId
+            ) ?? throw new InvalidOperationException("No mission found.");
 }

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/MutationBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/MutationBase.cs
@@ -24,6 +24,8 @@ public abstract class MutationBase
         Func<IQueryable<DbPlayer>, IQueryable<DbPlayer>>? include = null
     )
     {
+        IDisposable context = this.identityService.StartUserImpersonation(viewerId, null);
+
         IQueryable<DbPlayer> query = this.apiContext.Players.Where(x =>
             x.UserData != null && x.UserData.ViewerId == viewerId
         );
@@ -38,6 +40,6 @@ public abstract class MutationBase
 
         this.Player = player;
 
-        return this.identityService.StartUserImpersonation(viewerId, player.AccountId);
+        return context;
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/PresentMutations.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/PresentMutations.cs
@@ -43,14 +43,15 @@ public class PresentMutations : MutationBase
                 EntityType = args.EntityType,
                 EntityQuantity = args.EntityQuantity ?? 1,
                 EntityLevel = args.EntityLevel ?? 1,
-                MessageId = PresentMessage.DragaliaLostTeam,
+                MessageId = PresentMessage.DragaliaLostTeamMessage,
             };
 
         this.logger.LogInformation("Granting present {@present}", present);
         this.Player.Presents.Add(present);
         db.SaveChanges();
 
-        return (ctx) => ctx.PlayerPresents.First(x => x.PresentId == present.PresentId);
+        return (ctx) =>
+            ctx.PlayerPresents.IgnoreQueryFilters().First(x => x.PresentId == present.PresentId);
     }
 
     [GraphQLMutation("Clear a player's presents")]

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/Schema.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/Schema.cs
@@ -25,7 +25,8 @@ public static class Schema
                         new { viewerId = ArgumentHelper.Required<long>() },
                         (ctx, args) =>
                             ctx
-                                .Players.Include(x => x.UserData)
+                                .Players.IgnoreQueryFilters()
+                                .Include(x => x.UserData)
                                 .Include(x => x.AbilityCrestList)
                                 .Include(x => x.TalismanList)
                                 .Include(x => x.StoryStates)

--- a/DragaliaAPI/DragaliaAPI/Features/GraphQL/UserDataMutations.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/GraphQL/UserDataMutations.cs
@@ -43,7 +43,8 @@ public class UserDataMutations : MutationBase
         this.Player.UserData.TutorialStatus = args.NewStatus;
         db.SaveChanges();
 
-        return (ctx) => ctx.PlayerUserData.First(x => x.ViewerId == this.Player.ViewerId);
+        return (ctx) =>
+            ctx.PlayerUserData.IgnoreQueryFilters().First(x => x.ViewerId == this.Player.ViewerId);
     }
 
     [GraphQLMutation("Add a tutorial flag to a user.")]
@@ -65,7 +66,8 @@ public class UserDataMutations : MutationBase
         tutorialService.AddTutorialFlag(args.Flag);
         db.SaveChanges();
 
-        return (ctx) => ctx.PlayerUserData.First(x => x.ViewerId == this.Player.ViewerId);
+        return (ctx) =>
+            ctx.PlayerUserData.IgnoreQueryFilters().First(x => x.ViewerId == this.Player.ViewerId);
     }
 
     [GraphQLMutation("Remove a tutorial flag to a user.")]
@@ -91,7 +93,8 @@ public class UserDataMutations : MutationBase
         this.Player.UserData.TutorialFlagList = flagList;
         db.SaveChanges();
 
-        return (ctx) => ctx.PlayerUserData.First(x => x.ViewerId == this.Player.ViewerId);
+        return (ctx) =>
+            ctx.PlayerUserData.IgnoreQueryFilters().First(x => x.ViewerId == this.Player.ViewerId);
     }
 
     [GraphQLArguments]

--- a/DragaliaAPI/DragaliaAPI/Features/Login/LoginGiftResetAction.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/LoginGiftResetAction.cs
@@ -17,7 +17,7 @@ public class LoginGiftResetAction : IDailyResetAction
     {
         this.presentService.AddPresent(
             new Present.Present(
-                PresentMessage.DragaliaLostTeam,
+                PresentMessage.DragaliaLostTeamMessage,
                 EntityTypes.Material,
                 (int)Materials.ChampionsTestament,
                 5
@@ -26,7 +26,7 @@ public class LoginGiftResetAction : IDailyResetAction
 
         this.presentService.AddPresent(
             new Present.Present(
-                PresentMessage.DragaliaLostTeam,
+                PresentMessage.DragaliaLostTeamMessage,
                 EntityTypes.Material,
                 (int)Materials.KnightsTestament,
                 5
@@ -35,7 +35,7 @@ public class LoginGiftResetAction : IDailyResetAction
 
         this.presentService.AddPresent(
             new Present.Present(
-                PresentMessage.DragaliaLostTeam,
+                PresentMessage.DragaliaLostTeamMessage,
                 EntityTypes.Material,
                 (int)Materials.Omnicite
             )
@@ -43,7 +43,7 @@ public class LoginGiftResetAction : IDailyResetAction
 
         this.presentService.AddPresent(
             new Present.Present(
-                PresentMessage.DragaliaLostTeam,
+                PresentMessage.DragaliaLostTeamMessage,
                 EntityTypes.Material,
                 (int)Materials.TwinklingSand,
                 10
@@ -59,7 +59,7 @@ public class LoginGiftResetAction : IDailyResetAction
                 Materials.ShadowTome,
                 Materials.LightTome
             }.Select(x => new Present.Present(
-                PresentMessage.DragaliaLostTeam,
+                PresentMessage.DragaliaLostTeamMessage,
                 EntityTypes.Material,
                 (int)x,
                 5

--- a/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V20Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V20Update.cs
@@ -1,0 +1,71 @@
+using DragaliaAPI.Database;
+using DragaliaAPI.Features.Present;
+using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.Features.Presents;
+using DragaliaAPI.Shared.PlayerDetails;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.SavefileUpdate;
+
+/// <summary>
+/// Update to fix an issue where Harle and Origa were not correctly unlocked from the event compendium.
+/// </summary>
+[UsedImplicitly]
+public class V20Update(
+    ApiContext apiContext,
+    IPresentService presentService,
+    IPlayerIdentityService playerIdentityService,
+    ILogger<V20Update> logger
+) : ISavefileUpdate
+{
+    private const int HarleStoryId = 2044303;
+    private const int OrigaStoryId = 2046203;
+
+    public int SavefileVersion => 20;
+
+    public async Task Apply()
+    {
+        List<int> completedStoryIds = await apiContext
+            .PlayerStoryState.Where(x =>
+                x.StoryType == StoryTypes.Quest && x.State == StoryState.Read
+            )
+            .Where(x => x.StoryId == HarleStoryId || x.StoryId == OrigaStoryId)
+            .Select(x => x.StoryId)
+            .ToListAsync();
+
+        List<Charas> ownedCharaIds = await apiContext
+            .PlayerCharaData.Where(x => x.CharaId == Charas.Harle || x.CharaId == Charas.Origa)
+            .Select(x => x.CharaId)
+            .ToListAsync();
+
+        logger.LogDebug("Completed story IDs: {CompletedStoryIds}", completedStoryIds);
+        logger.LogDebug("Owned chara IDs: {OwnedCharaIds}", ownedCharaIds);
+
+        if (completedStoryIds.Contains(HarleStoryId) && !ownedCharaIds.Contains(Charas.Harle))
+        {
+            logger.LogInformation("Detected Harle as missing. Adding present.");
+
+            presentService.AddPresent(
+                new Present.Present(
+                    PresentMessage.DragaliaLostTeamGift,
+                    EntityTypes.Chara,
+                    (int)Charas.Harle
+                )
+            );
+        }
+
+        if (completedStoryIds.Contains(OrigaStoryId) && !ownedCharaIds.Contains(Charas.Origa))
+        {
+            logger.LogInformation("Detected Origa as missing. Adding present.");
+
+            presentService.AddPresent(
+                new Present.Present(
+                    PresentMessage.DragaliaLostTeamGift,
+                    EntityTypes.Chara,
+                    (int)Charas.Origa
+                )
+            );
+        }
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V9Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V9Update.cs
@@ -15,7 +15,6 @@ namespace DragaliaAPI.Features.SavefileUpdate;
 /// Fixes missing stories for 3* characters due to issue #358
 /// </summary>
 public class V9Update(
-    IUnitRepository unitRepository,
     IStoryRepository storyRepository,
     ApiContext apiContext,
     IPlayerIdentityService playerIdentityService,
@@ -27,8 +26,8 @@ public class V9Update(
     public async Task Apply()
     {
         IEnumerable<(Charas Id, SortedSet<int> ManaNodes)> charaManaData = (
-            await unitRepository
-                .Charas
+            await apiContext
+                .PlayerCharaData
                 /* .Where(x => x.Rarity == 3) // A 3-star character could have been upgraded */
                 .Where(x => x.CharaId != Charas.ThePrince && x.CharaId != Charas.MegaMan) // No stories
                 .Select(x => new { x.CharaId, x.ManaNodeUnlockCount })

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/ISummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/ISummonService.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Features.Summoning;
 
 public interface ISummonService
 {
-    List<AtgenResultUnitList> GenerateRewardList(
+    Task<List<AtgenResultUnitList>> GenerateRewardList(
         IEnumerable<AtgenRedoableSummonResultUnitList> baseRewardList
     );
 

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
@@ -46,15 +46,19 @@ public class SummonService(
     /// <summary>
     /// Populate a summon result with is_new and eldwater values.
     /// </summary>
-    public List<AtgenResultUnitList> GenerateRewardList(
+    public async Task<List<AtgenResultUnitList>> GenerateRewardList(
         IEnumerable<AtgenRedoableSummonResultUnitList> baseRewardList
     )
     {
         List<AtgenResultUnitList> newUnits = new();
 
-        IEnumerable<Charas> ownedCharas = unitRepository.Charas.Select(x => x.CharaId);
+        List<Charas> ownedCharas = await apiContext
+            .PlayerCharaData.Select(x => x.CharaId)
+            .ToListAsync();
 
-        IEnumerable<Dragons> ownedDragons = unitRepository.Dragons.Select(x => x.DragonId);
+        List<Dragons> ownedDragons = await unitRepository
+            .Dragons.Select(x => x.DragonId)
+            .ToListAsync();
 
         foreach (AtgenRedoableSummonResultUnitList reward in baseRewardList)
         {

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
@@ -972,13 +972,13 @@ public partial class DmodeDungeonStartRequest
     public int ServitorId { get; set; }
 
     [Key("bring_edit_skill_chara_id_list")]
-    public IEnumerable<Charas> BringEditSkillCharaIdList { get; set; }
+    public IList<Charas> BringEditSkillCharaIdList { get; set; }
 
     public DmodeDungeonStartRequest(
         Charas charaId,
         int startFloorNum,
         int servitorId,
-        IEnumerable<Charas> bringEditSkillCharaIdList
+        IList<Charas> bringEditSkillCharaIdList
     )
     {
         this.CharaId = charaId;
@@ -3562,7 +3562,7 @@ public partial class PartySetPartySettingRequest
     public int PartyNo { get; set; }
 
     [Key("request_party_setting_list")]
-    public IEnumerable<PartySettingList> RequestPartySettingList { get; set; } = [];
+    public IList<PartySettingList> RequestPartySettingList { get; set; } = [];
 
     [Key("party_name")]
     public string PartyName { get; set; }
@@ -3576,7 +3576,7 @@ public partial class PartySetPartySettingRequest
 
     public PartySetPartySettingRequest(
         int partyNo,
-        IEnumerable<PartySettingList> requestPartySettingList,
+        IList<PartySettingList> requestPartySettingList,
         string partyName,
         bool isEntrust,
         UnitElement entrustElement

--- a/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
@@ -208,8 +208,8 @@ public class DragonService(
             {
                 if (levelIndex == 1 || levelIndex == 3)
                 {
-                    int nextStoryUnlockIndex = await storyRepository
-                        .Stories.Where(x => dragonStories.Contains(x.StoryId))
+                    int nextStoryUnlockIndex = await apiContext
+                        .PlayerStoryState.Where(x => dragonStories.Contains(x.StoryId))
                         .CountAsync();
 
                     int nextStoryId = dragonStories.ElementAtOrDefault(nextStoryUnlockIndex);

--- a/DragaliaAPI/DragaliaAPI/Services/Game/StoryService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/StoryService.cs
@@ -238,7 +238,7 @@ public class StoryService(
         if (
             MasterAsset.EventData.TryGetValue(story.GroupId, out EventData? eventData)
             && eventData.IsMemoryEvent // Real events need to set is_temporary and do friendship points
-            && eventData.GuestJoinStoryId == storyId
+            && eventData.GetActualGuestJoinStoryId() == storyId
         )
         {
             logger.LogDebug("Granting memory event character {chara}", eventData.EventCharaId);

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Database.Entities;
+﻿using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Photon.Shared.Models;
@@ -17,6 +18,7 @@ public class MatchingService : IMatchingService
     private readonly IUserDataRepository userDataRepository;
     private readonly ILogger<MatchingService> logger;
     private readonly IPlayerIdentityService playerIdentityService;
+    private readonly ApiContext apiContext;
 
     public MatchingService(
         IPhotonStateApi photonStateApi,
@@ -24,7 +26,8 @@ public class MatchingService : IMatchingService
         IPartyRepository partyRepository,
         IUserDataRepository userDataRepository,
         ILogger<MatchingService> logger,
-        IPlayerIdentityService playerIdentityService
+        IPlayerIdentityService playerIdentityService,
+        ApiContext apiContext
     )
     {
         this.photonStateApi = photonStateApi;
@@ -33,6 +36,7 @@ public class MatchingService : IMatchingService
         this.userDataRepository = userDataRepository;
         this.logger = logger;
         this.playerIdentityService = playerIdentityService;
+        this.apiContext = apiContext;
     }
 
     public async Task<IEnumerable<RoomList>> GetRoomList()
@@ -147,7 +151,7 @@ public class MatchingService : IMatchingService
                 .GetPartyUnits(game.HostPartyNo)
                 .Where(x => x.UnitNo == 1)
                 .Join(
-                    unitRepository.Charas,
+                    this.apiContext.PlayerCharaData,
                     partyUnit => partyUnit.CharaId,
                     charaData => charaData.CharaId,
                     (partyUnit, charaData) => charaData


### PR DESCRIPTION
The GuestJoinStoryId for these events in the StoryData asset is inaccurate and refers to a story from outside of the event, so our mechanism to award them will never trigger.

Adds a custom overrides table to rectify this - these events appear to be the only ones affected based on the below query:

```sql
SELECT _Id FROM "EventData" 
WHERE _GuestJoinStoryId / 100 <> _Id AND _GuestJoinStoryId <> 0 AND _IsMemoryEvent = 1;
```

To-do:
- [x] Tests
- [x] Savefile update

Also did a bit of refactoring in our quest to remove repositories - added a global query filter to DbPlayerStoryState and DbPlayerCharaData i.e. the tables needed for the new savefile update. This also included refactoring PartyController a bit since I saw the validation code and almost cried at the looped db query.