### PR TITLE
Add additional logging around rotating gifts

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -56,8 +56,8 @@ public class LoginTest : TestFixture
             .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 100));
 
         this.MockTimeProvider.SetUtcNow(
-            new DateTimeOffset(2049, 03, 15, 23, 13, 59, TimeSpan.Zero)
-        ); // Monday
+            new DateTimeOffset(2049, 03, 16, 02, 13, 59, TimeSpan.Zero)
+        ); // Into Tuesday, but last reset was Monday
 
         await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
 

--- a/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/DragonGiftResetAction.cs
@@ -2,6 +2,7 @@ using System.Collections.Frozen;
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Utils;
+using DragaliaAPI.Helpers;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.EntityFrameworkCore;
@@ -10,7 +11,7 @@ namespace DragaliaAPI.Features.Login;
 
 public class DragonGiftResetAction(
     ApiContext apiContext,
-    TimeProvider timeProvider,
+    IResetHelper resetHelper,
     IPlayerIdentityService playerIdentityService
 ) : IDailyResetAction
 {
@@ -41,7 +42,7 @@ public class DragonGiftResetAction(
             dbGift.Quantity = 1;
         }
 
-        DayOfWeek todayDayOfWeek = timeProvider.GetUtcNow().DayOfWeek;
+        DayOfWeek todayDayOfWeek = resetHelper.LastDailyReset.DayOfWeek;
 
         foreach (DragonGifts dailyGiftId in DragonConstants.RotatingGifts)
         {

--- a/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.Log.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.Log.cs
@@ -1,0 +1,20 @@
+using DragaliaAPI.Shared.Definitions.Enums;
+
+namespace DragaliaAPI.Services.Game;
+
+public partial class DragonService
+{
+    private static partial class Log
+    {
+        [LoggerMessage(
+            LogLevel.Debug,
+            "Last daily reset: {Reset} on {DayOfWeek}. Rotating gift: {Gift}"
+        )]
+        public static partial void CurrentRotatingGift(
+            ILogger logger,
+            DateTimeOffset reset,
+            DayOfWeek dayOfWeek,
+            DragonGifts gift
+        );
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/DragonService.cs
@@ -17,7 +17,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Services.Game;
 
-public class DragonService(
+public partial class DragonService(
     IUserDataRepository userDataRepository,
     IUnitRepository unitRepository,
     IInventoryRepository inventoryRepository,
@@ -33,9 +33,14 @@ public class DragonService(
 {
     public async Task<DragonGetContactDataResponse> DoDragonGetContactData()
     {
+        DateTimeOffset reset = resetHelper.LastDailyReset;
+        DayOfWeek dayOfWeek = reset.DayOfWeek;
+
         DragonGifts rotatingGift = DragonConstants.RotatingGifts[
             (int)resetHelper.LastDailyReset.DayOfWeek
         ];
+
+        Log.CurrentRotatingGift(logger, reset, dayOfWeek, rotatingGift);
 
         Dictionary<DragonGifts, DbPlayerDragonGift> gifts = await apiContext
             .PlayerDragonGifts.Where(x =>


### PR DESCRIPTION
Attempting to track down an issue where the rotating gift is changing over 1h early each day. Can't work it out from the code so hoping some debug logs might help.

Code inspection turned up a bug in DragonGiftResetAction where we might use the next day's gift if you experience daily reset at e.g. 2AM UTC.