### PR TITLE
Forward JWT cookie as header

### DIFF
--- a/Website/src/hooks.server.ts
+++ b/Website/src/hooks.server.ts
@@ -25,7 +25,14 @@ export const handleFetch: HandleFetch = ({ request, fetch, event }) => {
     // Rewrite URL to internal
     const newUrl = request.url.replace(requestUrl.origin, internalApiUrl.origin);
     console.log(`Rewriting request: from ${requestUrl.href} to ${newUrl}`);
-    console.log({ cookies: event.cookies.getAll() });
+
+    // We need to explicitly add the JWT back in, because SvelteKit seems to refuse to forward cookies here; it's
+    // possible it views the request as changing origins and no longer internal.
+    const idToken = event.cookies.get(Cookies.IdToken);
+    if (idToken) {
+      request.headers.append('Authorization', `Bearer ${idToken}`);
+    }
+
     return fetch(new Request(newUrl, request));
   }
 


### PR DESCRIPTION
Fixes 401s when SSRing the profile page after the request is rewritten