### PR TITLE
Add indicator to fresh news posts

### DIFF
--- a/DragaliaAPI/DragaliaAPI/App.razor
+++ b/DragaliaAPI/DragaliaAPI/App.razor
@@ -1,10 +1,11 @@
 ﻿@using DragaliaAPI.Authentication
 @{
-    string? darkModeCookie = this.HttpContext?.Request.Cookies.FirstOrDefault(x => x.Key == "darkMode").Value;
-    bool? isDarkMode = null;
+    string? darkModeCookie = this.HttpContext?.Request.Cookies.FirstOrDefault(x => x.Key == Cookies.DarkMode).Value;
 
-    if (bool.TryParse(darkModeCookie, out bool darkModeParsed))
-        isDarkMode = darkModeParsed;
+    if (!bool.TryParse(darkModeCookie, out bool isDarkMode))
+    {
+        isDarkMode = false;
+    }
 
     HttpRequestState httpRequestState = new() 
     {
@@ -50,14 +51,14 @@
 <script>
     window.blazorExtensions = {
         writeCookie: function (name, value) {
-            document.cookie = `${name}=${value}; SameSite=Lax`;
+            document.cookie = `${name}=${value}; SameSite=Lax; path=/`;
         },
         scrollToTop: function () {
             document.documentElement.scrollTop = 0;
         },
         getHash: function () {
             return window.location.hash
-        }    
+        }
     }
 </script>
 

--- a/DragaliaAPI/DragaliaAPI/App.razor
+++ b/DragaliaAPI/DragaliaAPI/App.razor
@@ -2,9 +2,10 @@
 @{
     string? darkModeCookie = this.HttpContext?.Request.Cookies.FirstOrDefault(x => x.Key == Cookies.DarkMode).Value;
 
-    if (!bool.TryParse(darkModeCookie, out bool isDarkMode))
+    bool? isDarkMode = null;
+    if (bool.TryParse(darkModeCookie, out bool isDarkModeParsed))
     {
-        isDarkMode = false;
+        isDarkMode = isDarkModeParsed;
     }
 
     HttpRequestState httpRequestState = new() 

--- a/DragaliaAPI/DragaliaAPI/Pages/News/NewsWebview.razor
+++ b/DragaliaAPI/DragaliaAPI/Pages/News/NewsWebview.razor
@@ -55,5 +55,4 @@
             this.StateHasChanged();
         }
     }
-
 }

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/Cookies.cs
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/Cookies.cs
@@ -1,0 +1,6 @@
+namespace DragaliaAPI.RazorComponents;
+
+public static class Cookies
+{
+    public const string DarkMode = "darkMode";
+}

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/MainLayout.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/MainLayout.razor
@@ -6,8 +6,8 @@
 @inherits LayoutComponentBase
 
 <MudThemeProvider Theme="theme" @ref=provider IsDarkMode="@darkMode" IsDarkModeChanged="OnIsDarkModeChanged"/>
-<MudDialogProvider />
-<MudSnackbarProvider />
+<MudDialogProvider/>
+<MudSnackbarProvider/>
 
 <MudLayout>
     <MudAppBar Elevation="0">
@@ -58,7 +58,6 @@
 </MudLayout>
 
 
-
 @code {
     private bool popoverOpen;
     private bool navDrawerOpen;
@@ -71,22 +70,22 @@
 
 
     private MudTheme theme = new()
+    {
+        PaletteDark = new PaletteDark()
         {
-            PaletteDark = new PaletteDark()
-            {
-                AppbarBackground = Colors.Teal.Darken3,
-                Primary = Colors.Teal.Lighten1,
-                Secondary = Colors.Pink.Accent2,
-                Tertiary = Colors.DeepPurple.Darken1,
-            },
-            Palette = new PaletteLight()
-            {
-                AppbarBackground = Colors.Teal.Default,
-                Primary = Colors.Teal.Accent4,
-                Secondary = Colors.Pink.Accent2,
-                Tertiary = Colors.DeepPurple.Lighten1,
-            }
-        };
+            AppbarBackground = Colors.Teal.Darken3,
+            Primary = Colors.Teal.Lighten1,
+            Secondary = Colors.Pink.Accent2,
+            Tertiary = Colors.DeepPurple.Darken1,
+        },
+        Palette = new PaletteLight()
+        {
+            AppbarBackground = Colors.Teal.Default,
+            Primary = Colors.Teal.Accent4,
+            Secondary = Colors.Pink.Accent2,
+            Tertiary = Colors.DeepPurple.Lighten1,
+        }
+    };
 
     private void OnClickLogout()
     {
@@ -96,7 +95,7 @@
     private async void OnIsDarkModeChanged(bool value)
     {
         this.darkMode = value;
-        await this.JsRuntime.InvokeVoidAsync("blazorExtensions.writeCookie", new object[] { nameof(darkMode), value});
+        await this.JsRuntime.InvokeVoidAsync("blazorExtensions.writeCookie", new object[] { nameof(darkMode), value });
         this.StateHasChanged();
     }
 
@@ -110,4 +109,5 @@
     {
         await this.BlazorIdentityService.InitializeAsync();
     }
+
 }

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
@@ -1,4 +1,4 @@
-﻿@using System.Text.Json;
+﻿@using DragaliaAPI.Authentication
 @using DragaliaAPI.Database.Entities;
 @using DragaliaAPI.Database;
 @using DragaliaAPI.Features.Blazor
