### PR TITLE
Handle Midgardsormr reliability PK error in fallback

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
@@ -268,7 +268,12 @@ public class StoryService(
                         )
                     );
 
-                    if (reward is { Type: EntityTypes.Dragon, Id: (int)Dragons.Midgardsormr })
+                    if (
+                        reward is { Type: EntityTypes.Dragon, Id: (int)Dragons.Midgardsormr }
+                        && !await apiContext.PlayerDragonReliability.AnyAsync(x =>
+                            x.DragonId == Dragons.Midgardsormr
+                        )
+                    )
                     {
                         // The game doesn't handle it well if you send the Chapter 1 Midgardsormr to the gift box.
                         // You will later be forced to give him a gift in the dragon's roost tutorial, which will fail


### PR DESCRIPTION
The edge case fix in #800 for having full storage when trying to complete the story that gives you Midgardsormr has its own edge case. It causes a PK error if you somehow already have Midgardsormr - which is possible via save editing.