### PR TITLE
Fix duplicate summon ticket rows

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -1,5 +1,7 @@
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums.Summon;
 using DragaliaAPI.Shared.Features.Presents;
+using DragaliaAPI.Shared.MasterAsset.Models.Summon;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Integration.Test.Features.Present;
@@ -453,6 +455,51 @@ public class PresentTest : TestFixture
             .Data.UpdateDataList.CharaList.Should()
             .ContainSingle()
             .And.Contain(x => x.CharaId == Charas.Addis);
+    }
+
+    [Fact]
+    public async Task Receive_SummonTickets_StacksCorrectly()
+    {
+        List<DbPlayerPresent> presents =
+        [
+            new DbPlayerPresent()
+            {
+                EntityType = EntityTypes.SummonTicket,
+                EntityId = (int)SummonTickets.AdventurerSummon,
+                EntityQuantity = 2,
+            },
+            new DbPlayerPresent()
+            {
+                EntityType = EntityTypes.SummonTicket,
+                EntityId = (int)SummonTickets.AdventurerSummon,
+                EntityQuantity = 2,
+            }
+        ];
+
+        await this.AddRangeToDatabase(presents);
+
+        await this.ApiContext.PlayerSummonTickets.ExecuteDeleteAsync();
+
+        IEnumerable<ulong> presentIdList = presents.Select(x => (ulong)x.PresentId);
+
+        await this.Client.PostMsgpack<PresentReceiveResponse>(
+            $"{Controller}/receive",
+            new PresentReceiveRequest() { PresentIdList = presentIdList }
+        );
+
+        this.ApiContext.PlayerSummonTickets.AsNoTracking()
+            .Should()
+            .BeEquivalentTo<DbSummonTicket>(
+                [
+                    new DbSummonTicket()
+                    {
+                        ViewerId = this.ViewerId,
+                        SummonTicketId = SummonTickets.AdventurerSummon,
+                        Quantity = 4
+                    },
+                ],
+                opts => opts.Excluding(x => x.KeyId)
+            );
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -16,7 +16,7 @@ public class SummonTest : TestFixture
     public SummonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
+        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/SummonTicketHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/SummonTicketHandler.cs
@@ -48,9 +48,11 @@ public class SummonTicketHandler(
     private async Task AddStackableTicket(SummonTickets ticketId, int quantity)
     {
         DbSummonTicket ticket =
-            await apiContext
-                .PlayerSummonTickets.Where(x => x.SummonTicketId == ticketId)
-                .FirstOrDefaultAsync() ?? this.InitializeEmptyStackableTicket(ticketId);
+            apiContext.PlayerSummonTickets.Local.FirstOrDefault(x => x.SummonTicketId == ticketId)
+            ?? await apiContext.PlayerSummonTickets.FirstOrDefaultAsync(x =>
+                x.SummonTicketId == ticketId
+            )
+            ?? this.InitializeEmptyStackableTicket(ticketId);
 
         ticket.Quantity += quantity;
     }


### PR DESCRIPTION
Fixes an issue where two summon ticket rows could be added if you claimed two presents with summon tickets simultaneously, as subsequent invocations of SummonTicketHandler weren't aware of the pending row in the change tracker.

Additionally bump time tolerance due to summon history test failures in CI