### PR TITLE
Fix weapon passives not applying when using off-element weapons

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
@@ -54,7 +54,7 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
             }
         );
 
-        this.weaponRepository.GetPassiveAbilities(WeaponBodies.Nothung)
+        this.weaponRepository.GetPassiveAbilities(Charas.Marth)
             .Should()
             .NotContain(x => x.WeaponPassiveAbilityId == 1010108);
     }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/IWeaponRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/IWeaponRepository.cs
@@ -8,7 +8,7 @@ public interface IWeaponRepository
 {
     IQueryable<DbWeaponBody> WeaponBodies { get; }
     IQueryable<DbWeaponSkin> WeaponSkins { get; }
-    IQueryable<DbWeaponPassiveAbility> GetPassiveAbilities(WeaponBodies id);
+    IQueryable<DbWeaponPassiveAbility> GetPassiveAbilities(Charas id);
     Task Add(WeaponBodies weaponBodyId);
     Task AddSkin(int weaponSkinId);
     Task<bool> CheckOwnsWeapons(params WeaponBodies[] weaponIds);

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/WeaponRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/WeaponRepository.cs
@@ -48,13 +48,13 @@ public class WeaponRepository : IWeaponRepository
             x.ViewerId == this.playerIdentityService.ViewerId
         );
 
-    public IQueryable<DbWeaponPassiveAbility> GetPassiveAbilities(WeaponBodies id)
+    public IQueryable<DbWeaponPassiveAbility> GetPassiveAbilities(Charas id)
     {
-        WeaponBody data = MasterAsset.WeaponBody.Get(id);
+        CharaData charaData = MasterAsset.CharaData.Get(id);
 
         IEnumerable<int> searchIds = MasterAsset
             .WeaponPassiveAbility.Enumerable.Where(x =>
-                x.WeaponType == data.WeaponType && x.ElementalType == data.ElementalType
+                x.WeaponType == charaData.WeaponType && x.ElementalType == charaData.ElementalType
             )
             .ExceptBy(AstralsBaneAbilityIds, x => x.AbilityId) // Sending astral abilities in the list breaks scorch res. Don't ask me why.
             .Select(x => x.Id);

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -289,12 +289,9 @@ public class DungeonStartService(
                 x is not null
             );
 
-            if (detailedUnit.WeaponBodyData is not null)
-            {
-                detailedUnit.GameWeaponPassiveAbilityList = await weaponRepository
-                    .GetPassiveAbilities(detailedUnit.CharaData.CharaId)
-                    .ToListAsync();
-            }
+            detailedUnit.GameWeaponPassiveAbilityList = await weaponRepository
+                .GetPassiveAbilities(detailedUnit.CharaData.CharaId)
+                .ToListAsync();
         }
 
         List<PartyUnitList> units = detailedPartyUnits

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -292,7 +292,7 @@ public class DungeonStartService(
             if (detailedUnit.WeaponBodyData is not null)
             {
                 detailedUnit.GameWeaponPassiveAbilityList = await weaponRepository
-                    .GetPassiveAbilities(detailedUnit.WeaponBodyData.WeaponBodyId)
+                    .GetPassiveAbilities(detailedUnit.CharaData.CharaId)
                     .ToListAsync();
             }
         }

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
@@ -81,7 +81,7 @@ public class HeroParamService : IHeroParamService
             if (unit.WeaponBodyData is not null)
             {
                 unit.GameWeaponPassiveAbilityList = await this
-                    .weaponRepository.GetPassiveAbilities(unit.WeaponBodyData.WeaponBodyId)
+                    .weaponRepository.GetPassiveAbilities(unit.CharaData.CharaId)
                     .ToListAsync();
             }
         }

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
@@ -104,6 +104,10 @@ public class HeroParamService(
             result.DragonSkill2Lv = 0; // ???
         }
 
