### PR TITLE
EFCore tweaks

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-ef": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "commands": [
         "dotnet-ef"
       ]

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContextFactory.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContextFactory.cs
@@ -1,0 +1,3 @@
+namespace DragaliaAPI.Database;
+
+public class ApiContextFactory { }

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContextFactory.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContextFactory.cs
@@ -1,3 +1,47 @@
+using DragaliaAPI.Shared.PlayerDetails;
+using JetBrains.Annotations;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
 namespace DragaliaAPI.Database;
 
-public class ApiContextFactory { }
+[UsedImplicitly]
+public class ApiContextFactory : IDesignTimeDbContextFactory<ApiContext>
+{
+    public ApiContext CreateDbContext(string[] args)
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddEnvironmentVariables()
+            .AddCommandLine(args)
+            .Build();
+
+        PostgresOptions? postgresOptions = configuration
+            .GetSection(nameof(PostgresOptions))
+            ?.Get<PostgresOptions>();
+
+        DbContextOptions<ApiContext> contextOptions = new DbContextOptionsBuilder<ApiContext>()
+            .UseNpgsql(postgresOptions?.GetConnectionString())
+            .Options;
+
+        return new ApiContext(contextOptions, new StubPlayerIdentityService());
+    }
+
+    private class StubPlayerIdentityService : IPlayerIdentityService
+    {
+        public string AccountId =>
+            throw new NotImplementedException(
+                "StubPlayerIdentityService cannot function as an actual identity service"
+            );
+
+        public long ViewerId =>
+            throw new NotImplementedException(
+                "StubPlayerIdentityService cannot function as an actual identity service"
+            );
+
+        public IDisposable StartUserImpersonation(long? viewer = null, string? account = null) =>
+            throw new NotImplementedException(
+                "StubPlayerIdentityService cannot function as an actual identity service"
+            );
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Database/DatabaseConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/DatabaseConfiguration.cs
@@ -22,11 +22,9 @@ public static class DatabaseConfiguration
         PostgresOptions postgresOptions
     )
     {
-        string connectionString = GetConnectionString(postgresOptions);
-
         services = services
             .AddDbContext<ApiContext>(options =>
-                options.UseNpgsql(connectionString).EnableDetailedErrors()
+                options.UseNpgsql(postgresOptions.GetConnectionString()).EnableDetailedErrors()
             )
 #pragma warning disable CS0618 // Type or member is obsolete
             .AddScoped<IDeviceAccountRepository, DeviceAccountRepository>()
@@ -43,22 +41,6 @@ public static class DatabaseConfiguration
             .AddScoped<IAbilityCrestRepository, AbilityCrestRepository>();
 
         return services;
-    }
-
-    private static string GetConnectionString(PostgresOptions options)
-    {
-        NpgsqlConnectionStringBuilder connectionStringBuilder =
-            new()
-            {
-                Host = options.Hostname,
-                Port = options.Port,
-                Username = options.Username,
-                Password = options.Password,
-                Database = options.Database,
-                IncludeErrorDetail = true,
-            };
-
-        return connectionStringBuilder.ConnectionString;
     }
 
     [ExcludeFromCodeCoverage]

--- a/DragaliaAPI/DragaliaAPI.Database/DragaliaAPI.Database.csproj
+++ b/DragaliaAPI/DragaliaAPI.Database/DragaliaAPI.Database.csproj
@@ -4,7 +4,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
             <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
             <PrivateAssets>all</PrivateAssets>

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbAbilityCrestSet.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbAbilityCrestSet.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using DragaliaAPI.Database.Entities.Abstract;
 using DragaliaAPI.Shared.Definitions.Enums;
 using Microsoft.EntityFrameworkCore;
@@ -28,6 +29,7 @@ public class DbAbilityCrestSet : DbPlayerData
     /// <summary>
     /// Gets or sets a string indicating the wyrmprint set's name.
     /// </summary>
+    [StringLength(32)]
     public string AbilityCrestSetName { get; set; } = "";
 
     /// <summary>

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbDeviceAccount.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbDeviceAccount.cs
@@ -1,6 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using DragaliaAPI.Shared;
 
+// ReSharper disable EntityFramework.ModelValidation.UnlimitedStringLength
+// Deprecated model
+
 namespace DragaliaAPI.Database.Entities;
 
 [Obsolete(ObsoleteReasons.BaaS)]

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbNewsItem.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbNewsItem.cs
@@ -9,9 +9,11 @@ public class DbNewsItem
     [Key]
     public int Id { get; set; }
 
+    [StringLength(256)]
     public required string Headline { get; set; }
 
     public DateTimeOffset Time { get; set; }
 
+    [StringLength(4096)]
     public required string Description { get; set; }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbPartyUnit.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbPartyUnit.cs
@@ -9,6 +9,7 @@ public class DbPartyUnit : DbPartyUnitBase, IDbPlayerData
     // In theory, a composite primary key of [Party, UnitNo] would work great.
     // However, EF Core doesn't like navigation properties being used as keys.
     [Key]
+    [StringLength(64)]
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
     [ForeignKey($"{nameof(ViewerId)},{nameof(PartyNo)}")]

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbSetUnit.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbSetUnit.cs
@@ -18,5 +18,6 @@ public class DbSetUnit : DbUnitBase, IDbPlayerData
     [Required]
     public int UnitSetNo { get; set; }
 
