### PR TITLE
Fix failure to get RoomId in OnCloseGame callback

### DIFF
--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-        <AssemblyVersion>3.2.5</AssemblyVersion>
+        <AssemblyVersion>3.2.6</AssemblyVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-        <Exec Command="xcopy /Y /Q &quot;$(TargetDir)*.*&quot; &quot;$(SolutionDir)PhotonServer\deploy\Plugins\GluonPlugin\bin\&quot;" />
+        <Exec Command="xcopy /Y /Q &quot;$(TargetDir)*.*&quot; &quot;$(MSBuildThisFileDirectory)..\..\PhotonServer\deploy\Plugins\GluonPlugin\bin\&quot;" />
     </Target>
 
 </Project>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Discord/DiscordPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Discord/DiscordPlugin.cs
@@ -98,11 +98,6 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Discord
                 CustomHeaders = new Dictionary<string, string>()
                 {
                     { "Authorization", $"Bearer {this.configuration.DiscordBearerToken}" },
-                    { "RoomName", this.PluginHost.GameId },
-                    {
-                        "RoomId",
-                        this.PluginHost.GameProperties.GetInt(GamePropertyKeys.RoomId).ToString()
-                    }
                 }
             };
         }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/StateManager/StateManagerPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/StateManager/StateManagerPlugin.cs
@@ -316,11 +316,6 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.StateManager
                 CustomHeaders = new Dictionary<string, string>()
                 {
                     { "Authorization", $"Bearer {this.BearerToken}" },
-                    { "RoomName", this.PluginHost.GameId },
-                    {
-                        "RoomId",
-                        this.PluginHost.GameProperties.GetInt(GamePropertyKeys.RoomId).ToString()
-                    }
                 }
             };
         }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Properties/launchSettings.json
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Properties/launchSettings.json
@@ -1,0 +1,9 @@
+{
+    "profiles": {
+        "PhotonServer": {
+            "commandName": "Executable",
+            "executablePath": "$(ProjectDir)..\\..\\PhotonServer\\deploy\\bin_Win64\\PhotonSocketServer.exe",
+            "commandLineArgs": "/run LoadBalancing /configPath \"$(ProjectDir)..\\..\\PhotonServer\\deploy\\bin_Win64\""
+        }
+    }
+}


### PR DESCRIPTION
There are some errors in the logs where the OnCloseGame callback of the StateManagerPlugin is failing because there is no RoomId property.

This appears to happen if a player joins a game and it closes instantly, typically due to connection issues. It seems in this case the code in OnCreateGame which would initialize the RoomId does not have a chance to run.

These headers are not required for the state manager or for Zena, and are only used for recording time attack clears in the main API (for requests originating from GameLogicPlugin). So the simplest thing to do is remove them.