+        result.WeaponPassiveAbilityIds = unit
+            .GameWeaponPassiveAbilityList.Select(x => x.WeaponPassiveAbilityId)
+            .ToArray();
+
         if (unit.WeaponBodyData is not null)
         {
             result.WeaponBodyId = (int)unit.WeaponBodyData.WeaponBodyId;
@@ -112,9 +116,6 @@ public class HeroParamService(
             result.WeaponBodyAbility2Lv = unit.WeaponBodyData.Ability2Level;
             result.WeaponBodySkillLv = unit.WeaponBodyData.SkillLevel;
             result.WeaponBodySkillNo = unit.WeaponBodyData.SkillNo;
-            result.WeaponPassiveAbilityIds = unit
-                .GameWeaponPassiveAbilityList.Select(x => x.WeaponPassiveAbilityId)
-                .ToArray();
         }
         else
         {

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/HeroParamService.cs
@@ -14,7 +14,14 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Services.Photon;
 
-public class HeroParamService : IHeroParamService
+public class HeroParamService(
+    IDungeonRepository dungeonRepository,
+    IWeaponRepository weaponRepository,
+    IBonusService bonusService,
+    IPartyRepository partyRepository,
+    ILogger<HeroParamService> logger,
+    IPlayerIdentityService playerIdentityService
+) : IHeroParamService
 {
     private static readonly ImmutableDictionary<WeaponTypes, WeaponBodies> DefaultWeapons =
         new Dictionary<WeaponTypes, WeaponBodies>()
@@ -30,63 +37,29 @@ public class HeroParamService : IHeroParamService
             { WeaponTypes.Gun, WeaponBodies.BattlewornManacaster }
         }.ToImmutableDictionary();
 
-    private readonly IDungeonRepository dungeonRepository;
-    private readonly IWeaponRepository weaponRepository;
-    private readonly IBonusService bonusService;
-    private readonly IUserDataRepository userDataRepository;
-    private readonly IPartyRepository partyRepository;
-    private readonly ILogger<HeroParamService> logger;
-    private readonly IPlayerIdentityService playerIdentityService;
-
-    public HeroParamService(
-        IDungeonRepository dungeonRepository,
-        IWeaponRepository weaponRepository,
-        IBonusService bonusService,
-        IUserDataRepository userDataRepository,
-        IPartyRepository partyRepository,
-        ILogger<HeroParamService> logger,
-        IPlayerIdentityService playerIdentityService
-    )
-    {
-        this.dungeonRepository = dungeonRepository;
-        this.weaponRepository = weaponRepository;
-        this.bonusService = bonusService;
-        this.userDataRepository = userDataRepository;
-        this.partyRepository = partyRepository;
-        this.logger = logger;
-        this.playerIdentityService = playerIdentityService;
-    }
-
     public async Task<List<HeroParam>> GetHeroParam(long viewerId, int partySlot)
     {
-        this.logger.LogDebug("Fetching HeroParam for slot {partySlots}", partySlot);
+        logger.LogDebug("Fetching HeroParam for slot {partySlots}", partySlot);
 
-        DbPlayerUserData userData = await this
-            .userDataRepository.GetViewerData(viewerId)
-            .SingleAsync();
+        using IDisposable ctx = playerIdentityService.StartUserImpersonation(viewerId);
 
-        using IDisposable ctx = this.playerIdentityService.StartUserImpersonation(viewerId);
-
-        List<DbDetailedPartyUnit> detailedPartyUnits = await this
-            .dungeonRepository.BuildDetailedPartyUnit(
-                partyRepository.GetPartyUnits(partySlot),
-                partySlot
-            )
+        List<DbDetailedPartyUnit> detailedPartyUnits = await dungeonRepository
+            .BuildDetailedPartyUnit(partyRepository.GetPartyUnits(partySlot), partySlot)
             .ToListAsync();
 
-        this.logger.LogDebug("Retrieved {n} party units", detailedPartyUnits.Count);
+        logger.LogDebug("Retrieved {n} party units", detailedPartyUnits.Count);
 
         foreach (DbDetailedPartyUnit unit in detailedPartyUnits)
         {
             if (unit.WeaponBodyData is not null)
             {
-                unit.GameWeaponPassiveAbilityList = await this
-                    .weaponRepository.GetPassiveAbilities(unit.CharaData.CharaId)
+                unit.GameWeaponPassiveAbilityList = await weaponRepository
+                    .GetPassiveAbilities(unit.CharaData.CharaId)
                     .ToListAsync();
             }
         }
 
-        FortBonusList bonusList = await this.bonusService.GetBonusList();
+        FortBonusList bonusList = await bonusService.GetBonusList();
 
         return detailedPartyUnits.Select(x => MapHeroParam(x, bonusList)).ToList();
     }


### PR DESCRIPTION
The current logic to retrieve weapon passive abilities uses the equipped weapon's element, when it should use the character's element. This manifests as not having any passive abilities active if you use an off-element weapon, because the off-element passive abilities won't apply correctly. The actual behaviour should be that a weapon passive that has been unlocked is active for all units of that element and weapon type, regardless of what weapon is being used.

Additionally removes if statements that only send weapon passive data if a weapon is equipped. Weapon passive abilities should be available even when no weapon is equipped.