### PR TITLE
Fix DragonHandler ignoring multiple dragons

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Present/IPresentService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Present/IPresentService.cs
@@ -12,4 +12,5 @@ public interface IPresentService
     void AddPresent(Present present);
 
     void AddPresent(IEnumerable<Present> presents);
+    IEnumerable<AtgenBuildEventRewardEntityList> GetTrackedPresentList();
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DragonHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DragonHandler.cs
@@ -16,6 +16,14 @@ public partial class DragonHandler(
 
     public async Task<GrantReturn> Grant(Entity entity)
     {
+        if (entity.Quantity > 1)
+        {
+            throw new ArgumentException(
+                "Cannot process dragons with quantity >1 in single reward handler due to the possibility of multiple results. Use the batch handler instead.",
+                nameof(entity)
+            );
+        }
+
         Dragons dragon = (Dragons)entity.Id;
         if (!Enum.IsDefined(dragon))
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/IRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/IRewardService.cs
@@ -37,7 +37,7 @@ public interface IRewardService
     EntityResult GetEntityResult();
     IEnumerable<ConvertedEntity> GetConvertedEntityList();
 
-    Task<IDictionary<TKey, RewardGrantResult>> GrantRewardsWithBatchHandler<TKey>(
+    Task<IDictionary<TKey, RewardGrantResult>> BatchGrantRewards<TKey>(
         IDictionary<TKey, Entity> entities
     )
         where TKey : struct;

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
@@ -479,13 +479,9 @@ public sealed partial class SummonService(
             returnedResult.Add(processedResult);
         }
 
-        IEnumerable<AtgenBuildEventRewardEntityList> overPresentEntityList = apiContext
-            .PlayerPresents.Local.Where(x => x.EntityType == EntityTypes.Dragon)
-            .Select(x => new AtgenBuildEventRewardEntityList(
-                x.EntityType,
-                x.EntityId,
-                x.EntityQuantity
-            ));
+        IEnumerable<AtgenBuildEventRewardEntityList> overPresentEntityList = presentService
+            .GetTrackedPresentList()
+            .Where(x => x.EntityType == EntityTypes.Dragon);
 
         return (
             returnedResult,

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/UnitService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/UnitService.cs
@@ -34,7 +34,7 @@ public class UnitService(
             .ToDictionary();
 
         IDictionary<int, RewardGrantResult> outputRewardDict =
-            await rewardService.GrantRewardsWithBatchHandler(inputRewardDict);
+            await rewardService.BatchGrantRewards(inputRewardDict);
 
         List<CharaNewCheckResult> result = [];
 
@@ -55,7 +55,7 @@ public class UnitService(
             .ToDictionary();
 
         IDictionary<int, RewardGrantResult> outputRewardDict =
-            await rewardService.GrantRewardsWithBatchHandler(inputRewardDict);
+            await rewardService.BatchGrantRewards(inputRewardDict);
 
         IEnumerable<Present.Present> presentsToAdd = outputRewardDict
             .Where(kvp => kvp.Value == RewardGrantResult.Limit)

--- a/DragaliaAPI/DragaliaAPI/Features/Trade/ITradeService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Trade/ITradeService.cs
@@ -20,4 +20,5 @@ public interface ITradeService
         IEnumerable<AtgenNeedUnitList>? needUnitList = null
     );
     Task DoAbilityCrestTrade(int id, int count);
+    EntityResult GetEntityResult();
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Trade/TreasureTradeController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Trade/TreasureTradeController.cs
@@ -44,6 +44,7 @@ public class TreasureTradeController(
         resp.UpdateDataList = await updateDataService.SaveChangesAsync(cancellationToken);
         resp.TreasureTradeAllList = tradeService.GetCurrentTreasureTradeList();
         resp.UserTreasureTradeList = await tradeService.GetUserTreasureTradeList();
+        resp.EntityResult = tradeService.GetEntityResult();
 
         return Ok(resp);
     }


### PR DESCRIPTION
More fallout from #792 - I forgot that you can trade for multiple dragons at once in treasure trade. After #792 this only gives 1 dragon and scams the player, as DragonHandler ignores `Entity.Quantity`. This is actually quite tricky to handle since each dragon could put you over the limit.

This change special-cases dragon trades and splits them up to be sent to the batch reward handler one-by-one which can process each one individually. To accomplish this the BatchGrantReward method has been expanded to use a fallback for non-batchable entities instead of just throwing.