### PR TITLE
Filter out hidden news items in Blazor

### DIFF
--- a/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
+++ b/DragaliaAPI/DragaliaAPI/RazorComponents/News/NewsComponent.razor
@@ -73,6 +73,7 @@
         }
 
         this.allNewsItems = await this.ApiContext.NewsItems
+            .Where(x => !x.Hidden)
             .OrderByDescending(x => x.Date)
             .Select(x => new NewsItem(x))
             .ToListAsync();


### PR DESCRIPTION
The MG news item was added as part of #850 but was filtered from the Svelte site, however it is now showing on the Blazor website