### PR TITLE
Fix T3 event materials being unavailable from certain events

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Event/EventDropService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/EventDropService.cs
@@ -180,8 +180,18 @@ public class EventDropService(IRewardService rewardService, IEventRepository eve
         if (type == DungeonTypes.Wave)
         {
             // T3 only drops from Challenge Battle quests
+
+            // Typically, there are two challenge battle quests - an easier one and a harder one. We want to give more
+            // rewards for the harder one. This previously used questData.VariationType, but that is inconsistent
+            // between events; see https://github.com/SapiensAnatis/Dawnshard/issues/507. 
+            // This hack instead relies on the fact that the quest IDs for wave quests are always organized like:
+            //     208170501  Season's Beatings: Expert
+            //     208170502  Season's Beatings: Master
+            // It therefore provides a multiplier of 1 for the hard quest, and 0.5 for the easy quest.
+            double t3Multiplier = quest.Id % 10 / 2d;
+            
             int t3Quantity = GenerateDropAmount(
-                10 * record.Wave * ((variation - VariationTypes.Hard) / 2d) * buildDropMultiplier
+                10 * record.Wave * t3Multiplier * buildDropMultiplier
             );
             yield return new Entity(evt.ViewEntityType3, evt.ViewEntityId3, t3Quantity);
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Event/EventDropService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/EventDropService.cs
@@ -183,13 +183,13 @@ public class EventDropService(IRewardService rewardService, IEventRepository eve
 
             // Typically, there are two challenge battle quests - an easier one and a harder one. We want to give more
             // rewards for the harder one. This previously used questData.VariationType, but that is inconsistent
-            // between events; see https://github.com/SapiensAnatis/Dawnshard/issues/507. 
+            // between events; see https://github.com/SapiensAnatis/Dawnshard/issues/507.
             // This hack instead relies on the fact that the quest IDs for wave quests are always organized like:
             //     208170501  Season's Beatings: Expert
             //     208170502  Season's Beatings: Master
             // It therefore provides a multiplier of 1 for the hard quest, and 0.5 for the easy quest.
             double t3Multiplier = quest.Id % 10 / 2d;
-            
+
             int t3Quantity = GenerateDropAmount(
                 10 * record.Wave * t3Multiplier * buildDropMultiplier
             );

--- a/DragaliaAPI/DragaliaAPI/Properties/launchSettings.json
+++ b/DragaliaAPI/DragaliaAPI/Properties/launchSettings.json
@@ -8,7 +8,7 @@
                 "RedisOptions__Hostname": "localhost",
                 "PostgresOptions__Hostname": "localhost"
             },
-            "applicationUrl": "http://localhost:80"
+            "applicationUrl": "http://*:80"
         }
     }
 }


### PR DESCRIPTION
Closes #507

Replaces the calculation based on VariationType with one that looks at the least significant digits of the quest ID, as these always follow a particular structure for wave quests across all events. It produces an identical result to the old calculation assuming that the old calculation was intended for typical events with VariationType 3 and 4 in the wave quests.

\+ `launchSettings.json` fix for making the server accessible via a mobile device