### PR TITLE
Actually remove dungeon sessions

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -103,7 +103,7 @@ public class DungeonRecordTest : TestFixture
                 }
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         DungeonRecordRecordResponse response = (
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -229,7 +229,7 @@ public class DungeonRecordTest : TestFixture
                 }
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         DungeonRecordRecordResponse response = (
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -280,7 +280,7 @@ public class DungeonRecordTest : TestFixture
                 }
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         DungeonRecordRecordResponse response = (
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -864,7 +864,7 @@ public class DungeonRecordTest : TestFixture
                 }
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         DragaliaResponse<DungeonRecordRecordResponse> response =
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -988,7 +988,7 @@ public class DungeonRecordTest : TestFixture
                 EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         (
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -1043,7 +1043,7 @@ public class DungeonRecordTest : TestFixture
                 EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         (
             await Client.PostMsgpack<DungeonRecordRecordResponse>(
@@ -1209,8 +1209,14 @@ public class DungeonRecordTest : TestFixture
         response.UpdateDataList.UserData.TutorialStatus.Should().Be(20501);
     }
 
-    private async Task<string> StartDungeon(DungeonSession session) =>
-        await Services.GetRequiredService<IDungeonService>().StartDungeon(session);
+    private async Task<string> StartDungeon(DungeonSession session)
+    {
+        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
+        string key = service.CreateSession(session);
+        await service.WriteSession(CancellationToken.None);
+
+        return key;
+    }
 
     private void SetupPhotonAuthentication()
     {

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -1211,9 +1211,8 @@ public class DungeonRecordTest : TestFixture
 
     private async Task<string> StartDungeon(DungeonSession session)
     {
-        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
-        string key = service.CreateSession(session);
-        await service.WriteSession(CancellationToken.None);
+        string key = this.DungeonService.CreateSession(session);
+        await this.DungeonService.SaveSession(CancellationToken.None);
 
         return key;
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -869,10 +869,22 @@ public class SummonTest : TestFixture
 
         response.Data.ResultUnitList.Should().Contain(x => x.Rarity == 5);
 
-        this.ApiContext.PlayerBannerData.AsNoTracking()
-            .First(x => x.SummonBannerId == TestGalaBannerId)
-            .SummonCountSinceLastFiveStar.Should()
-            .Be(0);
+        SummonGetOddsDataResponse oddsResponse = (
+            await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
+                "summon/get_odds_data",
+                new SummonGetOddsDataRequest(TestBannerId)
+            )
+        ).Data;
+
+        oddsResponse
+            .OddsRateList.Normal.RarityList.Should()
+            .BeEquivalentTo(
+                [
+                    new AtgenRarityList { Rarity = 5, TotalRate = "4.00%" },
+                    new AtgenRarityList { Rarity = 4, TotalRate = "16.00%" },
+                    new AtgenRarityList { Rarity = 3, TotalRate = "80.00%" },
+                ]
+            );
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -332,9 +332,8 @@ public class WallRecordTest : TestFixture
 
     private async Task<string> StartDungeon(DungeonSession session)
     {
-        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
-        string key = service.CreateSession(session);
-        await service.WriteSession(CancellationToken.None);
+        string key = this.DungeonService.CreateSession(session);
+        await this.DungeonService.SaveSession(CancellationToken.None);
 
         return key;
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -62,7 +62,7 @@ public class WallRecordTest : TestFixture
                 WallLevel = wallLevel + 1 // Client passes (db wall level + 1)
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
@@ -160,7 +160,7 @@ public class WallRecordTest : TestFixture
                 WallLevel = wallLevel
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
@@ -239,7 +239,7 @@ public class WallRecordTest : TestFixture
                 WallLevel = 6
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
@@ -309,7 +309,7 @@ public class WallRecordTest : TestFixture
                 WallLevel = 80
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
@@ -328,5 +328,14 @@ public class WallRecordTest : TestFixture
             ?.NormalMissionNotice;
 
         missionNotice.Should().BeNull();
+    }
+
+    private async Task<string> StartDungeon(DungeonSession session)
+    {
+        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
+        string key = service.CreateSession(session);
+        await service.WriteSession(CancellationToken.None);
+
+        return key;
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
@@ -259,9 +259,8 @@ public class WallTest : TestFixture
 
     private async Task<string> StartDungeon(DungeonSession session)
     {
-        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
-        string key = service.CreateSession(session);
-        await service.WriteSession(CancellationToken.None);
+        string key = this.DungeonService.CreateSession(session);
+        await this.DungeonService.SaveSession(CancellationToken.None);
 
         return key;
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
@@ -38,7 +38,7 @@ public class WallTest : TestFixture
                 WallLevel = expectedWallLevel
             };
 
-        string key = await Services.GetRequiredService<IDungeonService>().StartDungeon(mockSession);
+        string key = await this.StartDungeon(mockSession);
 
         WallFailResponse response = (
             await Client.PostMsgpack<WallFailResponse>(
@@ -255,5 +255,14 @@ public class WallTest : TestFixture
         );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.CommonInvalidArgument);
+    }
+
+    private async Task<string> StartDungeon(DungeonSession session)
+    {
+        IDungeonService service = this.Services.GetRequiredService<IDungeonService>();
+        string key = service.CreateSession(session);
+        await service.WriteSession(CancellationToken.None);
+
+        return key;
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Shared/Definitions/Enums/VariationTypes.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/Definitions/Enums/VariationTypes.cs
@@ -7,6 +7,7 @@ namespace DragaliaAPI.Shared.Definitions.Enums;
 /// </summary>
 public enum VariationTypes
 {
+    None = 0,
     Normal = 1,
     Hard = 2,
     VeryHard = 3,

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
@@ -66,22 +66,17 @@ public class DungeonControllerTest
                 }
             };
 
-        this.mockDungeonService.Setup(x => x.FinishDungeon("my key"))
-            .ReturnsAsync(
-                new DungeonSession()
-                {
-                    QuestData = MasterAsset.QuestData.Get(questId),
-                    Party = new List<PartySettingList>(),
-                    IsMulti = false,
-                    SupportViewerId = 4,
-                }
-            );
+        this.mockDungeonService.Setup(x => x.RemoveSession("my key", CancellationToken.None))
+            .Returns(Task.CompletedTask);
 
         this.mockDungeonRecordHelperService.Setup(x => x.ProcessHelperDataSolo(4))
             .ReturnsAsync((userSupportList, supportDetailList));
 
         DungeonFailResponse? response = (
-            await this.dungeonController.Fail(new DungeonFailRequest() { DungeonKey = "my key" })
+            await this.dungeonController.Fail(
+                new DungeonFailRequest() { DungeonKey = "my key" },
+                CancellationToken.None
+            )
         ).GetData<DungeonFailResponse>();
 
         response.Should().NotBeNull();
@@ -126,15 +121,8 @@ public class DungeonControllerTest
                 }
             };
 
-        this.mockDungeonService.Setup(x => x.FinishDungeon("my key"))
-            .ReturnsAsync(
-                new DungeonSession()
-                {
-                    QuestData = MasterAsset.QuestData.Get(questId),
-                    Party = new List<PartySettingList>(),
-                    IsMulti = true,
-                }
-            );
+        this.mockDungeonService.Setup(x => x.RemoveSession("my key", CancellationToken.None))
+            .Returns(Task.CompletedTask);
 
         this.mockDungeonRecordHelperService.Setup(x => x.ProcessHelperDataMulti())
             .ReturnsAsync((userSupportList, supportDetailList));
@@ -142,7 +130,10 @@ public class DungeonControllerTest
         this.mockMatchingService.Setup(x => x.GetIsHost()).ReturnsAsync(false);
 
         DungeonFailResponse? response = (
-            await this.dungeonController.Fail(new DungeonFailRequest() { DungeonKey = "my key" })
+            await this.dungeonController.Fail(
+                new DungeonFailRequest() { DungeonKey = "my key" },
+                CancellationToken.None
+            )
         ).GetData<DungeonFailResponse>();
 
         response.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/DungeonControllerTest.cs
@@ -66,6 +66,17 @@ public class DungeonControllerTest
                 }
             };
 
