### PR TITLE
Maybe fix NullReferenceException in party loading code 

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database/Entities/Scaffold/DbDetailedPartyUnit.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/Scaffold/DbDetailedPartyUnit.cs
@@ -12,7 +12,7 @@ public class DbDetailedPartyUnit
 
     public int Position { get; set; }
 
-    public required DbPlayerCharaData CharaData { get; set; }
+    public DbPlayerCharaData? CharaData { get; set; }
 
     public DbPlayerDragonData? DragonData { get; set; }
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.Log.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.Log.cs
@@ -6,6 +6,9 @@ public partial class DungeonStartService
 {
     private static partial class Log
     {
+        [LoggerMessage(LogLevel.Debug, "Loading party data for party number {PartyNumber}")]
+        public static partial void LoadingFromPartyNumber(ILogger logger, int partyNumber);
+
         [LoggerMessage(LogLevel.Debug, "Loading party data for party numbers {PartyNumbers}")]
         public static partial void LoadingFromPartyNumbers(ILogger logger, IList<int> partyNumbers);
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.Log.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.Log.cs
@@ -1,0 +1,21 @@
+using DragaliaAPI.Models.Generated;
+
+namespace DragaliaAPI.Features.Dungeon.Start;
+
+public partial class DungeonStartService
+{
+    private static partial class Log
+    {
+        [LoggerMessage(LogLevel.Debug, "Loading party data for party numbers {PartyNumbers}")]
+        public static partial void LoadingFromPartyNumbers(ILogger logger, IList<int> partyNumbers);
+
+        [LoggerMessage(
+            LogLevel.Debug,
+            "Loading party data for party setting list {@PartySettingList}"
+        )]
+        public static partial void LoadingFromPartySettingList(
+            ILogger logger,
+            IList<PartySettingList> partySettingList
+        );
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -172,7 +172,7 @@ public partial class DungeonStartService(
         ulong? supportViewerId = null
     )
     {
-        Log.LoadingFromPartyNumbers(logger, [partyNo]);
+        Log.LoadingFromPartyNumber(logger, partyNo);
 
         IQueryable<DbPartyUnit> partyQuery = partyRepository.GetPartyUnits(partyNo).AsNoTracking();
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -216,7 +216,7 @@ public partial class DungeonStartService(
         )
         {
             detailedPartyUnits.Add(
-                await detailQuery.AsNoTracking().SingleOrDefaultAsync()
+                await detailQuery.AsNoTracking().FirstOrDefaultAsync()
                     ?? throw new InvalidOperationException(
                         "Detailed party query returned no results"
                     )
@@ -239,7 +239,7 @@ public partial class DungeonStartService(
 
     public async Task<IngameQuestData> InitiateQuest(int questId)
     {
-        DbQuest? quest = await questRepository.Quests.SingleOrDefaultAsync(x =>
+        DbQuest? quest = await questRepository.Quests.FirstOrDefaultAsync(x =>
             x.QuestId == questId
         );
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -19,7 +19,7 @@ using static DragaliaAPI.Services.Game.TutorialService;
 
 namespace DragaliaAPI.Features.Dungeon.Start;
 
-public class DungeonStartService(
+public partial class DungeonStartService(
     IPartyRepository partyRepository,
     IDungeonRepository dungeonRepository,
     IWeaponRepository weaponRepository,
@@ -72,6 +72,8 @@ public class DungeonStartService(
         ulong? supportViewerId = null
     )
     {
+        Log.LoadingFromPartyNumbers(logger, partyNoList);
+
         IQueryable<DbPartyUnit> partyQuery = partyRepository
             .GetPartyUnits(partyNoList)
             .AsNoTracking();
@@ -128,6 +130,8 @@ public class DungeonStartService(
         RepeatSetting? repeatSetting = null
     )
     {
+        Log.LoadingFromPartySettingList(logger, party);
+
         IngameData result = await InitializeIngameData(questId, supportViewerId);
 
         List<DbDetailedPartyUnit> detailedPartyUnits = new();
@@ -139,7 +143,7 @@ public class DungeonStartService(
         )
         {
             detailedPartyUnits.Add(
-                await detailQuery.AsNoTracking().SingleOrDefaultAsync()
+                await detailQuery.AsNoTracking().FirstOrDefaultAsync()
                     ?? throw new InvalidOperationException(
                         "Detailed party query returned no results"
                     )
@@ -168,6 +172,8 @@ public class DungeonStartService(
         ulong? supportViewerId = null
     )
     {
+        Log.LoadingFromPartyNumbers(logger, [partyNo]);
+
         IQueryable<DbPartyUnit> partyQuery = partyRepository.GetPartyUnits(partyNo).AsNoTracking();
 
         List<PartySettingList> party = ProcessUnitList(await partyQuery.ToListAsync(), partyNo);
@@ -289,9 +295,12 @@ public class DungeonStartService(
                 x is not null
             );
 
-            detailedUnit.GameWeaponPassiveAbilityList = await weaponRepository
-                .GetPassiveAbilities(detailedUnit.CharaData.CharaId)
-                .ToListAsync();
+            if (detailedUnit.CharaData is not null)
+            {
+                detailedUnit.GameWeaponPassiveAbilityList = await weaponRepository
+                    .GetPassiveAbilities(detailedUnit.CharaData.CharaId)
+                    .ToListAsync();
+            }
         }
 
         List<PartyUnitList> units = detailedPartyUnits

--- a/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V20Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/SavefileUpdate/V20Update.cs
@@ -15,7 +15,6 @@ namespace DragaliaAPI.Features.SavefileUpdate;
 public class V20Update(
     ApiContext apiContext,
     IPresentService presentService,
-    IPlayerIdentityService playerIdentityService,
     ILogger<V20Update> logger
 ) : ISavefileUpdate
 {


### PR DESCRIPTION
I've observed the following exception in the logs since https://github.com/SapiensAnatis/Dawnshard/pull/752 was merged:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at DragaliaAPI.Features.Dungeon.Start.DungeonStartService.ProcessDetailedUnitList(List`1 detailedPartyUnits) in /src/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs:line 292
   at DragaliaAPI.Features.Dungeon.Start.DungeonStartService.GetAssignUnitIngameData(Int32 questId, IList`1 party, Nullable`1 supportViewerId, RepeatSetting repeatSetting) in /src/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs:line 151
   at DragaliaAPI.Features.Dungeon.Start.DungeonStartController.StartAssignUnit(DungeonStartStartAssignUnitRequest request, CancellationToken cancellationToken) in /src/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs:line 105
```

Nobody has come forward with a report or reproduction steps and I can't seem to trigger it myself. Since it started happening after we used `CharaData` to load up weapon passives, and because this is not in a null guard, I assume `detailedUnit.CharaData` is somehow null, so I've added a null guard.

If this doesn't work, then there's some additional logging included which should help to get to the bottom of the issue.