### PR TITLE
Make workflows more specific to changed files

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,15 @@ name: Lint
 
 on:
   pull_request:
+    paths:
+      - "**.cs"
+      - ".config/dotnet-tools.json"  
   push:
     branches:
       - main
+    paths:
+      - "**.cs"
+      - ".config/dotnet-tools.json"
 
 env:
   HUSKY: 0

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - DragaliaAPI/**
+      - Shared/**
+      - Directory.Packages.props
   pull_request:
     branches:
       - main

--- a/.github/workflows/test-statemanager.yaml
+++ b/.github/workflows/test-statemanager.yaml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
       - main
+    paths:
+      - PhotonStateManager/**
+      - Shared/**
+      - Directory.Packages.props
   pull_request:
     branches:
       - main
     paths:
       - PhotonStateManager/**
       - Shared/**
-      - Directory.Build.props
       - Directory.Packages.props
 
 jobs:

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".github", ".github", "{1A23
 		.github\workflows\test-report.yaml = .github\workflows\test-report.yaml
 		.github\workflows\test-statemanager.yaml = .github\workflows\test-statemanager.yaml
 		.github\workflows\test.yaml = .github\workflows\test.yaml
+		.github\workflows\test-worker.yaml = .github\workflows\test-worker.yaml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DragaliaAPI.Test.Utils", "DragaliaAPI\DragaliaAPI.Test.Utils\DragaliaAPI.Test.Utils.csproj", "{41916B7C-6304-4504-99C0-B24D23982F7E}"


### PR DESCRIPTION
Prompted by the recent dependabot config update to target the other components... GH actions is free but I don't want to abuse their genorosity and ruin the climate :)

- Only run csharpier for dotnet tool upgrades and cs file changes
- Use same `changes` rules for running test pipelines on main as are applied to pull requests.