### PR TITLE
Use IOptionsMonitor to hot reload config

### DIFF
--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -161,8 +161,11 @@ public static class ServiceConfiguration
         services.AddHttpClient<IPhotonStateApi, PhotonStateApi>(
             (sp, client) =>
             {
-                IOptions<PhotonOptions> options = sp.GetRequiredService<IOptions<PhotonOptions>>();
-                client.BaseAddress = new(options.Value.StateManagerUrl);
+                IOptionsMonitor<PhotonOptions> options = sp.GetRequiredService<
+                    IOptionsMonitor<PhotonOptions>
+                >();
+
+                client.BaseAddress = new(options.CurrentValue.StateManagerUrl);
             }
         );
         services.AddScoped<IMatchingService, MatchingService>();


### PR DESCRIPTION
I was operating under the mistaken assumption that `IOptions<T>` represented the config value at the time of injection and that you only needed `IOptionsMonitor<T>` if you expected the value to change while you were holding on to the instance...

Turns out `IOptions<T>` does not reload at all at runtime.