+        this.mockDungeonService.Setup(x => x.GetSession("my key", CancellationToken.None))
+            .ReturnsAsync(
+                new DungeonSession()
+                {
+                    Party = [],
+                    IsMulti = false,
+                    SupportViewerId = 4,
+                    QuestData = MasterAsset.QuestData[questId]
+                }
+            );
+
         this.mockDungeonService.Setup(x => x.RemoveSession("my key", CancellationToken.None))
             .Returns(Task.CompletedTask);
 
@@ -120,6 +131,16 @@ public class DungeonControllerTest
                     GetManaPoint = 50,
                 }
             };
+
+        this.mockDungeonService.Setup(x => x.GetSession("my key", CancellationToken.None))
+            .ReturnsAsync(
+                new DungeonSession()
+                {
+                    Party = [],
+                    IsMulti = true,
+                    QuestData = MasterAsset.QuestData[questId]
+                }
+            );
 
         this.mockDungeonService.Setup(x => x.RemoveSession("my key", CancellationToken.None))
             .Returns(Task.CompletedTask);

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonServiceTest.cs
@@ -53,7 +53,7 @@ public class DungeonServiceTest
             };
 
         string key = dungeonService.CreateSession(session);
-        await dungeonService.WriteSession(CancellationToken.None);
+        await dungeonService.SaveSession(CancellationToken.None);
 
         (await dungeonService.GetSession(key, CancellationToken.None))
             .Should()

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonServiceTest.cs
@@ -3,6 +3,7 @@ using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Models.Options;
 using DragaliaAPI.Shared.MasterAsset;
+using DragaliaAPI.Test.Utils;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -33,6 +34,7 @@ public class DungeonServiceTest
         dungeonService = new DungeonService(
             testCache,
             this.mockOptions.Object,
+            IdentityTestUtils.MockPlayerDetailsService.Object,
             this.mockLogger.Object
         );
     }
@@ -50,8 +52,11 @@ public class DungeonServiceTest
                 }
             };
 
-        string key = await dungeonService.StartDungeon(session);
+        string key = dungeonService.CreateSession(session);
+        await dungeonService.WriteSession(CancellationToken.None);
 
-        (await dungeonService.GetDungeon(key)).Should().BeEquivalentTo(session);
+        (await dungeonService.GetSession(key, CancellationToken.None))
+            .Should()
+            .BeEquivalentTo(session);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
@@ -75,7 +75,9 @@ public class WallRecordControllerTest
                 WallLevel = wallLevel
             };
 
-        mockDungeonService.Setup(x => x.FinishDungeon(dungeonKey)).ReturnsAsync(session);
+        mockDungeonService
+            .Setup(x => x.RemoveSession(dungeonKey, CancellationToken.None))
+            .Returns(Task.CompletedTask);
 
         mockWallService.Setup(x => x.GetQuestWall(wallId)).ReturnsAsync(playerQuestWall);
         mockWallService.Setup(x => x.LevelupQuestWall(wallId)).Returns(Task.CompletedTask);

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
@@ -75,6 +75,9 @@ public class WallRecordControllerTest
                 WallLevel = wallLevel
             };
 
+        this.mockDungeonService.Setup(x => x.GetSession(dungeonKey, CancellationToken.None))
+            .ReturnsAsync(session);
+
         mockDungeonService
             .Setup(x => x.RemoveSession(dungeonKey, CancellationToken.None))
             .Returns(Task.CompletedTask);