+    [StringLength(32)]
     public required string UnitSetName { get; set; }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackClear.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackClear.cs
@@ -1,14 +1,14 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using DragaliaAPI.Database.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace DragaliaAPI.Database;
+namespace DragaliaAPI.Database.Entities;
 
 [Index(nameof(QuestId))]
 public class DbTimeAttackClear
 {
     [Key]
+    [StringLength(64)]
     public required string GameId { get; set; }
 
     public int QuestId { get; set; }

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackClearUnit.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackClearUnit.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using DragaliaAPI.Database.Entities.Abstract;
 using DragaliaAPI.Shared.Definitions.Enums;
 using Microsoft.EntityFrameworkCore;
@@ -8,6 +9,7 @@ namespace DragaliaAPI.Database.Entities;
 [PrimaryKey(nameof(GameId), nameof(ViewerId), nameof(UnitNo))]
 public class DbTimeAttackClearUnit : DbPartyUnitBase, IDbPlayerData
 {
+    [StringLength(64)]
     public required string GameId { get; set; }
 
     public required long ViewerId { get; set; }

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackPlayer.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbTimeAttackPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database.Entities;
@@ -7,6 +8,7 @@ namespace DragaliaAPI.Database.Entities;
 public class DbTimeAttackPlayer
 {
     [ForeignKey(nameof(Clear))]
+    [StringLength(64)]
     public required string GameId { get; set; }
 
     [ForeignKey(nameof(Player))]
@@ -19,6 +21,7 @@ public class DbTimeAttackPlayer
     /// For manual inspection after contest ends.
     /// </remarks>
     [Column(TypeName = "jsonb")]
+    // ReSharper disable once EntityFramework.ModelValidation.UnlimitedStringLength
     public required string PartyInfo { get; set; }
 
     public List<DbTimeAttackClearUnit> Units { get; set; } = new();

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbWeaponBody.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbWeaponBody.cs
@@ -59,7 +59,7 @@ public class DbWeaponBody : DbPlayerData
     /// <remarks>Always 0 on my endgame savefile, for all 235 weapons.</remarks>
     /// </summary>
     [NotMapped]
-    public int AdditionalEffectCount { get; }
+    public int AdditionalEffectCount { get; set; }
 
     /// <summary>
     /// Gets or sets a list of passive abilities that are unlocked on the weapon.

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20240419230507_StringLength.Designer.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20240419230507_StringLength.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20240419230507_StringLength")]
+    partial class StringLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20240419230507_StringLength.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20240419230507_StringLength.cs
@@ -1,0 +1,162 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class StringLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackPlayers",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackClearUnits",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackClears",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UnitSetName",
+                table: "PlayerSetUnit",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "PlayerPartyUnits",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AbilityCrestSetName",
+                table: "PlayerAbilityCrestSets",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Headline",
+                table: "NewsItems",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "NewsItems",
+                type: "character varying(4096)",
+                maxLength: 4096,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "text");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackPlayers",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackClearUnits",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "GameId",
+                table: "TimeAttackClears",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "UnitSetName",
+                table: "PlayerSetUnit",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Id",
+                table: "PlayerPartyUnits",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(64)",
+                oldMaxLength: 64);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "AbilityCrestSetName",
+                table: "PlayerAbilityCrestSets",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(32)",
+                oldMaxLength: 32);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Headline",
+                table: "NewsItems",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "NewsItems",
+                type: "text",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(4096)",
+                oldMaxLength: 4096);
+        }
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Database/PostgresOptions.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/PostgresOptions.cs
@@ -1,3 +1,5 @@
+using Npgsql;
+
 namespace DragaliaAPI.Database;
 
 public class PostgresOptions
@@ -13,4 +15,20 @@ public class PostgresOptions
     public string? Database { get; set; }
 
     public bool DisableAutoMigration { get; set; }
+
+    public string GetConnectionString()
+    {
+        NpgsqlConnectionStringBuilder connectionStringBuilder =
+            new()
+            {
+                Host = this.Hostname,
+                Port = this.Port,
+                Username = this.Username,
+                Password = this.Password,
+                Database = this.Database,
+                IncludeErrorDetail = true,
+            };
+
+        return connectionStringBuilder.ConnectionString;
+    }
 }

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/TimeAttack/OwnClear.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/TimeAttack/OwnClear.razor
@@ -1,4 +1,5 @@
 ﻿@using DragaliaAPI.Database;
+@using DragaliaAPI.Database.Entities
 @using DragaliaAPI.Features.Blazor
 @using Microsoft.EntityFrameworkCore;
 @inherits ServiceComponentBase


### PR DESCRIPTION
- Limit string length of columns to potentially improve performance
- Add design time factory to be able to configure migrations (migrations broken since Design package was removed from main API project in #746) cc @Nightmerp 

To configure a migration now:
- from the repo root do `dotnet ef migrations add MyMigration -p DragaliaAPI/DragaliaAPI.Database -s DragaliaAPI/DragaliaAPI.Database`
- cd to `DragaliaAPI/DragaliaAPI.Database` and just do `dotnet ef migrations add MyMigration`

If you want to use `dotnet ef database update`, the context factory accepts config from the CLI or env variables in the same format as docker-compose `PostgresOptions__*` but I haven't tried this