### PR TITLE
Fix auto-repeat counter not resetting

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
@@ -185,7 +185,7 @@ public class AutoRepeatTest : TestFixture
             await Client.PostMsgpack<RepeatEndResponse>("repeat/end")
         ).Data;
 
-        repeatEndResponse.RepeatData.Should().BeEquivalentTo(recordResponse2.RepeatData);
+        repeatEndResponse.RepeatData.Should().BeNull();
 
         // Breaking news: lazy developer too lazy to test cumbersome merging logic
         int expectedCoin =

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/MypageController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/MypageController.cs
@@ -47,7 +47,9 @@ public class MypageController(
         RepeatInfo? repeatInfo = await autoRepeatService.GetRepeatInfo();
 
         if (repeatInfo != null)
+        {
             resp.RepeatData = new(repeatInfo.Key.ToString(), repeatInfo.CurrentCount, 1);
+        }
 
         return Ok(resp);
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/AutoRepeatService.cs
@@ -2,6 +2,7 @@ using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Shared.Definitions.Enums.Dungeon;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 
@@ -56,9 +57,6 @@ public class AutoRepeatService(
          *
          * In the former case, we need to retrieve the pre-configured settings from the start request,
          * and in the latter case we need to create default settings.
-         *
-         * Additionally, the client may also send a stale repeat key on the first iteration instead of a null value.
-         * This then fails to find any data. We treat this the same as not having provided a key in the first place.
          */
 
         if (repeatKey != null)
@@ -70,7 +68,11 @@ public class AutoRepeatService(
         if (info == null)
         {
             info = await this.GetRepeatInfo();
-            logger.LogTrace("Repeat key lookup failed. Viewer ID lookup found: {@Info}", info);
+            logger.LogTrace(
+                "Repeat key lookup for key {Key} failed. Viewer ID lookup found: {@Info}",
+                repeatKey,
+                info
+            );
         }
 
         if (info == null)

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/AutoRepeat/RepeatController.cs
@@ -39,7 +39,7 @@ public class RepeatController(
                     OverPresentLimitEntityList = [],
                     OverPresentEntityList = []
                 },
-                RepeatData = new(info.Key.ToString(), info.CurrentCount, 1)
+                RepeatData = null,
             };
 
         return response;


### PR DESCRIPTION
Closes #764.

We need to set `RepeatData` to null in the `/repeat/end` response, to convince the client that auto-repeat is over.

One would have thought it was smart enough to realize that calling `/repeat/end` means that auto-repeat has ended. :shrug: 