--- a/DragaliaAPI/DragaliaAPI/Extensions/DistributedCacheExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Extensions/DistributedCacheExtensions.cs
@@ -6,13 +6,16 @@ public static class DistributedCacheExtensions
 {
     public static async Task<TObject?> GetJsonAsync<TObject>(
         this IDistributedCache cache,
-        string key
+        string key,
+        CancellationToken cancellationToken = default
     )
         where TObject : class
     {
-        string? json = await cache.GetStringAsync(key);
+        string? json = await cache.GetStringAsync(key, cancellationToken);
         if (json == null)
+        {
             return default;
+        }
 
         return JsonSerializer.Deserialize<TObject>(json);
     }
@@ -21,6 +24,7 @@ public static class DistributedCacheExtensions
         this IDistributedCache cache,
         string key,
         object entry,
-        DistributedCacheEntryOptions options
-    ) => cache.SetStringAsync(key, JsonSerializer.Serialize(entry), options);
+        DistributedCacheEntryOptions options,
+        CancellationToken cancellationToken = default
+    ) => cache.SetStringAsync(key, JsonSerializer.Serialize(entry), options, cancellationToken);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonController.cs
@@ -44,7 +44,7 @@ public class DungeonController(
             cancellationToken
         );
 
-        await dungeonService.WriteSession(cancellationToken);
+        await dungeonService.SaveSession(cancellationToken);
 
         return Ok(new DungeonGetAreaOddsResponse() { OddsInfo = oddsInfo });
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonMapper.cs
@@ -1,0 +1,37 @@
+using System.Collections;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Entities.Scaffold;
+using DragaliaAPI.Models.Generated;
+using DragaliaAPI.Shared.MasterAsset.Models;
+using Riok.Mapperly.Abstractions;
+
+namespace DragaliaAPI.Features.Dungeon;
+
+[Mapper(
+    RequiredMappingStrategy = RequiredMappingStrategy.Target,
+    IgnoreObsoleteMembersStrategy = IgnoreObsoleteMembersStrategy.Target
+)]
+public static partial class DungeonMapper
+{
+    public static partial IEnumerable<PartyUnitList> MapToPartyUnitList(
+        this IEnumerable<DbDetailedPartyUnit> detailedPartyUnits
+    );
+
+    public static partial IEnumerable<PartySettingList> MapToPartySettingList(
+        this IEnumerable<DbPartyUnit> partyUnits
+    );
+
+    public static partial IEnumerable<AreaInfoList> MapToAreaInfoList(
+        this IEnumerable<AreaInfo> areaInfo
+    );
+
+    [MapperIgnoreTarget(nameof(CharaList.StatusPlusCount))]
+    private static partial CharaList MapToCharaList(DbPlayerCharaData charaData);
+
+    [MapperIgnoreTarget(nameof(DragonList.StatusPlusCount))]
+    private static partial DragonList MapToDragonList(DbPlayerDragonData charaData);
+
+    [MapProperty(nameof(DbAbilityCrest.AbilityLevel), nameof(GameAbilityCrest.Ability1Level))]
+    [MapProperty(nameof(DbAbilityCrest.AbilityLevel), nameof(GameAbilityCrest.Ability2Level))]
+    private static partial GameAbilityCrest? MapToGameAbilityCrest(DbAbilityCrest? abilityCrest);
+}

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
@@ -43,15 +43,11 @@ public class DungeonService(
         CancellationToken cancellationToken
     )
     {
-        string json =
-            await cache.GetStringAsync(
+        DungeonSession session =
+            await cache.GetJsonAsync<DungeonSession>(
                 Schema.DungeonKey_DungeonData(playerIdentityService.ViewerId, dungeonKey),
                 cancellationToken
             ) ?? throw new DungeonException(dungeonKey);
-
-        DungeonSession session =
-            JsonSerializer.Deserialize<DungeonSession>(json)
-            ?? throw new JsonException("Could not deserialize dungeon session.");
 
         this.currentSession = session;
         this.currentKey = dungeonKey;
@@ -69,9 +65,9 @@ public class DungeonService(
             );
         }
 
-        await cache.SetStringAsync(
+        await cache.SetJsonAsync(
             Schema.DungeonKey_DungeonData(playerIdentityService.ViewerId, this.currentKey),
-            JsonSerializer.Serialize(this.currentSession),
+            this.currentSession,
             CacheOptions,
             cancellationToken
         );

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
@@ -49,11 +49,17 @@ public class DungeonService(
                 cancellationToken
             ) ?? throw new DungeonException(dungeonKey);
 
-        return JsonSerializer.Deserialize<DungeonSession>(json)
+        DungeonSession session =
+            JsonSerializer.Deserialize<DungeonSession>(json)
             ?? throw new JsonException("Could not deserialize dungeon session.");
+
+        this.currentSession = session;
+        this.currentKey = dungeonKey;
+
+        return session;
     }
 
-    public async Task WriteSession(CancellationToken cancellationToken)
+    public async Task SaveSession(CancellationToken cancellationToken)
     {
         if (this.currentSession == null || this.currentKey == null)
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonService.cs
@@ -1,15 +1,20 @@
 ﻿using DragaliaAPI.Models;
 using DragaliaAPI.Models.Options;
+using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Options;
 
 namespace DragaliaAPI.Features.Dungeon;
 
-public class DungeonService : IDungeonService
+public class DungeonService(
+    IDistributedCache cache,
+    IOptionsMonitor<RedisCachingOptions> options,
+    IPlayerIdentityService playerIdentityService,
+    ILogger<DungeonService> logger
+) : IDungeonService
 {
-    private readonly IDistributedCache cache;
-    private readonly IOptionsMonitor<RedisCachingOptions> options;
-    private readonly ILogger<DungeonService> logger;
+    private DungeonSession? currentSession;
+    private string? currentKey;
 
     private DistributedCacheEntryOptions CacheOptions =>
         new()
@@ -19,77 +24,73 @@ public class DungeonService : IDungeonService
 
     private static class Schema
     {
-        public static string DungeonKey_DungeonData(string dungeonKey) => $":dungeon:{dungeonKey}";
+        public static string DungeonKey_DungeonData(long viewerId, string dungeonKey) =>
+            $":dungeon:{viewerId}:{dungeonKey}";
     }
 
-    public DungeonService(
-        IDistributedCache cache,
-        IOptionsMonitor<RedisCachingOptions> options,
-        ILogger<DungeonService> logger
+    public string CreateSession(DungeonSession dungeonSession)
+    {
+        this.currentKey = Guid.NewGuid().ToString();
+        this.currentSession = dungeonSession;
+
+        logger.LogDebug("Created dungeon session with key {Key}", currentKey);
+
+        return currentKey;
+    }
+
+    public async Task<DungeonSession> GetSession(
+        string dungeonKey,
+        CancellationToken cancellationToken
     )
     {
-        this.cache = cache;
-        this.options = options;
-        this.logger = logger;
-    }
-
-    public async Task<string> StartDungeon(DungeonSession dungeonSession)
-    {
-        string dungeonKey = Guid.NewGuid().ToString();
-        await WriteDungeon(dungeonKey, dungeonSession);
-
-        this.logger.LogDebug("Issued dungeon key {key}", dungeonKey);
-
-        return dungeonKey;
-    }
-
-    public async Task<DungeonSession> GetDungeon(string dungeonKey)
-    {
         string json =
-            await cache.GetStringAsync(Schema.DungeonKey_DungeonData(dungeonKey))
-            ?? throw new DungeonException(dungeonKey);
+            await cache.GetStringAsync(
+                Schema.DungeonKey_DungeonData(playerIdentityService.ViewerId, dungeonKey),
+                cancellationToken
+            ) ?? throw new DungeonException(dungeonKey);
 
         return JsonSerializer.Deserialize<DungeonSession>(json)
             ?? throw new JsonException("Could not deserialize dungeon session.");
     }
 
-    private async Task WriteDungeon(string dungeonKey, DungeonSession session)
+    public async Task WriteSession(CancellationToken cancellationToken)
     {
+        if (this.currentSession == null || this.currentKey == null)
+        {
+            throw new InvalidOperationException(
+                "Cannot perform WriteSession when no dungeon session is being tracked. "
+                    + "A session must be loaded either via CreateSession or GetSession before one can be saved."
+            );
+        }
+
         await cache.SetStringAsync(
-            Schema.DungeonKey_DungeonData(dungeonKey),
-            JsonSerializer.Serialize(session),
-            CacheOptions
+            Schema.DungeonKey_DungeonData(playerIdentityService.ViewerId, this.currentKey),
+            JsonSerializer.Serialize(this.currentSession),
+            CacheOptions,
+            cancellationToken
         );
     }
 
-    /// <summary>
-    /// Update a session already in the cache.
-    /// </summary>
-    /// <remarks>
-    /// This method should not exist. The dungeon_start code could be better structured to avoid its use.
-    /// TODO: Remove all usages
-    /// </remarks>
-    /// <param name="dungeonKey">The dungeon key.</param>
-    /// <param name="update">The action to update with.</param>
-    /// <returns>A task.</returns>
-    public async Task ModifySession(string dungeonKey, Action<DungeonSession> update)
+    public async Task ModifySession(
+        string dungeonKey,
+        Action<DungeonSession> update,
+        CancellationToken cancellationToken
+    )
     {
-        DungeonSession session = await this.GetDungeon(dungeonKey);
-
-        update.Invoke(session);
-
-        await WriteDungeon(dungeonKey, session);
+        this.currentSession ??= await this.GetSession(dungeonKey, cancellationToken);
+        update.Invoke(this.currentSession);
     }
 
-    public async Task<DungeonSession> FinishDungeon(string dungeonKey)
+    public async Task RemoveSession(string dungeonKey, CancellationToken cancellationToken)
     {
-        DungeonSession session = await GetDungeon(dungeonKey);
+        logger.LogDebug("Removing dungeon session with key {Key}", dungeonKey);
 
-        this.logger.LogDebug("Completed dungeon with key {key}", dungeonKey);
+        await cache.RemoveAsync(
+            Schema.DungeonKey_DungeonData(playerIdentityService.ViewerId, dungeonKey),
+            cancellationToken
+        );
 
-        // Don't remove in case the client re-calls due to timeout
-        // await cache.RemoveAsync(Schema.DungeonKey_DungeonData(dungeonKey));
-
-        return session;
+        this.currentSession = null;
+        this.currentKey = null;
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonSession.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonSession.cs
@@ -2,9 +2,9 @@
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset.Models;
 
-namespace DragaliaAPI.Models;
+namespace DragaliaAPI.Features.Dungeon;
 
-public record DungeonSession
+public class DungeonSession
 {
     public required IEnumerable<PartySettingList> Party { get; init; }
 
@@ -26,9 +26,9 @@ public record DungeonSession
 
     public int WallLevel { get; init; }
 
-    public int QuestId => QuestData?.Id ?? 0;
+    public int QuestId => this.QuestData?.Id ?? 0;
 
-    public int QuestGid => QuestData?.Gid ?? 0;
+    public int QuestGid => this.QuestData?.Gid ?? 0;
 
-    public VariationTypes QuestVariation => QuestData?.VariationType ?? VariationTypes.Normal;
+    public VariationTypes QuestVariation => this.QuestData?.VariationType ?? VariationTypes.None;
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonService.cs
@@ -12,5 +12,5 @@ public interface IDungeonService
         CancellationToken cancellationToken
     );
     string CreateSession(DungeonSession dungeonSession);
-    Task WriteSession(CancellationToken cancellationToken);
+    Task SaveSession(CancellationToken cancellationToken);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonService.cs
@@ -4,8 +4,13 @@ namespace DragaliaAPI.Features.Dungeon;
 
 public interface IDungeonService
 {
-    Task<DungeonSession> FinishDungeon(string dungeonKey);
-    Task<DungeonSession> GetDungeon(string dungeonKey);
-    Task ModifySession(string dungeonKey, Action<DungeonSession> update);
-    Task<string> StartDungeon(DungeonSession dungeonSession);
+    Task RemoveSession(string dungeonKey, CancellationToken cancellationToken);
+    Task<DungeonSession> GetSession(string dungeonKey, CancellationToken cancellationToken);
+    Task ModifySession(
+        string dungeonKey,
+        Action<DungeonSession> update,
+        CancellationToken cancellationToken
+    );
+    string CreateSession(DungeonSession dungeonSession);
+    Task WriteSession(CancellationToken cancellationToken);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -37,5 +37,5 @@ public interface IDungeonStartService
         ulong? supportViewerId
     );
 
-    Task SaveSession(CancellationToken cancellationToken = default);
+    Task SaveSession(CancellationToken cancellationToken);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -20,17 +20,24 @@ public interface IDungeonStartService
     );
 
     Task<IngameQuestData> UpdateDbQuest(int questId);
+
     Task<bool> ValidateStamina(int questId, StaminaType staminaType);
+
     Task<IngameData> GetWallIngameData(
         int wallId,
         int wallLevel,
         int partyNo,
-        ulong? supportViewerId = null
+        ulong? supportViewerId,
+        CancellationToken cancellationToken
     );
+
     Task<IngameData> GetWallIngameData(
         int wallId,
         int wallLevel,
         IList<PartySettingList> party,
-        ulong? supportViewerId = null
+        ulong? supportViewerId,
+        CancellationToken cancellationToken
     );
+
+    Task SaveSession(CancellationToken cancellationToken = default);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -23,21 +23,15 @@ public interface IDungeonStartService
 
     Task<bool> ValidateStamina(int questId, StaminaType staminaType);
 
-    Task<IngameData> GetWallIngameData(
-        int wallId,
+    Task<IngameData> GetWallIngameData(int wallId,
         int wallLevel,
         int partyNo,
-        ulong? supportViewerId,
-        CancellationToken cancellationToken
-    );
+        ulong? supportViewerId);
 
-    Task<IngameData> GetWallIngameData(
-        int wallId,
+    Task<IngameData> GetWallIngameData(int wallId,
         int wallLevel,
         IList<PartySettingList> party,
-        ulong? supportViewerId,
-        CancellationToken cancellationToken
-    );
+        ulong? supportViewerId);
 
     Task SaveSession(CancellationToken cancellationToken = default);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -23,15 +23,19 @@ public interface IDungeonStartService
 
     Task<bool> ValidateStamina(int questId, StaminaType staminaType);
 
-    Task<IngameData> GetWallIngameData(int wallId,
+    Task<IngameData> GetWallIngameData(
+        int wallId,
         int wallLevel,
         int partyNo,
-        ulong? supportViewerId);
+        ulong? supportViewerId
+    );
 
-    Task<IngameData> GetWallIngameData(int wallId,
+    Task<IngameData> GetWallIngameData(
+        int wallId,
         int wallLevel,
         IList<PartySettingList> party,
-        ulong? supportViewerId);
+        ulong? supportViewerId
+    );
 
     Task SaveSession(CancellationToken cancellationToken = default);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IDungeonStartService.cs
@@ -19,7 +19,7 @@ public interface IDungeonStartService
         RepeatSetting? repeatSetting = null
     );
 
-    Task<IngameQuestData> InitiateQuest(int questId);
+    Task<IngameQuestData> UpdateDbQuest(int questId);
     Task<bool> ValidateStamina(int questId, StaminaType staminaType);
     Task<IngameData> GetWallIngameData(
         int wallId,

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
@@ -53,7 +53,7 @@ public class DungeonStartController(
             cancellationToken
         );
 
-        await dungeonService.WriteSession(cancellationToken);
+        await dungeonService.SaveSession(cancellationToken);
 
         return Ok(response);
     }
@@ -103,7 +103,7 @@ public class DungeonStartController(
             cancellationToken
         );
 
-        await dungeonService.WriteSession(cancellationToken);
+        await dungeonService.SaveSession(cancellationToken);
 
         return Ok(response);
     }
@@ -132,7 +132,7 @@ public class DungeonStartController(
 
         response.IngameData.RepeatState = request.RepeatState;
 
-        await dungeonService.WriteSession(cancellationToken);
+        await dungeonService.SaveSession(cancellationToken);
 
         return Ok(response);
     }
@@ -183,7 +183,7 @@ public class DungeonStartController(
             cancellationToken
         );
 
-        await dungeonService.WriteSession(cancellationToken);
+        await dungeonService.SaveSession(cancellationToken);
 
         return Ok(response);
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
@@ -36,7 +36,9 @@ public class DungeonStartController(
         );
 
         if (!await dungeonStartService.ValidateStamina(request.QuestId, StaminaType.Single))
+        {
             return this.Code(ResultCode.QuestStaminaSingleShort);
+        }
 
         IngameData ingameData = await dungeonStartService.GetIngameData(
             request.QuestId,
@@ -51,6 +53,8 @@ public class DungeonStartController(
             cancellationToken
         );
 
+        await dungeonService.WriteSession(cancellationToken);
+
         return Ok(response);
     }
 
@@ -61,7 +65,9 @@ public class DungeonStartController(
     )
     {
         if (!await dungeonStartService.ValidateStamina(request.QuestId, StaminaType.Multi))
+        {
             return this.Code(ResultCode.QuestStaminaMultiShort);
+        }
 
         IngameData ingameData = await dungeonStartService.GetIngameData(
             request.QuestId,
@@ -87,7 +93,8 @@ public class DungeonStartController(
             {
                 session.IsHost = ingameData.IsHost;
                 session.IsMulti = true;
-            }
+            },
+            cancellationToken
         );
 
         DungeonStartStartResponse response = await BuildResponse(
@@ -95,6 +102,8 @@ public class DungeonStartController(
             ingameData,
             cancellationToken
         );
+
+        await dungeonService.WriteSession(cancellationToken);
 
         return Ok(response);
     }
@@ -122,6 +131,8 @@ public class DungeonStartController(
         );
 
         response.IngameData.RepeatState = request.RepeatState;
+
+        await dungeonService.WriteSession(cancellationToken);
 
         return Ok(response);
     }
@@ -162,7 +173,8 @@ public class DungeonStartController(
             {
                 session.IsHost = ingameData.IsHost;
                 session.IsMulti = true;
-            }
+            },
+            cancellationToken
         );
 
         DungeonStartStartResponse response = await BuildResponse(
@@ -170,6 +182,8 @@ public class DungeonStartController(
             ingameData,
             cancellationToken
         );
+
+        await dungeonService.WriteSession(cancellationToken);
 
         return Ok(response);
     }
@@ -182,14 +196,15 @@ public class DungeonStartController(
     {
         logger.LogDebug("Starting dungeon for quest id {questId}", questId);
 
-        IngameQuestData ingameQuestData = await dungeonStartService.InitiateQuest(questId);
-
+        IngameQuestData ingameQuestData = await dungeonStartService.UpdateDbQuest(questId);
         UpdateDataList updateData = await updateDataService.SaveChangesAsync(cancellationToken);
 
         OddsInfo oddsInfo = oddsInfoService.GetOddsInfo(questId, 0);
+
         await dungeonService.ModifySession(
             ingameData.DungeonKey,
-            session => session.EnemyList[0] = oddsInfo.Enemy
+            session => session.EnemyList[0] = oddsInfo.Enemy,
+            cancellationToken
         );
 
         if (questId == 204270302)

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartController.cs
@@ -103,7 +103,7 @@ public class DungeonStartController(
             cancellationToken
         );
 
-        await dungeonService.SaveSession(cancellationToken);
+        await dungeonStartService.SaveSession(cancellationToken);
 
         return Ok(response);
     }
@@ -132,7 +132,7 @@ public class DungeonStartController(
 
         response.IngameData.RepeatState = request.RepeatState;
 
-        await dungeonService.SaveSession(cancellationToken);
+        await dungeonStartService.SaveSession(cancellationToken);
 
         return Ok(response);
     }
@@ -183,7 +183,7 @@ public class DungeonStartController(
             cancellationToken
         );
 
-        await dungeonService.SaveSession(cancellationToken);
+        await dungeonStartService.SaveSession(cancellationToken);
 
         return Ok(response);
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -163,20 +163,17 @@ public partial class DungeonStartService(
         return result;
     }
 
-    public async Task<IngameData> GetWallIngameData(
-        int wallId,
+    public async Task<IngameData> GetWallIngameData(int wallId,
         int wallLevel,
         int partyNo,
-        ulong? supportViewerId,
-        CancellationToken cancellationToken
-    )
+        ulong? supportViewerId)
     {
         Log.LoadingFromPartyNumber(logger, partyNo);
 
         IQueryable<DbPartyUnit> partyQuery = partyRepository.GetPartyUnits(partyNo).AsNoTracking();
 
         List<PartySettingList> party = ProcessUnitList(
-            await partyQuery.ToListAsync(cancellationToken),
+            await partyQuery.ToListAsync(),
             partyNo
         );
 
@@ -184,7 +181,7 @@ public partial class DungeonStartService(
 
         List<DbDetailedPartyUnit> detailedPartyUnits = await dungeonRepository
             .BuildDetailedPartyUnit(partyQuery, partyNo)
-            .ToListAsync(cancellationToken);
+            .ToListAsync();
 
         result.PartyInfo.PartyUnitList = await ProcessDetailedUnitList(detailedPartyUnits);
         result.DungeonKey = dungeonService.CreateSession(
@@ -197,18 +194,13 @@ public partial class DungeonStartService(
             }
         );
 
-        await dungeonService.SaveSession(cancellationToken);
-
         return result;
     }
 
-    public async Task<IngameData> GetWallIngameData(
-        int wallId,
+    public async Task<IngameData> GetWallIngameData(int wallId,
         int wallLevel,
         IList<PartySettingList> party,
-        ulong? supportViewerId,
-        CancellationToken cancellationToken
-    )
+        ulong? supportViewerId)
     {
         IngameData result = await InitializeIngameData(0, supportViewerId);
 
@@ -221,7 +213,7 @@ public partial class DungeonStartService(
         )
         {
             detailedPartyUnits.Add(
-                await detailQuery.AsNoTracking().FirstOrDefaultAsync(cancellationToken)
+                await detailQuery.AsNoTracking().FirstOrDefaultAsync()
                     ?? throw new InvalidOperationException(
                         "Detailed party query returned no results"
                     )
@@ -238,8 +230,6 @@ public partial class DungeonStartService(
                 SupportViewerId = supportViewerId
             }
         );
-
-        await dungeonService.SaveSession(cancellationToken);
 
         return result;
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -92,7 +92,7 @@ public partial class DungeonStartService(
         QuestData questInfo = MasterAsset.QuestData.Get(questId);
 
         result.PartyInfo.PartyUnitList = await ProcessDetailedUnitList(detailedPartyUnits);
-        result.DungeonKey = await dungeonService.StartDungeon(
+        result.DungeonKey = dungeonService.CreateSession(
             new()
             {
                 QuestData = questInfo,
@@ -153,7 +153,7 @@ public partial class DungeonStartService(
         QuestData questInfo = MasterAsset.QuestData.Get(questId);
 
         result.PartyInfo.PartyUnitList = await ProcessDetailedUnitList(detailedPartyUnits);
-        result.DungeonKey = await dungeonService.StartDungeon(
+        result.DungeonKey = dungeonService.CreateSession(
             new()
             {
                 QuestData = questInfo,
@@ -185,7 +185,7 @@ public partial class DungeonStartService(
             .ToListAsync();
 
         result.PartyInfo.PartyUnitList = await ProcessDetailedUnitList(detailedPartyUnits);
-        result.DungeonKey = await dungeonService.StartDungeon(
+        result.DungeonKey = dungeonService.CreateSession(
             new()
             {
                 Party = party.Where(x => x.CharaId != 0),
@@ -224,7 +224,7 @@ public partial class DungeonStartService(
         }
 
         result.PartyInfo.PartyUnitList = await ProcessDetailedUnitList(detailedPartyUnits);
-        result.DungeonKey = await dungeonService.StartDungeon(
+        result.DungeonKey = dungeonService.CreateSession(
             new()
             {
                 Party = party.Where(x => x.CharaId != 0),
@@ -237,7 +237,7 @@ public partial class DungeonStartService(
         return result;
     }
 
-    public async Task<IngameQuestData> InitiateQuest(int questId)
+    public async Task<IngameQuestData> UpdateDbQuest(int questId)
     {
         DbQuest? quest = await questRepository.Quests.FirstOrDefaultAsync(x =>
             x.QuestId == questId

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Start/DungeonStartService.cs
@@ -163,19 +163,18 @@ public partial class DungeonStartService(
         return result;
     }
 
-    public async Task<IngameData> GetWallIngameData(int wallId,
+    public async Task<IngameData> GetWallIngameData(
+        int wallId,
         int wallLevel,
         int partyNo,
-        ulong? supportViewerId)
+        ulong? supportViewerId
+    )
     {
         Log.LoadingFromPartyNumber(logger, partyNo);
 
         IQueryable<DbPartyUnit> partyQuery = partyRepository.GetPartyUnits(partyNo).AsNoTracking();
 
-        List<PartySettingList> party = ProcessUnitList(
-            await partyQuery.ToListAsync(),
-            partyNo
-        );
+        List<PartySettingList> party = ProcessUnitList(await partyQuery.ToListAsync(), partyNo);
 
         IngameData result = await InitializeIngameData(0, supportViewerId);
 
@@ -197,10 +196,12 @@ public partial class DungeonStartService(
         return result;
     }
 
-    public async Task<IngameData> GetWallIngameData(int wallId,
+    public async Task<IngameData> GetWallIngameData(
+        int wallId,
         int wallLevel,
         IList<PartySettingList> party,
-        ulong? supportViewerId)
+        ulong? supportViewerId
+    )
     {
         IngameData result = await InitializeIngameData(0, supportViewerId);
 

--- a/DragaliaAPI/DragaliaAPI/Features/Quest/IQuestService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Quest/IQuestService.cs
@@ -7,6 +7,7 @@ namespace DragaliaAPI.Features.Quest;
 public interface IQuestService
 {
     Task<int> GetQuestStamina(int questId, StaminaType type);
+
     Task<(bool BestClearTime, IEnumerable<AtgenFirstClearSet> Bonus)> ProcessQuestCompletion(
         DungeonSession session,
         PlayRecord playRecord

--- a/DragaliaAPI/DragaliaAPI/Features/Quest/IQuestService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Quest/IQuestService.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Features.Player;
+﻿using DragaliaAPI.Features.Dungeon;
+using DragaliaAPI.Features.Player;
 using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 

--- a/DragaliaAPI/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Quest/QuestService.cs
@@ -1,5 +1,6 @@
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Features.Dungeon;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Player;
 using DragaliaAPI.Features.Reward;

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallController.cs
@@ -23,9 +23,16 @@ public partial class WallController(
 ) : DragaliaControllerBase
 {
     [HttpPost("fail")]
-    public async Task<DragaliaResult> Fail(WallFailRequest request)
+    public async Task<DragaliaResult> Fail(
+        WallFailRequest request,
+        CancellationToken cancellationToken
+    )
     {
-        DungeonSession session = await dungeonService.FinishDungeon(request.DungeonKey);
+        DungeonSession session = await dungeonService.GetSession(
+            request.DungeonKey,
+            cancellationToken
+        );
+        await dungeonService.RemoveSession(request.DungeonKey, cancellationToken);
 
         return Ok(
             new WallFailResponse()

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallRecordController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallRecordController.cs
@@ -50,7 +50,11 @@ public class WallRecordController : DragaliaControllerBase
         CancellationToken cancellationToken
     )
     {
-        DungeonSession dungeonSession = await dungeonService.FinishDungeon(request.DungeonKey);
+        DungeonSession dungeonSession = await this.dungeonService.GetSession(
+            request.DungeonKey,
+            cancellationToken
+        );
+
         DbPlayerQuestWall questWall = await this.wallService.GetQuestWall(request.WallId);
 
         int finishedLevel = dungeonSession.WallLevel; // ex: if you finish level 2, this value should be 2
@@ -127,6 +131,9 @@ public class WallRecordController : DragaliaControllerBase
                 WallDropReward = wallDropReward,
                 WallUnitInfo = wallUnitInfo
             };
+
+        await dungeonService.RemoveSession(request.DungeonKey, cancellationToken);
+
         return Ok(data);
     }
 

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
@@ -11,19 +11,12 @@ namespace DragaliaAPI.Features.Wall;
 
 [Route("wall_start")]
 public class WallStartController(
-    IMapper mapper,
     IUpdateDataService updateDataService,
     IOddsInfoService oddsInfoService,
     IWallService wallService,
     IDungeonStartService dungeonStartService
 ) : DragaliaControllerBase
 {
-    private readonly IMapper mapper = mapper;
-    private readonly IUpdateDataService updateDataService = updateDataService;
-    private readonly IOddsInfoService oddsInfoService = oddsInfoService;
-    private readonly IWallService wallService = wallService;
-    private readonly IDungeonStartService dungeonStartService = dungeonStartService;
-
     // Called when starting a Mercurial Gauntlet quest
     [HttpPost("start")]
     public async Task<DragaliaResult> Start(
@@ -38,19 +31,20 @@ public class WallStartController(
             request.WallLevel
         );
 
-        IngameData ingameData = await this.dungeonStartService.GetWallIngameData(
+        IngameData ingameData = await dungeonStartService.GetWallIngameData(
             request.WallId,
             request.WallLevel,
             request.PartyNo,
-            request.SupportViewerId
+            request.SupportViewerId,
+            cancellationToken
         );
 
-        ingameData.AreaInfoList = questWallDetail.AreaInfo.Select(mapper.Map<AreaInfoList>);
+        ingameData.AreaInfoList = questWallDetail.AreaInfo.MapToAreaInfoList();
 
         IngameWallData ingameWallData =
             new() { WallId = request.WallId, WallLevel = request.WallLevel };
 
-        OddsInfo oddsInfo = this.oddsInfoService.GetWallOddsInfo(request.WallId, request.WallLevel);
+        OddsInfo oddsInfo = oddsInfoService.GetWallOddsInfo(request.WallId, request.WallLevel);
 
         UpdateDataList updateDataList = await updateDataService.SaveChangesAsync(cancellationToken);
 
@@ -78,19 +72,20 @@ public class WallStartController(
             request.WallLevel
         );
 
-        IngameData ingameData = await this.dungeonStartService.GetWallIngameData(
+        IngameData ingameData = await dungeonStartService.GetWallIngameData(
             request.WallId,
             request.WallLevel,
             request.RequestPartySettingList,
-            request.SupportViewerId
+            request.SupportViewerId,
+            cancellationToken
         );
 
-        ingameData.AreaInfoList = questWallDetail.AreaInfo.Select(mapper.Map<AreaInfoList>);
+        ingameData.AreaInfoList = questWallDetail.AreaInfo.MapToAreaInfoList();
 
         IngameWallData ingameWallData =
             new() { WallId = request.WallId, WallLevel = request.WallLevel };
 
-        OddsInfo oddsInfo = this.oddsInfoService.GetWallOddsInfo(request.WallId, request.WallLevel);
+        OddsInfo oddsInfo = oddsInfoService.GetWallOddsInfo(request.WallId, request.WallLevel);
 
         UpdateDataList updateDataList = await updateDataService.SaveChangesAsync(cancellationToken);
 

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
@@ -35,10 +35,11 @@ public class WallStartController(
             request.WallId,
             request.WallLevel,
             request.PartyNo,
-            request.SupportViewerId,
-            cancellationToken
+            request.SupportViewerId
         );
-
+        
+        await dungeonStartService.SaveSession(cancellationToken);
+        
         ingameData.AreaInfoList = questWallDetail.AreaInfo.MapToAreaInfoList();
 
         IngameWallData ingameWallData =
@@ -76,9 +77,10 @@ public class WallStartController(
             request.WallId,
             request.WallLevel,
             request.RequestPartySettingList,
-            request.SupportViewerId,
-            cancellationToken
+            request.SupportViewerId
         );
+
+        await dungeonStartService.SaveSession(cancellationToken);
 
         ingameData.AreaInfoList = questWallDetail.AreaInfo.MapToAreaInfoList();
 

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallStartController.cs
@@ -37,9 +37,9 @@ public class WallStartController(
             request.PartyNo,
             request.SupportViewerId
         );
-        
+
         await dungeonStartService.SaveSession(cancellationToken);
-        
+
         ingameData.AreaInfoList = questWallDetail.AreaInfo.MapToAreaInfoList();
 
         IngameWallData ingameWallData =

--- a/DragaliaAPI/DragaliaAPI/Models/DungeonSession.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/DungeonSession.cs
@@ -4,31 +4,31 @@ using DragaliaAPI.Shared.MasterAsset.Models;
 
 namespace DragaliaAPI.Models;
 
-public class DungeonSession
+public record DungeonSession
 {
-    public required IEnumerable<PartySettingList> Party { get; set; }
+    public required IEnumerable<PartySettingList> Party { get; init; }
 
-    public QuestData? QuestData { get; set; }
+    public QuestData? QuestData { get; init; }
+
+    public bool IsHost { get; set; } = true;
+
+    public bool IsMulti { get; set; }
+
+    public ulong? SupportViewerId { get; init; }
+
+    public DateTimeOffset StartTime { get; init; }
+
+    public Dictionary<int, IEnumerable<AtgenEnemy>> EnemyList { get; set; } = new();
+
+    public int PlayCount { get; init; } = 1;
+
+    public int WallId { get; init; }
+
+    public int WallLevel { get; init; }
 
     public int QuestId => QuestData?.Id ?? 0;
 
     public int QuestGid => QuestData?.Gid ?? 0;
 
     public VariationTypes QuestVariation => QuestData?.VariationType ?? VariationTypes.Normal;
-
-    public bool IsHost { get; set; } = true;
-
-    public bool IsMulti { get; set; }
-
-    public ulong? SupportViewerId { get; set; }
-
-    public DateTimeOffset StartTime { get; set; }
-
-    public Dictionary<int, IEnumerable<AtgenEnemy>> EnemyList { get; set; } = new();
-
-    public int PlayCount { get; set; } = 1;
-
-    public int WallId { get; set; }
-
-    public int WallLevel { get; set; }
 }


### PR DESCRIPTION
~~Speculative fix for random auto-repeat glitches throwing up stale data, and something we should be doing anyway.~~

Today, when you finish a dungeon, the session remains in the cache for the remainder of its expiry time, because issues were previously encountered with the client retrying record requests if they take too long, and then encountering errors because the session had been deleted on the first request.

Now that the codebase makes better use of CancellationToken, this is much less likely if we put the eviction of the session right at the end of the response method. It is still possible if the request is cancelled during serialization, however. If we encounter issues we can make the RemoveDungeon method instead mark the session to be removed in 1 minute's time or similar.

Also includes a refactoring of the DungeonService to implement a unit-of-work pattern, where the current session can be cached and modified in-memory without round-trips to the cache. This is primarily aimed at the DungeonStart logic which can require several updates after creating the session, arising from how the code is structured.

Finally, makes sessions keyed by viewer ID, so that it isn't possible to get another player's session. It probably wasn't really possible before, given the astronomical likelihood of guessing/colliding GUIDs, but it makes sense to segregate this data by tenant all the same. **This key change is breaking, and the server should be taken down during the deployment.**