### PR TITLE
Publish statemanager events for private rooms

### DIFF
--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-        <AssemblyVersion>3.2.4</AssemblyVersion>
+        <AssemblyVersion>3.2.5</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
@@ -122,7 +122,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
                 roomId
             );
 
-            this.pluginStateService.ShouldPublish =
+            this.pluginStateService.IsPubliclyVisible =
                 matchingType == MatchingTypes.Anyone && !this.roomState.IsRandomMatching;
         }
 

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
@@ -48,10 +48,10 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnCreateGame(ICreateGameCallInfo info)
         {
             this.gameLogicPlugin.OnCreateGame(info);
-
-            if (this.pluginStateService.ShouldPublish)
+            this.stateManagerPlugin.OnCreateGame(info);
+            
+            if (this.pluginStateService.IsPubliclyVisible)
             {
-                this.stateManagerPlugin.OnCreateGame(info);
                 this.discordPlugin.OnCreateGame(info);
             }
 
@@ -62,11 +62,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnJoin(IJoinGameCallInfo info)
         {
             this.gameLogicPlugin.OnJoin(info);
-
-            if (this.pluginStateService.ShouldPublish)
-            {
-                this.stateManagerPlugin.OnJoin(info);
-            }
+            this.stateManagerPlugin.OnJoin(info);
 
             if (!info.IsProcessed)
                 info.Continue();
@@ -75,9 +71,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnLeave(ILeaveGameCallInfo info)
         {
             this.gameLogicPlugin.OnLeave(info);
-
-            if (this.pluginStateService.ShouldPublish)
-                this.stateManagerPlugin.OnLeave(info);
+            this.stateManagerPlugin.OnLeave(info);
 
             if (!info.IsProcessed)
                 base.OnLeave(info);
@@ -88,7 +82,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             // This can't use OnCloseGame with StateManagerPlugin, as there can only be one synchronous outbound HTTP request
             // per event handler. (Unless we chain them together using callbacks...)
 
-            if (this.pluginStateService.ShouldPublish)
+            if (this.pluginStateService.IsPubliclyVisible)
             {
                 this.discordPlugin.BeforeCloseGame(info);
             }
@@ -100,11 +94,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnCloseGame(ICloseGameCallInfo info)
         {
             // GameLogicPlugin has no override for closing a game
-
-            if (this.pluginStateService.ShouldPublish)
-            {
-                this.stateManagerPlugin.OnCloseGame(info);
-            }
+            this.stateManagerPlugin.OnCloseGame(info);
 
             if (!info.IsProcessed)
                 info.Continue();
@@ -113,9 +103,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnRaiseEvent(IRaiseEventCallInfo info)
         {
             this.gameLogicPlugin.OnRaiseEvent(info);
-
-            if (this.pluginStateService.ShouldPublish)
-                this.stateManagerPlugin.OnRaiseEvent(info);
+            this.stateManagerPlugin.OnRaiseEvent(info);
 
             if (!info.IsProcessed)
                 info.Continue();
@@ -132,10 +120,10 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         public override void OnSetProperties(ISetPropertiesCallInfo info)
         {
             this.gameLogicPlugin.OnSetProperties(info);
+            this.stateManagerPlugin.OnSetProperties(info);
 
-            if (this.pluginStateService.ShouldPublish)
+            if (this.pluginStateService.IsPubliclyVisible)
             {
-                this.stateManagerPlugin.OnSetProperties(info);
                 this.discordPlugin.OnSetProperties(info);
             }
 

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
@@ -49,7 +49,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         {
             this.gameLogicPlugin.OnCreateGame(info);
             this.stateManagerPlugin.OnCreateGame(info);
-            
+
             if (this.pluginStateService.IsPubliclyVisible)
             {
                 this.discordPlugin.OnCreateGame(info);

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/PluginStateService.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/PluginStateService.cs
@@ -11,8 +11,8 @@ namespace DragaliaAPI.Photon.Plugin.Shared
         public bool IsUseSecondaryServer { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether room events should be pushed to Redis / Discord.
+        /// Gets or sets a value indicating whether room events should be pushed to Discord.
         /// </summary>
-        public bool ShouldPublish { get; set; }
+        public bool IsPubliclyVisible { get; set; }
     }
 }


### PR DESCRIPTION
The practice of not publishing StateManager events when a room's ShouldPublish flag is false is probably incorrect, since it breaks the ability to join private rooms via passcode if no room is ever created in Redis.

In general, it is probably best to update StateManager in all cases even if not _strictly_ necessary, for example updating player count in random matching rooms. The requests are generally non-blocking and will not cause any user-facing announcements. So we should limit the publish restrictions to the Discord plugin which does make user-facing announcements.