### PR TITLE
Fix dragon's roost gifting softlock

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -338,6 +338,42 @@ public class DragonTest : TestFixture
     }
 
     [Fact]
+    public async Task DragonGiftSendMultiple_ReachLevel5_ReturnsExpectedRewardReliabilityList()
+    {
+        await this.AddToDatabase(
+            DbPlayerDragonReliabilityFactory.Create(ViewerId, Dragons.HighMercury)
+        );
+
+        DragonSendGiftMultipleRequest request = new DragonSendGiftMultipleRequest()
+        {
+            DragonId = Dragons.HighMercury,
+            DragonGiftId = DragonGifts.FourLeafClover,
+            Quantity = 1
+        };
+
+        DragonSendGiftMultipleResponse? response = (
+            await this.Client.PostMsgpack<DragonSendGiftMultipleResponse>(
+                "dragon/send_gift_multiple",
+                request
+            )
+        ).Data;
+
+        response
+            .RewardReliabilityList.Should()
+            .BeEquivalentTo(
+                new List<RewardReliabilityList>()
+                {
+                    new()
+                    {
+                        Level = 5,
+                        IsReleaseStory = true,
+                        LevelupEntityList = []
+                    }
+                }
+            );
+    }
+
+    [Fact]
     public async Task DragonSendGiftMultiple_CompletesMissionsCorrectly()
     {
         int missionId = 302600; // Reach Bond Lv. 30 with a Dragon

--- a/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
@@ -194,11 +194,7 @@ public class DragonService(
         RewardReliabilityList? reward = null;
         if (level > 4 && level % 5 == 0)
         {
-            reward = new RewardReliabilityList()
-            {
-                Level = level,
-                LevelupEntityList = new DragonRewardEntityList[1]
-            };
+            reward = new RewardReliabilityList() { Level = level, LevelupEntityList = [] };
             int levelIndex = level / 5;
             ImmutableArray<Materials> rewardMats = isPuppy ? PuppyLevelReward : DragonLevelReward;
             int[] rewardQuantity = isPuppy
@@ -208,6 +204,8 @@ public class DragonService(
             {
                 if (levelIndex == 1 || levelIndex == 3)
                 {
+                    reward.IsReleaseStory = true;
+
                     int nextStoryUnlockIndex = await apiContext
                         .PlayerStoryState.Where(x => dragonStories.Contains(x.StoryId))
                         .CountAsync();
@@ -217,7 +215,6 @@ public class DragonService(
                     if (nextStoryId != default)
                     {
                         await storyRepository.GetOrCreateStory(StoryTypes.Dragon, nextStoryId);
-                        reward.IsReleaseStory = true;
                     }
                     else
                     {
@@ -245,7 +242,7 @@ public class DragonService(
                 await inventoryRepository.GetMaterial((Materials)rewardItem.EntityId)
                 ?? inventoryRepository.AddMaterial((Materials)rewardItem.EntityId);
             mat.Quantity += rewardItem.EntityQuantity;
-            ((DragonRewardEntityList[])reward.LevelupEntityList)[0] = rewardItem;
+            reward.LevelupEntityList = [rewardItem];
         }
         return reward;
     }


### PR DESCRIPTION
Fix a softlock when reaching bond level 5 or 15 in the Dragon's Roost. We were creating an array of size 1 but early returning if the bond level unlocked a story. This lead to returning a list of `[null]`, which the game didn't like. This PR changes that to return an empty list `[]` in this case.

It also makes it so that the reward.IsReleaseStory flag is set even if the story fails to unlock due to invalid savedata. This is because if you send `[]` without `IsReleaseStory` then it shows an empty gifts screen, which is a minor visual glitch.