@@ -6,18 +6,24 @@
 @inherits ServiceComponentBase
 @inject IJSRuntime JsRuntime;
 
-<MudStack Spacing="4" Class="mb-2" AlignItems="AlignItems.Center">
+<MudStack Style="width: 100%" Spacing="4" Class="mb-2" AlignItems="AlignItems.Center">
     <MudStack Style="width: 95%; min-height: 70vh;">
         @foreach (NewsItem item in this.visibleNewsItems)
         {
-            <MudCard>
+            <MudCard Style="@(item.Time > this.lastReadDate ? "border: medium solid var(--mud-palette-info); border-radius: var(--mud-default-borderradius);" : string.Empty)">
                 <MudCardHeader Style="margin-bottom: -1rem">
-                    <MudStack Spacing="-1">
-                        <MudText Typo="Typo.h6" Color="Color.Primary">
-                            @item.Headline
-                        </MudText>
+                    <MudStack Style="width: 100%" Spacing="-1">
+                        <MudStack Style="width: 100%" AlignItems="AlignItems.Start" Row="true" Justify="Justify.SpaceBetween">
+                            <MudText Typo="Typo.h6" Color="Color.Primary">
+                                @item.Headline
+                            </MudText>
+                            @if (item.Time > this.lastReadDate)
+                            {
+                                <MudIcon Color="Color.Info" Icon="@Icons.Material.Filled.NewReleases"></MudIcon>
+                            }
+                        </MudStack>
                         <MudText Typo="Typo.caption">
-                            @item.Time
+                            @item.TimeString
                         </MudText>
                     </MudStack>
                 </MudCardHeader>
@@ -31,16 +37,20 @@
 </MudStack>
 
 @code {
-
     private const int PageSize = 4;
-    
-    private List<NewsItem> allNewsItems = new();
-    private IEnumerable<NewsItem> visibleNewsItems = Enumerable.Empty<NewsItem>();
+    private const string LastReadStorageKey = "lastReadNews";
+
+    private List<NewsItem> allNewsItems = [];
+    private IEnumerable<NewsItem> visibleNewsItems = [];
     private int numPages = 1;
     private int selected = 1;
+    private DateTimeOffset lastReadDate;
 
     [InjectScoped] 
     private ApiContext ApiContext { get; set; } = null!;
+
+    [CascadingParameter(Name = "HttpRequestState")]
+    protected HttpRequestState? HttpRequestState { get; set; }
 
     private int Selected
     {
@@ -49,22 +59,36 @@
         {
             this.visibleNewsItems = allNewsItems.Skip(PageSize * (value - 1)).Take(PageSize);
             this.selected = value;
-            
+
             // Fire-and-forget
             this.JsRuntime.InvokeVoidAsync("window.blazorExtensions.scrollToTop");
         }
     }
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
+        if (!firstRender)
+            return;
+        
+        string? lastReadDateStr = await JsRuntime.InvokeAsync<string?>("localStorage.getItem", default(CancellationToken), [LastReadStorageKey]);
+        if (!DateTimeOffset.TryParse(lastReadDateStr, out this.lastReadDate))
+        {
+            // Do not show all news items as new on a first visit to the page
+            this.lastReadDate = DateTimeOffset.UtcNow;
+        }
+
         this.allNewsItems = await this.ApiContext.NewsItems
             .OrderByDescending(x => x.Time)
             .Select(x => new NewsItem(x))
             .ToListAsync();
 
         this.numPages = (int)Math.Ceiling((double)this.allNewsItems.Count / PageSize);
-
         this.visibleNewsItems = this.allNewsItems.Take(PageSize);
+
+        this.StateHasChanged();
+
+        string newLastReadDate = DateTimeOffset.UtcNow.ToString("O");
+        ValueTask _ = JsRuntime.InvokeVoidAsync("localStorage.setItem", default(CancellationToken), [LastReadStorageKey, newLastReadDate]);
     }
 
     private class NewsItem
@@ -72,14 +96,18 @@
         public NewsItem(DbNewsItem dbNewsItem)
         {
             this.Headline = dbNewsItem.Headline;
-            this.Time = $"{dbNewsItem.Time:dd/MM/yyyy HH:mm} UTC";
+            this.Time = dbNewsItem.Time;
+            this.TimeString = $"{dbNewsItem.Time:dd/MM/yyyy HH:mm} UTC";
             this.Description = new((builder) => builder.AddMarkupContent(0, dbNewsItem.Description));
         }
 
         public string Headline { get; }
 
-        public string Time { get; }
+        public DateTimeOffset Time { get; }
+
+        public string TimeString { get; }
 
         public RenderFragment Description { get; }
     }
