### PR TITLE
Fix story mission softlock

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Missions/MissionService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Missions/MissionService.cs
@@ -439,6 +439,7 @@ public class MissionService(
     {
         int? mainStoryMissionGroupId = await this
             .missionRepository.GetMissionsByType(MissionType.MainStory)
+            .Where(x => x.State < MissionState.Claimed)
             .MaxAsync(x => x.GroupId);
 
         if (mainStoryMissionGroupId == null)


### PR DESCRIPTION
A player got into a state where they were unable to progress the main campaign as their client was refusing to call `/mission/unlock_main_story_group`. Upon further investigation it seems the cause of this is that we are always sending
`current_main_story_mission` from `/mission/get_mission_list` with data, even if it relates to main story missions that are already completed.

This lead to the missions showing as completed on their screen, but without any endeavours to claim and with the quest remaining locked.

Fix this by filtering out the current main story mission to those that are not claimed. We will therefore send an empty
`current_main_story_mission` if none is in progress. This fixes the issue, and lines up with what I have seen in my captures from my main account on the official servers, which had completed the campaign.

Also includes a misc fix to user impersionation as I used it while troubleshooting and noticed that it was broken after the global query filter changes :P