### PR TITLE
Fire mission progression events during story skip

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -107,7 +107,7 @@ csharp_preferred_modifier_order = public,private,protected,internal,static,exter
 csharp_style_prefer_readonly_struct = true
 
 # Code-block preferences
-csharp_prefer_braces = when_multiline:warning
+csharp_prefer_braces = true:warning
 csharp_prefer_simple_using_statement = true:warning
 csharp_style_namespace_declarations = file_scoped:warning
 csharp_style_prefer_method_group_conversion = true:warning

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -1,6 +1,8 @@
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Utils;
 using DragaliaAPI.Features.StorySkip;
 using DragaliaAPI.Shared.Features.StorySkip;
+using DragaliaAPI.Shared.MasterAsset.Models.Missions;
 using Microsoft.EntityFrameworkCore;
 using static DragaliaAPI.Shared.Features.StorySkip.StorySkipRewards;
 
@@ -57,6 +59,8 @@ public class StorySkipTest : TestFixture
             .ApiContext.PlayerFortBuilds.Where(x => x.ViewerId == this.ViewerId)
             .ExecuteDeleteAsync();
 
+        await this.Client.PostMsgpack("mission/unlock_drill_mission_group", new MissionUnlockDrillMissionGroupRequest(1));
+
         StorySkipSkipResponse data = (
             await this.Client.PostMsgpack<StorySkipSkipResponse>("story_skip/skip")
         ).Data;
@@ -98,5 +102,13 @@ public class StorySkipTest : TestFixture
                 fort.Level.Should().Be(fortConfig.Level);
             }
         }
+        
+        int clearCh1Quest23Mission = 100200;
+        this.ApiContext.PlayerMissions.Should().Contain(x => x.Id == clearCh1Quest23Mission).Which.State.Should()
+            .Be(MissionState.Completed);
+
+        int upgradeHalidomToLv3Mission = 105500;
+        this.ApiContext.PlayerMissions.Should().Contain(x => x.Id == upgradeHalidomToLv3Mission).Which.State.Should()
+            .Be(MissionState.Completed);
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Missions/MissionService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Missions/MissionService.cs
@@ -515,7 +515,7 @@ public class MissionService(
         {
             DbPlayerMission? activeMission = allMissions
                 .OrderBy(x => x.Id)
-                .FirstOrDefault(x => x.State < MissionState.Claimed);
+                .FirstOrDefault(x => x.State < MissionState.Completed);
 
             if (activeMission != null)
             {


### PR DESCRIPTION
Closes #829. Ensure that we fire the corresponding mission events when updating player state during the story skip process.

Also:
- Fix royal regimen displaying completed but unclaimed quests as active
- Minor naming nitpicks, micro-optimization of LINQ in StorySkipService
- Force braces for 1-line if statements after I read about `goto fail`

https://en.wikipedia.org/wiki/Unreachable_code#goto_fail_bug