### PR TITLE
Update image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,9 +78,6 @@ jobs:
           context: .
           push: true
           file: ${{ inputs.dockerfile }}
-          build-args: |
-            CI=true
-            BASE_DOTNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled
           tags: ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max    

--- a/DragaliaAPI/DragaliaAPI/Dockerfile
+++ b/DragaliaAPI/DragaliaAPI/Dockerfile
@@ -1,14 +1,9 @@
-ARG BASE_DOTNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0.3
-
-FROM $BASE_DOTNET_IMAGE AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.3-jammy-chiseled AS base
+USER app
+EXPOSE 8080
 WORKDIR /app
 
-EXPOSE 8080
-
 FROM mcr.microsoft.com/dotnet/sdk:8.0.203 AS build
-
-ARG CI
-
 WORKDIR /src
 COPY ["DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj", "DragaliaAPI/DragaliaAPI.MissionDesigner/"]
 COPY ["DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj", "DragaliaAPI/DragaliaAPI.MasterAssetConverter/"]
@@ -26,6 +21,5 @@ WORKDIR "/src/DragaliaAPI/DragaliaAPI"
 RUN dotnet publish "DragaliaAPI.csproj" -c Release -o /app/publish/ /p:UseAppHost=false
 
 FROM base AS final
-WORKDIR /app
 COPY --from=build /app/publish/ .
 ENTRYPOINT ["dotnet", "DragaliaAPI.dll"]

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Dockerfile
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Dockerfile
@@ -1,9 +1,7 @@
-ARG BASE_DOTNET_IMAGE=mcr.microsoft.com/dotnet/aspnet:8.0.3
-
-FROM $BASE_DOTNET_IMAGE AS base
-WORKDIR /app
-
+FROM mcr.microsoft.com/dotnet/aspnet:8.0.3-jammy-chiseled AS base
+USER app
 EXPOSE 8080
+WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0.203 AS build
 WORKDIR /src
@@ -19,6 +17,5 @@ WORKDIR "/src/PhotonStateManager/DragaliaAPI.Photon.StateManager"
 RUN dotnet publish "DragaliaAPI.Photon.StateManager.csproj" -c Release -o /app/publish/ /p:UseAppHost=false
 
 FROM base AS final
-WORKDIR /app
 COPY --from=build /app/publish/ .
 ENTRYPOINT ["dotnet", "DragaliaAPI.Photon.StateManager.dll"]


### PR DESCRIPTION
- Use non-root user
- Remove custom image argument, as dependabot doesn't understand it *1
- Remove redunant CI arg *2

*1 This was previously done to avoid using chiseled images locally as doing so caused the VS container debugging to die after not finding `tail`. This has been fixed in 17.10 Preview 2 and should be released soon https://github.com/microsoft/DockerTools/issues/409 

*2 This was done to not generate MissionProgressionInfo in CI but this condition was removed from the project file in #746 