### PR TITLE
Fix empty Ch 13 endeavour reward list

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MainStoryMissionGroupRewards.json
+++ b/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MainStoryMissionGroupRewards.json
@@ -50,7 +50,7 @@
       {
         "_Type": "Material",
         "_Id": 103001003,
-        "_Quantity": 20
+        "_Quantity": 60
       },
       {
         "_Type": "HustleHammer",

--- a/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MainStoryMissionGroupRewards.json
+++ b/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MainStoryMissionGroupRewards.json
@@ -41,7 +41,28 @@
   },
   {
     "_Id": 3,
-    "_Rewards": []
+    "_Rewards": [
+      {
+        "_Type": "Material",
+        "_Id": 104001043,
+        "_Quantity": 8
+      },
+      {
+        "_Type": "Material",
+        "_Id": 103001003,
+        "_Quantity": 20
+      },
+      {
+        "_Type": "HustleHammer",
+        "_Id": 0,
+        "_Quantity": 4
+      },
+      {
+        "_Type": "Rupies",
+        "_Id": 0,
+        "_Quantity": 1000000
+      }
+    ]
   },
   {
     "_Id": 8,

--- a/DragaliaAPI/DragaliaAPI/Services/Game/BonusService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Game/BonusService.cs
@@ -53,14 +53,14 @@ public class BonusService(
             DragonTimeBonus = new()
             {
 #if CHEATING
-                dragon_time_bonus = 20
+                DragonTimeBonus = 20
 #endif
             },
             AllBonus = new()
             {
 #if CHEATING
-                attack = 100,
-                hp = 100
+                Attack = 100,
+                Hp = 100
 #endif
             },
         };
@@ -118,7 +118,7 @@ public class BonusService(
             result[(UnitElement)d.EffType1].Hp += d.EffArgs1;
             result[(UnitElement)d.EffType1].Attack += d.EffArgs2;
 #if CHEATING
-            result[(UnitElement)d.EffType1].attack += 100;
+            result[(UnitElement)d.EffType1].Attack += 100;
 #endif
 
             if (d.EffType2 != 0)
@@ -127,7 +127,7 @@ public class BonusService(
                 result[(UnitElement)d.EffType2].Attack += d.EffArgs2;
 
 #if CHEATING
-                result[(UnitElement)d.EffType2].attack += 100;
+                result[(UnitElement)d.EffType2].Attack += 100;
 #endif
             }
         }
@@ -156,7 +156,7 @@ public class BonusService(
             result[(WeaponTypes)d.EffType1].Hp += d.EffArgs1;
             result[(WeaponTypes)d.EffType1].Attack += d.EffArgs2;
 #if CHEATING
-            result[(WeaponTypes)d.EffType1].attack += 100;
+            result[(WeaponTypes)d.EffType1].Attack += 100;
 #endif
 
             if (d.EffType2 != 0)
@@ -164,7 +164,7 @@ public class BonusService(
                 result[(WeaponTypes)d.EffType2].Hp += d.EffArgs1;
                 result[(WeaponTypes)d.EffType2].Attack += d.EffArgs2;
 #if CHEATING
-                result[(WeaponTypes)d.EffType2].attack += 100;
+                result[(WeaponTypes)d.EffType2].Attack += 100;
 #endif
             }
         }
@@ -193,7 +193,7 @@ public class BonusService(
                 result[(UnitElement)d.EffType1].Hp += d.EffArgs1;
                 result[(UnitElement)d.EffType1].Attack += d.EffArgs2;
 #if CHEATING
-                result[(UnitElement)d.EffType1].attack += 100;
+                result[(UnitElement)d.EffType1].Attack += 100;
 #endif
 
                 if (d.EffType2 != 0)
@@ -201,7 +201,7 @@ public class BonusService(
                     result[(UnitElement)d.EffType2].Hp += d.EffArgs1;
                     result[(UnitElement)d.EffType2].Attack += d.EffArgs2;
 #if CHEATING
-                    result[(UnitElement)d.EffType2].attack += 100;
+                    result[(UnitElement)d.EffType2].Attack += 100;
 #endif
                 }
             }
@@ -209,7 +209,7 @@ public class BonusService(
             {
                 result[(UnitElement)d.EffType1].DragonBonus += d.EffArgs1;
 #if CHEATING
-                result[(UnitElement)d.EffType1].dragon_bonus += 100;
+                result[(UnitElement)d.EffType1].DragonBonus += 100;
 #endif
                 // No facility gives dragon bonus to two elemental types
             }
@@ -238,7 +238,7 @@ public class BonusService(
             result[w.WeaponType].Hp += w.WeaponPassiveEffHp;
             result[w.WeaponType].Attack += w.WeaponPassiveEffAtk;
 #if CHEATING
-            result[w.WeaponType].attack += 100;
+            result[w.WeaponType].Attack += 100;
 #endif
         }
 


### PR DESCRIPTION
Closes #766

It is not actually possible to have the game not show this pop-up, even if you send the list as `null`, so I dug a bit deeper and it turns out that there are rewards meant to be shown here. Source is Gigz's entire campaign recording:

https://youtu.be/S4V_Luy-ZnY?t=977

Screencap:

<img src="https://github.com/SapiensAnatis/Dawnshard/assets/5047192/0e3d48b1-09e8-4f46-ad2b-a5af9caad477" width="40%"/>


Implement these rewards + some fixes to BonusService I needed to enable cheats while testing