### PR TITLE
Update PhotonStateManager related configuration

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -7,7 +7,5 @@ POSTGRES_DB=DragaliaAPI
 
 # Bearer token for admin endpoints e.g. manual save import
 DEVELOPER_TOKEN=
-# Hostname to add to logging context
-HOSTNAME=
 # Token used to authenticate incoming requests from co-op Photon Server
-PHOTON_TOKEN=
+PhotonOptions__Token=

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -1219,7 +1219,6 @@ public class DungeonRecordTest : TestFixture
 
     private void SetupPhotonAuthentication()
     {
-        Environment.SetEnvironmentVariable("PHOTON_TOKEN", "supersecrettoken");
         this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
             "supersecrettoken"

--- a/DragaliaAPI/DragaliaAPI/Middleware/PhotonAuthenticationHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Middleware/PhotonAuthenticationHandler.cs
@@ -2,6 +2,7 @@
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using DragaliaAPI.Database;
+using DragaliaAPI.Models.Options;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.EntityFrameworkCore;
@@ -11,11 +12,12 @@ using Microsoft.Extensions.Primitives;
 namespace DragaliaAPI.Middleware;
 
 public class PhotonAuthenticationHandler(
-    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    IOptionsMonitor<AuthenticationSchemeOptions> authOptions,
+    IOptionsMonitor<PhotonOptions> photonOptions,
     ILoggerFactory logger,
     UrlEncoder encoder,
     ApiContext apiContext
-) : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+) : AuthenticationHandler<AuthenticationSchemeOptions>(authOptions, logger, encoder)
 {
     public const string Role = "Photon";
 
@@ -40,11 +42,7 @@ public class PhotonAuthenticationHandler(
             return AuthenticateResult.NoResult();
         }
 
-        string configuredToken =
-            Environment.GetEnvironmentVariable("PHOTON_TOKEN")
-            ?? throw new InvalidOperationException("PHOTON_TOKEN environment variable not set!");
-
-        if (authenticationHeader.Parameter != configuredToken)
+        if (authenticationHeader.Parameter != photonOptions.CurrentValue.Token)
         {
             Logger.LogInformation(
                 "AuthenticationHeader.Parameter value {param} did not match configured token.",

--- a/DragaliaAPI/DragaliaAPI/Models/Options/PhotonOptions.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Options/PhotonOptions.cs
@@ -2,7 +2,9 @@
 
 public class PhotonOptions
 {
-    public required string ServerUrl { get; set; }
+    public required string ServerUrl { get; init; }
 
-    public required string StateManagerUrl { get; set; }
+    public required string StateManagerUrl { get; init; }
+
+    public required string Token { get; init; }
 }

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -42,6 +42,10 @@ builder
         reloadOnChange: true
     );
 
+string kpfPath = Path.Combine(Directory.GetCurrentDirectory(), "config");
+
+builder.Configuration.AddKeyPerFile(directoryPath: kpfPath, optional: true, reloadOnChange: true);
+
 builder.WebHost.UseStaticWebAssets();
 
 builder.Logging.ClearProviders();
@@ -104,6 +108,8 @@ builder
     .ConfigureBlazorFrontend();
 
 WebApplication app = builder.Build();
+
+app.Logger.LogDebug("Using key-per-file configuration from path {KpfPath}", kpfPath);
 
 Stopwatch watch = new();
 app.Logger.LogInformation("Loading MasterAsset data.");

--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -158,15 +158,13 @@ public static class ServiceConfiguration
 
         services.AddHttpClient<IBaasApi, BaasApi>();
 
-        services.AddHttpClient<IPhotonStateApi, PhotonStateApi>(client =>
-        {
-            PhotonOptions? options = configuration
-                .GetRequiredSection(nameof(PhotonOptions))
-                .Get<PhotonOptions>();
-            ArgumentNullException.ThrowIfNull(options);
-
-            client.BaseAddress = new(options.StateManagerUrl);
-        });
+        services.AddHttpClient<IPhotonStateApi, PhotonStateApi>(
+            (sp, client) =>
+            {
+                IOptions<PhotonOptions> options = sp.GetRequiredService<IOptions<PhotonOptions>>();
+                client.BaseAddress = new(options.Value.StateManagerUrl);
+            }
+        );
         services.AddScoped<IMatchingService, MatchingService>();
 
         services.AddScoped<ResourceVersionActionFilter>().AddScoped<MaintenanceActionFilter>();

--- a/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
+++ b/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
@@ -23,6 +23,9 @@
         "Android": "y2XM6giU6zz56wCm",
         "Ios": "b1HyoeTFegeTexC0"
     },
+    "PhotonOptions": {
+        "Token": "supersecrettoken"
+    },
     "EventOptions": {
         "EventList": [
             {

--- a/PhotonPlugin/README.md
+++ b/PhotonPlugin/README.md
@@ -119,7 +119,7 @@ The state manager application should be comparitively easy to deploy. It is a Do
 deployed alongside a `redis/redis-stack` image. See the `docker-compose.yml` file in the repository for reference. It
 does not need to be on the same server as Photon.
 
-It expects an environment variable, `PHOTON_TOKEN`, to match that which is configured in `plugin.config` above, so as to
+It expects an environment variable, `PhotonOptions__Token`, to match that which is configured in `plugin.config` above, so as to
 authenticate requests from the Photon server. A sample Docker compose file could look like:
 
 ```yaml
@@ -132,7 +132,7 @@ services:
     ports:
       - "3000:80"
     environment:
-      PHOTON_TOKEN: yourtoken
+      PhotonOptions__Token: yourtoken
 
   redis:
     hostname: redis
@@ -154,9 +154,9 @@ In the main API `appsettings.json`, configure the following values in `$.PhotonO
 - `ServerUrl`: the Photon server URL. Must end with :5055 due to Dragalia using a legacy client.
 - `StateManagerUrl` the Photon state manager URL.
 
-Configure the following environment variables:
+Configure the following environment variables (or other source of `IConfiguration`):
 
-- `PHOTON_TOKEN`: the same photon token as the plugin and state manager use. Used to authenticate requests from Photon.
+- `PhotonOptions__Token`: the same photon token as the plugin and state manager use. Used to authenticate requests from Photon.
 
 #### Other servers
 

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/CustomWebApplicationFactory.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/CustomWebApplicationFactory.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 
 namespace DragaliaAPI.Photon.StateManager.Test;

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/CustomWebApplicationFactory.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/CustomWebApplicationFactory.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
 
 namespace DragaliaAPI.Photon.StateManager.Test;
 
@@ -12,25 +14,19 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>, IAsyn
         this.testContainersHelper = new();
     }
 
-    protected override void ConfigureWebHost(IWebHostBuilder builder)
-    {
-        Environment.SetEnvironmentVariable(
-            "RedisOptions__Hostname",
-            this.testContainersHelper.RedisHost
+    protected override void ConfigureWebHost(IWebHostBuilder builder) =>
+        builder.ConfigureAppConfiguration(cfg =>
+            cfg.AddInMemoryCollection(
+                new Dictionary<string, string?>
+                {
+                    ["PhotonOptions:Token"] = "photontoken",
+                    ["RedisOptions:Hostname"] = this.testContainersHelper.RedisHost,
+                    ["RedisOptions:Port"] = this.testContainersHelper.RedisPort.ToString()
+                }
+            )
         );
-        Environment.SetEnvironmentVariable(
-            "RedisOptions__Port",
-            this.testContainersHelper.RedisPort.ToString()
-        );
-    }
 
     public Task InitializeAsync() => this.testContainersHelper.StartAsync();
 
     Task IAsyncLifetime.DisposeAsync() => this.testContainersHelper.StopAsync();
-
-    protected override void Dispose(bool disposing)
-    {
-        Environment.SetEnvironmentVariable("RedisOptions__Hostname", null);
-        Environment.SetEnvironmentVariable("RedisOptions__Port", null);
-    }
 }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/TestFixture.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/TestFixture.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Http.Headers;
 using DragaliaAPI.Photon.StateManager.Models;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Redis.OM.Contracts;
@@ -11,27 +12,23 @@ namespace DragaliaAPI.Photon.StateManager.Test;
 [Collection(TestCollection.Name)]
 public class TestFixture : IAsyncLifetime
 {
-    private const string PhotonToken = "photontoken";
-
     public TestFixture(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
     {
         this.Client = factory
-            .WithWebHostBuilder(
-                (builder) =>
-                    builder.ConfigureLogging(logging =>
-                    {
-                        logging.ClearProviders();
-                        logging.AddXUnit(outputHelper);
-                    })
-            )
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.AddXUnit(outputHelper);
+                });
+            })
             .CreateClient();
 
         this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(
             "Bearer",
-            PhotonToken
+            "photontoken"
         );
-
-        Environment.SetEnvironmentVariable("PHOTON_TOKEN", PhotonToken);
 
         this.RedisConnectionProvider =
             factory.Services.GetRequiredService<IRedisConnectionProvider>();

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/TestFixture.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/TestFixture.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net.Http.Headers;
 using DragaliaAPI.Photon.StateManager.Models;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Redis.OM.Contracts;
@@ -16,13 +15,12 @@ public class TestFixture : IAsyncLifetime
     {
         this.Client = factory
             .WithWebHostBuilder(builder =>
-            {
                 builder.ConfigureLogging(logging =>
                 {
                     logging.ClearProviders();
                     logging.AddXUnit(outputHelper);
-                });
-            })
+                })
+            )
             .CreateClient();
 
         this.Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/PhotonOptions.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/PhotonOptions.cs
