### PR TITLE
Add Request-Token header to log context

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -34,6 +34,8 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public override OkObjectResult Ok(object? value)
     {
+        this.HttpContext.Items.Add(nameof(ResultCode), ResultCode.Success);
+
         return base.Ok(
             new DragaliaResponse<object>(
                 value ?? throw new ArgumentNullException(nameof(value)),
@@ -44,6 +46,8 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public OkObjectResult Code(ResultCode code, string message)
     {
+        this.HttpContext.Items.Add(nameof(ResultCode), code);
+
         return base.Ok(
             new DragaliaResponse<object>(
                 dataHeaders: new DataHeaders(code),

--- a/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -34,7 +34,9 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public override OkObjectResult Ok(object? value)
     {
-        this.HttpContext.Items.Add(nameof(ResultCode), ResultCode.Success);
+        // Controller unit tests will not set the HttpContext properly
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+        this.HttpContext?.Items.Add(nameof(ResultCode), ResultCode.Success);
 
         return base.Ok(
             new DragaliaResponse<object>(
@@ -46,7 +48,9 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public OkObjectResult Code(ResultCode code, string message)
     {
-        this.HttpContext.Items.Add(nameof(ResultCode), code);
+        // Controller unit tests will not set the HttpContext properly
+        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
+        this.HttpContext?.Items.Add(nameof(ResultCode), code);
 
         return base.Ok(
             new DragaliaResponse<object>(

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/RedoableSummonController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/RedoableSummonController.cs
@@ -7,6 +7,7 @@ using DragaliaAPI.Services;
 using DragaliaAPI.Shared.Definitions.Enums;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Distributed;
+using static DragaliaAPI.Infrastructure.DragaliaHttpConstants;
 
 namespace DragaliaAPI.Features.Summoning;
 
@@ -59,7 +60,9 @@ public class RedoableSummonController(
 
     [HttpPost]
     [Route("pre_exec")]
-    public async Task<DragaliaResult> PreExec([FromHeader(Name = "SID")] string sessionId)
+    public async Task<DragaliaResult> PreExec(
+        [FromHeader(Name = Headers.SessionId)] string sessionId
+    )
     {
         IEnumerable<AtgenRedoableSummonResultUnitList> summonResult =
             await summonService.GenerateRedoableSummonResult();
@@ -81,7 +84,7 @@ public class RedoableSummonController(
     [HttpPost]
     [Route("fix_exec")]
     public async Task<DragaliaResult> FixExec(
-        [FromHeader(Name = "SID")] string sessionId,
+        [FromHeader(Name = Headers.SessionId)] string sessionId,
         CancellationToken cancellationToken
     )
     {

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/DragaliaHttpConstants.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/DragaliaHttpConstants.cs
@@ -1,0 +1,23 @@
+using System.Collections.Frozen;
+
+namespace DragaliaAPI.Infrastructure;
+
+public static class DragaliaHttpConstants
+{
+    public static class RoutePrefixes
+    {
+        private const string Android = "/2.19.0_20220714193707";
+
+        private const string Ios = "/2.19.0_20220719103923";
+
+        public static IReadOnlySet<string> List { get; } =
+            new List<string>() { Android, Ios }.ToFrozenSet();
+    }
+
+    public static class Headers
+    {
+        public const string SessionId = "SID";
+
+        public const string RequestToken = "Request-Token";
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Middleware/ExceptionHandlerMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Middleware/ExceptionHandlerMiddleware.cs
@@ -81,6 +81,8 @@ public class ExceptionHandlerMiddleware(RequestDelegate next)
     {
         context.Response.ContentType = CustomMessagePackOutputFormatter.ContentType;
         context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Items.Add(nameof(ResultCode), code);
+
         DragaliaResponse<DataHeaders> gameResponse = new(new DataHeaders(code), code);
 
         await context.Response.Body.WriteAsync(

--- a/DragaliaAPI/DragaliaAPI/Middleware/LogContextMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Middleware/LogContextMiddleware.cs
@@ -1,10 +1,11 @@
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.Extensions.Primitives;
 using Serilog.Context;
+using static DragaliaAPI.Infrastructure.DragaliaHttpConstants;
 
 namespace DragaliaAPI.Middleware;
 
-public class PlayerIdentityLoggingMiddleware(IPlayerIdentityService playerIdentityService)
-    : IMiddleware
+public class LogContextMiddleware(IPlayerIdentityService playerIdentityService) : IMiddleware
 {
     public Task InvokeAsync(HttpContext context, RequestDelegate next)
     {
@@ -15,6 +16,13 @@ public class PlayerIdentityLoggingMiddleware(IPlayerIdentityService playerIdenti
         {
             LogContext.PushProperty("AccountId", playerIdentityService.AccountId);
             LogContext.PushProperty("ViewerId", playerIdentityService.ViewerId);
+        }
+
+        if (
+            context.Request.Headers.TryGetValue(Headers.RequestToken, out StringValues requestToken)
+        )
+        {
+            LogContext.PushProperty("RequestToken", requestToken.ToString());
         }
 
         return next.Invoke(context);

--- a/DragaliaAPI/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Middleware/SessionAuthenticationHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Security.Claims;
 using System.Text.Encodings.Web;
 using DragaliaAPI.Database;
+using DragaliaAPI.Infrastructure;
 using DragaliaAPI.Models;
 using DragaliaAPI.Services;
 using DragaliaAPI.Services.Exceptions;
@@ -8,6 +9,7 @@ using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
+using static DragaliaAPI.Infrastructure.DragaliaHttpConstants;
 
 namespace DragaliaAPI.Middleware;
 
@@ -39,7 +41,7 @@ public class SessionAuthenticationHandler : AuthenticationHandler<Authentication
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
-        if (!this.Request.Headers.TryGetValue("SID", out StringValues value))
+        if (!this.Request.Headers.TryGetValue(Headers.SessionId, out StringValues value))
         {
             this.Logger.LogDebug("SID header was missing.");
             return AuthenticateResult.NoResult();

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -5,6 +5,7 @@ using DragaliaAPI;
 using DragaliaAPI.Authentication;
 using DragaliaAPI.Database;
 using DragaliaAPI.Features.GraphQL;
+using DragaliaAPI.Infrastructure;
 using DragaliaAPI.Infrastructure.Hangfire;
 using DragaliaAPI.MessagePack;
 using DragaliaAPI.Middleware;

--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -75,7 +75,7 @@ public static class ServiceConfiguration
             .AddScoped<IStampService, StampService>()
             .AddScoped<IStampRepository, StampRepository>()
             .AddScoped<ISavefileUpdateService, SavefileUpdateService>()
-            .AddTransient<PlayerIdentityLoggingMiddleware>();
+            .AddTransient<LogContextMiddleware>();
 
         services
             .AddSummoningFeature()

--- a/DragaliaAPI/DragaliaAPI/appsettings.json
+++ b/DragaliaAPI/DragaliaAPI/appsettings.json
@@ -30,9 +30,9 @@
                 "Args": {
                     "formatter": {
                         "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-                        "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l} {RequestPath} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
-                    },
-                    "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console"
+                        "template": "[{@t:HH:mm:ss} {@l:u3} {SourceContext}] {@m}\n{@x}",
+                        "theme": "Serilog.Templates.Themes.TemplateTheme::Code, Serilog.Expressions"
+                    }
                 }
             },
             {
@@ -44,7 +44,7 @@
                             "Args": {
                                 "formatter": {
                                     "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-                                    "template": "[{@t:yyyy-MM-dd HH:mm:ss} {@l:u3} {Substring(SourceContext, LastIndexOf(SourceContext, '.') + 1)}{#each i in [RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
+                                    "template": "[{@t:yyyy-MM-dd HH:mm:ss}, {@l:u3}, {#each i in [SourceContext, RequestId, AccountId, ViewerId]}{Concat(' ', i)}{#end}] {@m}\n{@x}"
                                 },
                                 "path": "logs/dragaliaapi_.log",
                                 "rollingInterval": "Day",


### PR DESCRIPTION
Adding this header to the log context to prove a hypothesis about repeated unsafe requests, in which the client retries requests that mutate server state, for example clearing a dungeon or finishing an upgrade

![image](https://github.com/SapiensAnatis/Dawnshard/assets/5047192/2eb362e6-5eb5-44ed-b0ea-f6cfc64becb3)

If the request token header is the same for these we may be able to use output caching to serve up a cached response. I will investigate errors like the above and see if I can prove that the Request-Token remains the same

Contributes towards #875 