### PR TITLE
Initialize Mercurial Gauntlet on story skip

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -194,5 +194,13 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbPlayerPresentHistory>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbQuest>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbFortBuild>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/QuestRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/QuestRepository.cs
@@ -15,8 +15,8 @@ public class QuestRepository : IQuestRepository
         this.playerIdentityService = playerIdentityService;
     }
 
-    public IQueryable<DbQuest> Quests =>
-        this.apiContext.PlayerQuests.Where(x => x.ViewerId == this.playerIdentityService.ViewerId);
+    [Obsolete("This entity has a global query filter, use ApiContext.PlayerQuests instead.")]
+    public IQueryable<DbQuest> Quests => this.apiContext.PlayerQuests;
 
     public IQueryable<DbQuestEvent> QuestEvents =>
         this.apiContext.QuestEvents.Where(x => x.ViewerId == this.playerIdentityService.ViewerId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -118,5 +118,7 @@ public class StorySkipTest : TestFixture
             .Contain(x => x.Id == upgradeHalidomToLv3Mission)
             .Which.State.Should()
             .Be(MissionState.Completed);
+
+        this.ApiContext.PlayerQuestWalls.Should().Contain(x => x.ViewerId == this.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -97,6 +97,13 @@ public class GlobalQueryFilterTest : TestFixture
             .Be(this.ViewerId);
     }
 
+    [Fact]
+    public async Task DbQuest_HasGlobalQueryFilter() => await TestGlobalQueryFilter<DbQuest>();
+
+    [Fact]
+    public async Task DbFortBuild_HasGlobalQueryFilter() =>
+        await TestGlobalQueryFilter<DbFortBuild>();
+
     private async Task TestGlobalQueryFilter<TEntity>()
         where TEntity : class, IDbPlayerData
     {

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortRepository.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortRepository.cs
@@ -26,10 +26,8 @@ public class FortRepository : IFortRepository
         this.logger = logger;
     }
 
-    public IQueryable<DbFortBuild> Builds =>
-        this.apiContext.PlayerFortBuilds.Where(x =>
-            x.ViewerId == this.playerIdentityService.ViewerId
-        );
+    [Obsolete("This entity has a global query filter, use ApiContext.PlayerFortBuilds instead.")]
+    public IQueryable<DbFortBuild> Builds => this.apiContext.PlayerFortBuilds;
 
     public async Task InitializeFort()
     {

--- a/DragaliaAPI/DragaliaAPI/Features/StorySkip/StorySkipController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/StorySkip/StorySkipController.cs
@@ -1,64 +1,41 @@
 using DragaliaAPI.Controllers;
-using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
-using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.AspNetCore.Mvc;
 
 namespace DragaliaAPI.Features.StorySkip;
 
 [Route("story_skip")]
-public class StorySkipController : DragaliaControllerBase
+public class StorySkipController(
+    ILogger<StorySkipController> logger,
+    StorySkipService storySkipService,
+    IUpdateDataService updateDataService
+) : DragaliaControllerBase
 {
-    private readonly ILogger<StorySkipController> logger;
-    private readonly IPlayerIdentityService playerIdentityService;
-    private readonly IQuestRepository questRepository;
-    private readonly StorySkipService storySkipService;
-    private readonly IUpdateDataService updateDataService;
-    private readonly IUserDataRepository userDataRepository;
-
-    public StorySkipController(
-        ILogger<StorySkipController> logger,
-        IPlayerIdentityService playerIdentityService,
-        IQuestRepository questRepository,
-        StorySkipService storySkipService,
-        IUpdateDataService updateDataService,
-        IUserDataRepository userDataRepository
-    )
-    {
-        this.logger = logger;
-        this.playerIdentityService = playerIdentityService;
-        this.questRepository = questRepository;
-        this.storySkipService = storySkipService;
-        this.updateDataService = updateDataService;
-        this.userDataRepository = userDataRepository;
-    }
-
     [HttpPost("skip")]
     public async Task<DragaliaResult> Read(CancellationToken cancellationToken)
     {
-        string accountId = playerIdentityService.AccountId;
-        long viewerId = playerIdentityService.ViewerId;
+        logger.LogDebug("Beginning story skip.");
 
-        this.logger.LogDebug("Beginning story skip for player {accountId}.", accountId);
+        int wyrmite1 = await storySkipService.ProcessQuestCompletions();
+        logger.LogDebug("Wyrmite earned from quests: {Wyrmite}", wyrmite1);
 
-        int wyrmite1 = await storySkipService.ProcessQuestCompletions(viewerId);
-        this.logger.LogDebug("Wyrmite earned from quests: {wyrmite}", wyrmite1);
-
-        int wyrmite2 = await storySkipService.ProcessStoryCompletions(viewerId);
-        this.logger.LogDebug("Wyrmite earned from quest stories: {wyrmite}", wyrmite2);
+        int wyrmite2 = await storySkipService.ProcessStoryCompletions();
+        logger.LogDebug("Wyrmite earned from quest stories: {Wyrmite}", wyrmite2);
 
         await storySkipService.UpdateUserData(wyrmite1 + wyrmite2);
 
-        await storySkipService.IncreaseFortLevels(viewerId);
+        await storySkipService.IncreaseFortLevels();
 
-        await storySkipService.RewardCharas(viewerId);
+        await storySkipService.RewardCharas();
 
-        await storySkipService.RewardDragons(viewerId);
+        await storySkipService.RewardDragons();
+
+        await storySkipService.InitializeWall();
 
         await updateDataService.SaveChangesAsync(cancellationToken);
 
-        this.logger.LogDebug("Story Skip completed for player {accountId}.", accountId);
+        logger.LogDebug("Story Skip completed.");
 
         return this.Ok(new StorySkipSkipResponse() { ResultState = 1 });
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
@@ -57,7 +57,7 @@ public partial class WallService(
 
     public async Task<int> GetTotalWallLevel()
     {
-        int levelTotal = await apiContext.PlayerQuestWalls.Take(5).SumAsync(x => x.WallLevel);
+        int levelTotal = await apiContext.PlayerQuestWalls.SumAsync(x => x.WallLevel);
 
         if (levelTotal > MaximumQuestWallTotalLevel)
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
@@ -80,7 +80,9 @@ public partial class WallService(
     public async Task InitializeWall()
     {
         if (await this.CheckWallInitialized())
+        {
             return;
+        }
 
         logger.LogInformation("Initializing wall.");
 


### PR DESCRIPTION
Seeing errors in the logs about people attempting to access Mercurial Gauntlet without the required DbQuestWalls initialized. It seems the gap here is story skip - you skip past the MG story but without having the data initialized. Attempting to read the story after this will not send a request to the server.

Will need to run a DB query after this to fix affected saves.

Plus a usual bunch of misc refactoring and global query filter usage.