### PR TITLE
Add pity rate accumulation

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/FeatureExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/FeatureExtensions.cs
@@ -21,12 +21,12 @@ public static partial class FeatureExtensions
         serviceCollection
             .Configure<SummonBannerOptions>(config.GetRequiredSection(nameof(SummonBannerOptions)))
             .AddOptions<SummonBannerOptions>()
-            .PostConfigure(opts => opts.PostConfigure())
             .Validate(
                 opts => opts.Banners.DistinctBy(x => x.Id).Count() == opts.Banners.Count,
                 "bannerConfig.json IDs must be unique!"
             )
-            .ValidateOnStart();
+            .ValidateOnStart()
+            .PostConfigure(opts => opts.PostConfigure());
 
         return serviceCollection;
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonBannerOptions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonBannerOptions.cs
@@ -11,6 +11,7 @@ namespace DragaliaAPI.Features.Summoning;
 public class SummonBannerOptions
 {
     private readonly List<Banner> banners = [];
+    private Dictionary<int, Banner>? bannerDict;
 
     /// <summary>
     /// Gets a list of active summoning banners.
@@ -20,6 +21,14 @@ public class SummonBannerOptions
         get => this.banners;
         init => this.banners = value as List<Banner> ?? value.ToList();
     }
+
+    /// <summary>
+    /// Gets a dictionary of <see cref="Banner"/> objects, keyed by each banner's <see cref="Banner.Id"/>.
+    /// </summary>
+    /// <exception cref="InvalidOperationException"><see cref="PostConfigure"/> has not yet been called on this instance.</exception>
+    public IReadOnlyDictionary<int, Banner> BannerDict =>
+        this.bannerDict
+        ?? throw new InvalidOperationException("SummonBannerOptions not yet initialized!");
 
     /// <summary>
     /// Initializes the instance, intended for use with <see cref="Microsoft.Extensions.Options.OptionsBuilder{T}.PostConfigure"/>.
@@ -36,6 +45,8 @@ public class SummonBannerOptions
         {
             banner.PostConfigure();
         }
+
+        this.bannerDict = this.banners.ToDictionary(x => x.Id, x => x);
     }
 }
 

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonController.cs
@@ -180,7 +180,8 @@ public class SummonController(
 
         UserSummonList userSummonList = await summonService.UpdateUserSummonInformation(
             summonList,
-            summonCount
+            summonCount,
+            metaInfo
         );
 
         SummonEffect effect = SummonEffectHelper.CalculateEffect(metaInfo);

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonOddsService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonOddsService.cs
@@ -1,13 +1,9 @@
 using System.Diagnostics;
 using DragaliaAPI.Database;
-using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services.Exceptions;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Definitions.Enums.Summon;
-using DragaliaAPI.Shared.Features.Summoning;
-using DragaliaAPI.Shared.MasterAsset;
-using DragaliaAPI.Shared.MasterAsset.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
 
@@ -30,8 +26,8 @@ public class SummonOddsService(
     public OddsRate? GetGuaranteeOddsRate(int bannerId, int summonCountSinceLastFiveStar)
     {
         if (
-            optionsMonitor.CurrentValue.Banners.FirstOrDefault(x => x.Id == bannerId) is
-            { SummonType: not SummonTypes.Normal }
+            optionsMonitor.CurrentValue.BannerDict.TryGetValue(bannerId, out Banner? banner)
+            && banner.SummonType != SummonTypes.Normal
         )
         {
             // Certain special banners, like the 5* summon voucher ones, have no concept
@@ -51,9 +47,7 @@ public class SummonOddsService(
 
     public UnitRateCollection GetUnitRates(int bannerId, int summonCountSinceLastFiveStar)
     {
-        Banner? banner = optionsMonitor.CurrentValue.Banners.SingleOrDefault(x => x.Id == bannerId);
-
-        if (banner is null)
+        if (!optionsMonitor.CurrentValue.BannerDict.TryGetValue(bannerId, out Banner? banner))
         {
             throw new DragaliaException(
                 ResultCode.CommonInvalidArgument,
@@ -66,9 +60,7 @@ public class SummonOddsService(
 
     public UnitRateCollection GetGuaranteeUnitRates(int bannerId, int summonCountSinceLastFiveStar)
     {
-        Banner? banner = optionsMonitor.CurrentValue.Banners.SingleOrDefault(x => x.Id == bannerId);
-
-        if (banner is null)
+        if (!optionsMonitor.CurrentValue.BannerDict.TryGetValue(bannerId, out Banner? banner))
         {
             throw new DragaliaException(
                 ResultCode.CommonInvalidArgument,

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.Log.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.Log.cs
@@ -30,5 +30,8 @@ public partial class SummonService
             ILogger logger,
             AtgenSummonPointTradeList trade
         );
+
+        [LoggerMessage(LogLevel.Information, "Granting guaranteed 5* reward for banner {BannerId}")]
+        public static partial void GrantingGuaranteedFiveStar(ILogger logger, int bannerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
+++ b/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
@@ -78,6 +78,26 @@
                 "TradeDragons": [
                     "Arsene"
                 ]
+            },
+            {
+                "Id": 1020183,
+                "Start": "2024-02-24T15:22:06Z",
+                "End": "2037-02-24T15:22:06Z",
+                "IsGala": true,
+                "IsPrizeShowcase": false,
+                "FeaturedAdventurers": [
+                    "GalaCleo"
+                ],
+                "FeaturedDragons": [
+                ],
+                "LimitedAdventurers": [
+                ],
+                "LimitedDragons": [
+                ],
+                "TradeAdventurers": [
+                ],
+                "TradeDragons": [
+                ]
             }
         ]
     },


### PR DESCRIPTION
Closes #698.

Second half of work started in #849, which only implemented the calculation. This PR implements the logic to accumulate the pity counter when summoning, as well as the "maximum pity" mechanic which guarantees a five-star after reaching 9% pity rate.