### PR TITLE
Fix website save export

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileController.cs
@@ -1,3 +1,4 @@
+using DragaliaAPI.Models;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
 using DragaliaAPI.Shared.Serialization;
@@ -13,11 +14,15 @@ public class SavefileController(ILoadService loadService) : ControllerBase
     [Authorize(Policy = AuthConstants.PolicyNames.RequireDawnshardIdentity)]
     public async Task<FileResult> GetSavefile(CancellationToken cancellationToken)
     {
-        LoadIndexResponse savefile = await loadService.BuildIndexData(cancellationToken);
+        DragaliaResponse<LoadIndexResponse> savefile =
+            new(
+                new DataHeaders(ResultCode.Success),
+                await loadService.BuildIndexData(cancellationToken)
+            );
 
         return this.File(
             JsonSerializer.SerializeToUtf8Bytes(savefile, ApiJsonOptions.Instance),
-            "application/json",
+            "text/plain",
             "savedata.txt"
         );
     }


### PR DESCRIPTION
- Return wrapped response with data property
- Change Content-Type; I've observed my iPhone to default saving the file as savedata.txt.json and wonder if changing the Content-Type could fix that to save it as just .txt