@@ -1,0 +1,6 @@
+namespace DragaliaAPI.Photon.StateManager.Models;
+
+public class PhotonOptions
+{
+    public required string Token { get; init; }
+}

--- a/PhotonStateManager/README.md
+++ b/PhotonStateManager/README.md
@@ -16,3 +16,7 @@ The private endpoints are secured by bearer token authentication set by an envir
 - `/get/byid/{roomId}`: Searches for a room by its numeric passcode. This can include private rooms as well. If found, returns 200 OK, otherwise 404 Not Found.
 - `/get/ishost/{viewerId}`: Returns a scalar boolean indicating whether a user with the provided player ID is a host in any room.
 - `/get/byviewerid/{viewerId}`: Returns the room that a player is in, or 404 if they could not be found in a room.
+
+## HTTPS
+
+To configure the container to accept requests over HTTPS, follow the instructions in the [Microsoft documentation](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel/endpoints?view=aspnetcore-8.0#configure-https-in-appsettingsjson). 

--- a/PhotonStateManager/README.md
+++ b/PhotonStateManager/README.md
@@ -8,7 +8,7 @@ It operates by receiving webhook events from the Photon server, which trigger ro
 
 PhotonStateManager exposes a very simple REST API that is divided into two halves: 'private' endpoints designed for consumption by the Photon server, and 'public' endpoints that are designed to be consumed by the main Dragalia Lost API server. The private endpoints are under the /event/ route group, and the public endpoints are under the /get/ route group.
 
-The private endpoints are secured by bearer token authentication set by an environment variable `PHOTON_TOKEN`.
+The private endpoints are secured by bearer token authentication set by an IConfiguration property `PhotonOptions.Token`. The simplest way to configure this is by setting the environment variable `PhotonOptions__Token`.
 
 ### /get/ endpoints
 


### PR DESCRIPTION
- Adds support for the [key-per-file](https://learn.microsoft.com/en-us/dotnet/core/extensions/configuration-providers#key-per-file-configuration-provider) configuration provider to the app.
- Also fixes the lambda for adding `IPhotonStateApi` to make it pull an updated value for the base URL.
- Miscellaneous refactoring to PhotonStateManager config, including better use of DI and `IConfiguratioon`.

This includes several breaking changes for PhotonStateManager:
- `PHOTON_TOKEN` environment variable -> `PhotonOptions__Token`
- `ENABLE_HTTPS` environment variable no longer used, consult ASP.NET docs for alternative

---

This is primarily intended to solve the issue of the API having to re-template and restart each time the state manager is deployed, due to the fact that Nomad selects a random port for the state manager. Currently the URL is stored as an env variable which requires a container restart to reflect a change.

Previously this has been solved by using the public URL however this results in going through Cloudflare and Caddy again.

I could also put the state manager on a static port, but I'm not sure whether Consul would still re-template in the 5 second window that the service is deleted. This is also recommended against in the docs as it makes it harder for Nomad to schedule jobs.