+
 }

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
@@ -1,5 +1,4 @@
-﻿@using DragaliaAPI.Authentication
-@using DragaliaAPI.Database.Entities;
+﻿@using DragaliaAPI.Database.Entities;
 @using DragaliaAPI.Database;
 @using DragaliaAPI.Features.Blazor
 @using Microsoft.EntityFrameworkCore;
@@ -46,11 +45,7 @@
     private int selected = 1;
     private DateTimeOffset lastReadDate;
 
-    [InjectScoped] 
-    private ApiContext ApiContext { get; set; } = null!;
-
-    [CascadingParameter(Name = "HttpRequestState")]
-    protected HttpRequestState? HttpRequestState { get; set; }
+    [InjectScoped] private ApiContext ApiContext { get; set; } = null!;
 
     private int Selected
     {
@@ -69,7 +64,7 @@
     {
         if (!firstRender)
             return;
-        
+
         string? lastReadDateStr = await JsRuntime.InvokeAsync<string?>("localStorage.getItem", default(CancellationToken), [LastReadStorageKey]);
         if (!DateTimeOffset.TryParse(lastReadDateStr, out this.lastReadDate))
         {
@@ -109,5 +104,4 @@
 
         public RenderFragment Description { get; }
     }
-
 }

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/Routes.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/Routes.razor
@@ -4,7 +4,6 @@
         <Router AppAssembly="@typeof(App).Assembly">
             <Found Context="routeData">
                 <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" /> 
-                <FocusOnNavigate RouteData="@routeData" Selector="h1"/>
             </Found>
             <NotFound>
                 <PageTitle>Not found</PageTitle>

--- a/DragaliaAPI/DragaliaAPI/RazorComponents/WebviewLayout.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/WebviewLayout.razor
@@ -9,14 +9,16 @@
 </MudLayout>
 
 @code {
+
     private MudTheme theme = new()
+    {
+        Palette = new PaletteLight()
         {
-            Palette = new PaletteLight()
-            {
-                AppbarBackground = Colors.Teal.Default,
-                Primary = Colors.Teal.Accent4,
-                Secondary = Colors.Pink.Accent2,
-                Tertiary = Colors.DeepPurple.Lighten1,
-            }
-        };
+            AppbarBackground = Colors.Teal.Default,
+            Primary = Colors.Teal.Accent4,
+            Secondary = Colors.Pink.Accent2,
+            Tertiary = Colors.DeepPurple.Lighten1,
+        }
+    };
+
 }


### PR DESCRIPTION
Adds an icon and a border around news posts that are new based on
a local storage item that is set by the page indicating when it was last visited.

Also:
- Move loading of news items from OnInitializedAsync to
  OnAfterRenderAsync. The former is called twice and causes a flicker,
  as well as a wasteful DB query.
- Remove FocusOnNavigate that focused the title element on each page
- Some minor refactoring of the cookie logic, from when I thought I
  would use cookies to store the last date