### PR TITLE
Fix AddStamina not including passive recovery

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
@@ -53,6 +53,33 @@ public class ItemTest : TestFixture
     }
 
     [Fact]
+    public async Task UseRecoveryStamina_UpdatesStaminaBeforeAdd()
+    {
+        this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
+
+        DbPlayerUserData userData = this
+            .ApiContext.PlayerUserData.AsTracking()
+            .First(x => x.ViewerId == 1);
+        userData.StaminaSingle = 0;
+        userData.LastStaminaSingleUpdateTime = DateTimeOffset.UtcNow - TimeSpan.FromHours(6);
+        await this.ApiContext.SaveChangesAsync();
+
+        int expectedPassiveRegen = (int)TimeSpan.FromHours(6).TotalSeconds / 360; // 6 minutes per stamina point
+
+        DragaliaResponse<ItemUseRecoveryStaminaResponse> resp =
+            await Client.PostMsgpack<ItemUseRecoveryStaminaResponse>(
+                "item/use_recovery_stamina",
+                new ItemUseRecoveryStaminaRequest(
+                    new List<AtgenUseItemList> { new(UseItem.Honey, 1) }
+                )
+            );
+
+        resp.Data.RecoverData.RecoverStaminaType.Should().Be(UseItemEffect.RecoverStamina);
+        resp.Data.RecoverData.RecoverStaminaPoint.Should().Be(10);
+        resp.Data.UpdateDataList.UserData.StaminaSingle.Should().Be(10 + expectedPassiveRegen);
+    }
+
+    [Fact]
     public async Task UseRecoveryStamina_MultipleItems_RecoversStamina()
     {
         DragaliaResponse<ItemUseRecoveryStaminaResponse> resp =

--- a/DragaliaAPI/DragaliaAPI/Features/Player/UserService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Player/UserService.cs
@@ -36,6 +36,8 @@ public class UserService(
 
         logger.LogDebug("Adding {staminaAmount}x {staminaType}", amount, type);
 
+        _ = await GetAndUpdateStamina(type);
+
         DbPlayerUserData data = await userDataRepository.GetUserDataAsync();
         DateTimeOffset time = dateTimeProvider.GetUtcNow();
 


### PR DESCRIPTION
Ensure that the AddStamina method updates the current stamina before it adds the new stamina on to the user.

Fixes an issue with honey tea where sometimes claiming it could visually reduce your stamina - the interface shows the 'projected' stamina including passive recovery, and by updating it based on the underlying un-updated stamina value, we would set it to the wrong value.