### PR TITLE
Augment requests to /dungeon_record/record_multi

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -2998,12 +2998,12 @@ public partial class AtgenFirstMeeting
     public int Id { get; set; }
 
     [Key("type")]
-    public int Type { get; set; }
+    public EntityTypes Type { get; set; }
 
     [Key("total_quantity")]
     public int TotalQuantity { get; set; }
 
-    public AtgenFirstMeeting(int headcount, int id, int type, int totalQuantity)
+    public AtgenFirstMeeting(int headcount, int id, EntityTypes type, int totalQuantity)
     {
         this.Headcount = headcount;
         this.Id = id;

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
@@ -1,0 +1,33 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class DungeonRecordRecordMultiRequest
+{
+    /// <summary>
+    /// Gets the list of viewer IDs of other players in the room.
+    /// </summary>
+    /// <remarks>
+    /// This property is added by the Photon server while proxying the request.
+    /// </remarks>
+    [Key("connecting_viewer_id_list")]
+    public IList<ulong> ConnectingViewerIdList { get; set; } = [];
+
+    /// <summary>
+    /// Gets the astral raid multiplier used when joining or creating the room.
+    /// </summary>
+    /// <remarks>
+    /// This property is added by the Photon server while proxying the request.
+    /// </remarks>
+    [Key("astral_bet_count")]
+    public int AstralBetCount { get; set; }
+
+    /// <summary>
+    /// Gets the number of units that the player used during this quest.
+    /// </summary>
+    /// <remarks>
+    /// This property is added by the Photon server while proxying the request.
+    /// </remarks>
+    [Key("member_count")]
+    public int MemberCount { get; set; }
+}

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
@@ -5,7 +5,7 @@ namespace DragaliaAPI.Models.Generated;
 public partial class DungeonRecordRecordMultiRequest
 {
     /// <summary>
-    /// Gets the list of viewer IDs of other players in the room.
+    /// Gets the list of viewer IDs of the players in the room, excluding the ID of the player making the request.
     /// </summary>
     /// <remarks>
     /// This property is added by the Photon server while proxying the request.
@@ -30,4 +30,13 @@ public partial class DungeonRecordRecordMultiRequest
     /// </remarks>
     [Key("member_count")]
     public int MemberCount { get; set; }
+
+    /// <summary>
+    /// Gets a value indicating whether the player sending this request was the host of the room.
+    /// </summary>
+    /// <remarks>
+    /// This property is added by the Photon server while proxying the request.
+    /// </remarks>
+    [Key("is_host")]
+    public bool IsHost { get; set; }
 }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
@@ -1295,16 +1295,13 @@ public partial class DungeonRecordRecordMultiRequest
     [Key("dungeon_key")]
     public string DungeonKey { get; set; }
 
-    [Key("connecting_viewer_id_list")]
-    public IEnumerable<ulong> ConnectingViewerIdList { get; set; } = [];
-
     [Key("no_play_flg")]
     public int NoPlayFlg { get; set; }
 
     public DungeonRecordRecordMultiRequest(
         PlayRecord playRecord,
         string dungeonKey,
-        IEnumerable<ulong> connectingViewerIdList,
+        IList<ulong> connectingViewerIdList,
         int noPlayFlg
     )
     {

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <AssemblyVersion>3.2.6</AssemblyVersion>
+    <AssemblyVersion>3.3.0</AssemblyVersion>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <AssemblyVersion>3.2.6</AssemblyVersion>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
@@ -9,6 +9,7 @@ using DragaliaAPI.Photon.Plugin.Shared;
 using DragaliaAPI.Photon.Plugin.Shared.Constants;
 using DragaliaAPI.Photon.Plugin.Shared.Helpers;
 using DragaliaAPI.Photon.Shared.Enums;
+using MessagePack;
 using Photon.Hive.Plugin;
 
 namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
@@ -18,9 +19,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
     /// </summary>
     public class GameLogicPlugin : PluginBase
     {
-        private IPluginLogger logger;
         private RoomState roomState;
-        private GoToIngameStateManager goToIngameStateManager;
+        private IPluginLogger logger = null!;
+        private GoToIngameStateManager goToIngameStateManager = null!;
 
         private readonly PluginConfiguration configuration;
         private readonly PluginStateService pluginStateService;
@@ -79,6 +80,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
             // https://doc.photonengine.com/server/current/plugins/plugins-faq#how_to_get_the_actor_number_in_plugin_callbacks_
             // This is only invalid if the room is recreated from an inactive state, which Dragalia doesn't do (hopefully!)
             const int actorNr = 1;
+
             this.actorState[actorNr] = new ActorState();
 
             long viewerId = info.Request.ActorProperties.GetLong(ActorPropertyKeys.PlayerId);
@@ -228,7 +230,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
         public override void OnLeave(ILeaveGameCallInfo info)
         {
             // Get actor before continuing
-            IActor actor = this.PluginHost.GameActors.FirstOrDefault(x =>
+            IActor? actor = this.PluginHost.GameActors.FirstOrDefault(x =>
                 x.ActorNr == info.ActorNr
             );
 
@@ -502,9 +504,14 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
 
             ClearQuestRequest evt = info.DeserializeEvent<ClearQuestRequest>();
 
+            byte[] augmentedRequest = AugmentQuestClearRequest(
+                evt.RecordMultiRequest,
+                info.ActorNr
+            );
+
             this.PostApiRequest(
                 this.configuration.DungeonRecordMultiEndpoint,
-                evt.RecordMultiRequest,
+                augmentedRequest,
                 info,
                 this.ClearQuestRequestCallback,
                 callAsync: false
@@ -557,7 +564,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
             this.PluginHost.LogIfFailedCallback(response, userState);
 
             if (response.Status != HttpRequestQueueResult.Success)
+            {
                 return;
+            }
 
             HttpRequestUserState typedUserState = (HttpRequestUserState)userState;
 
@@ -630,5 +639,29 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
         }
 
         private int GenerateRoomId() => this.random.Next(100_0000, 1_000_0000);
+
+        private byte[] AugmentQuestClearRequest(byte[] original, int actorNr)
+        {
+            Dictionary<string, object?> deserialized = MessagePackSerializer.Deserialize<
+                Dictionary<string, object?>
+            >(original);
+
+            deserialized["connecting_viewer_id_list"] = this
+                .PluginHost.GameActors.Select(x => x.GetViewerId())
+                .ToArray();
+
+            deserialized["member_count"] = this.goToIngameStateManager.GetUsedMemberCount(actorNr);
+
+            IActor actor = this.PluginHost.GameActors.First(x => x.ActorNr == actorNr);
+
+            if (
+                actor.Properties.TryGetInt(ActorPropertyKeys.AstralBetCount, out int astralBetCount)
+            )
+            {
+                deserialized["astral_bet_count"] = astralBetCount;
+            }
+
+            return MessagePackSerializer.Serialize(deserialized);
+        }
     }
 }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
@@ -502,10 +502,8 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
 
             this.actorState[info.ActorNr] = new ActorState();
 
-            ClearQuestRequest evt = info.DeserializeEvent<ClearQuestRequest>();
-
             byte[] augmentedRequest = AugmentQuestClearRequest(
-                evt.RecordMultiRequest,
+                info.DeserializeEvent<ClearQuestRequest>().RecordMultiRequest,
                 info.ActorNr
             );
 
@@ -523,7 +521,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
 
                 this.PostApiRequest(
                     this.configuration.TimeAttackEndpoint,
-                    evt.RecordMultiRequest,
+                    augmentedRequest,
                     info,
                     this.PluginHost.LogIfFailedCallback,
                     callAsync: true
@@ -647,8 +645,11 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
             >(original);
 
             deserialized["connecting_viewer_id_list"] = this
-                .PluginHost.GameActors.Select(x => x.GetViewerId())
+                .PluginHost.GameActors.Where(x => x.ActorNr != actorNr)
+                .Select(x => x.GetViewerId())
                 .ToArray();
+
+            deserialized["is_host"] = actorNr == 1;
 
             deserialized["member_count"] = this.goToIngameStateManager.GetUsedMemberCount(actorNr);
 

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GoToIngameStateManager.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GoToIngameStateManager.cs
@@ -106,6 +106,11 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
             this.OnMinStateChange(info);
         }
 
+        public int GetUsedMemberCount(int actorNr)
+        {
+            return this.heroParamStorage[actorNr].UsedMemberCount;
+        }
+
         /// <summary>
         /// Handler to perform various operations when the minimum GoToIngameState of a room is increased.
         /// </summary>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/RoomState.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/RoomState.cs
@@ -10,7 +10,7 @@
 
         public bool IsRandomMatching { get; set; }
 
-        public object RandomMatchingStartTimer { get; set; }
+        public object? RandomMatchingStartTimer { get; set; }
 
         public RoomState() { }
 

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPlugin.cs
@@ -15,7 +15,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         private readonly PluginStateService pluginStateService;
         private readonly GameLogicPlugin gameLogicPlugin;
         private readonly StateManagerPlugin stateManagerPlugin;
-        private readonly DiscordPlugin discordPlugin;
+        private readonly DiscordPlugin? discordPlugin;
 
         public override string Name => nameof(GluonPlugin);
 
@@ -23,7 +23,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             PluginStateService pluginStateService,
             GameLogicPlugin gameLogicPlugin,
             StateManagerPlugin stateManagerPlugin,
-            DiscordPlugin discordPlugin
+            DiscordPlugin? discordPlugin
         )
         {
             this.pluginStateService = pluginStateService;
@@ -40,9 +40,23 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
         {
             this.PluginHost = host;
 
-            return this.stateManagerPlugin.SetupInstance(host, config, out errorMsg)
-                && this.gameLogicPlugin.SetupInstance(host, config, out errorMsg)
-                && this.discordPlugin.SetupInstance(host, config, out errorMsg);
+            if (!this.stateManagerPlugin.SetupInstance(host, config, out errorMsg))
+            {
+                return false;
+            }
+            if (!this.gameLogicPlugin.SetupInstance(host, config, out errorMsg))
+            {
+                return false;
+            }
+            if (
+                this.discordPlugin is not null
+                && !this.discordPlugin.SetupInstance(host, config, out errorMsg)
+            )
+            {
+                return false;
+            }
+
+            return true;
         }
 
         public override void OnCreateGame(ICreateGameCallInfo info)
@@ -52,11 +66,13 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
 
             if (this.pluginStateService.IsPubliclyVisible)
             {
-                this.discordPlugin.OnCreateGame(info);
+                this.discordPlugin?.OnCreateGame(info);
             }
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void OnJoin(IJoinGameCallInfo info)
@@ -65,7 +81,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             this.stateManagerPlugin.OnJoin(info);
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void OnLeave(ILeaveGameCallInfo info)
@@ -74,7 +92,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             this.stateManagerPlugin.OnLeave(info);
 
             if (!info.IsProcessed)
+            {
                 base.OnLeave(info);
+            }
         }
 
         public override void BeforeCloseGame(IBeforeCloseGameCallInfo info)
@@ -84,11 +104,13 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
 
             if (this.pluginStateService.IsPubliclyVisible)
             {
-                this.discordPlugin.BeforeCloseGame(info);
+                this.discordPlugin?.BeforeCloseGame(info);
             }
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void OnCloseGame(ICloseGameCallInfo info)
@@ -97,7 +119,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             this.stateManagerPlugin.OnCloseGame(info);
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void OnRaiseEvent(IRaiseEventCallInfo info)
@@ -106,7 +130,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             this.stateManagerPlugin.OnRaiseEvent(info);
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void BeforeSetProperties(IBeforeSetPropertiesCallInfo info)
@@ -114,7 +140,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             this.gameLogicPlugin.BeforeSetProperties(info);
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
 
         public override void OnSetProperties(ISetPropertiesCallInfo info)
@@ -124,11 +152,13 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
 
             if (this.pluginStateService.IsPubliclyVisible)
             {
-                this.discordPlugin.OnSetProperties(info);
+                this.discordPlugin?.OnSetProperties(info);
             }
 
             if (!info.IsProcessed)
+            {
                 info.Continue();
+            }
         }
     }
 }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPluginFactory.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/Gluon/GluonPluginFactory.cs
@@ -9,7 +9,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
 {
     public class GluonPluginFactory : IPluginFactory
     {
-        public IGamePlugin Create(
+        public IGamePlugin? Create(
             IPluginHost gameHost,
             string pluginName,
             Dictionary<string, string> config,
@@ -20,11 +20,15 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             PluginStateService stateService = new PluginStateService();
 
             GameLogicPlugin gameLogicPlugin = new GameLogicPlugin(stateService, configuration);
+
             StateManagerPlugin stateManagerPlugin = new StateManagerPlugin(
                 stateService,
                 configuration
             );
-            DiscordPlugin discordPlugin = new DiscordPlugin(configuration);
+
+            DiscordPlugin? discordPlugin = configuration.EnableDiscordIntegration
+                ? new DiscordPlugin(configuration)
+                : null;
 
             GluonPlugin gluonPlugin = new GluonPlugin(
                 stateService,
@@ -34,7 +38,9 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.Gluon
             );
 
             if (gluonPlugin.SetupInstance(gameHost, config, out errorMsg))
+            {
                 return gluonPlugin;
+            }
 
             return null;
         }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/Constants/ActorPropertyKeys.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/Constants/ActorPropertyKeys.cs
@@ -12,5 +12,7 @@
         public const string UsePartySlot = "UsePartySlot";
 
         public const string GoToIngameState = "GoToIngameState";
+
+        public const string AstralBetCount = "AstralBetCount";
     }
 }

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/Helpers/DtoHelpers.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Shared/Helpers/DtoHelpers.cs
@@ -30,17 +30,20 @@ namespace DragaliaAPI.Photon.Plugin.Shared.Helpers
                 MatchingCompatibleId = gameProperties.GetInt(GamePropertyKeys.MatchingCompatibleId),
                 RoomId = gameProperties.GetInt(GamePropertyKeys.RoomId),
                 QuestId = gameProperties.GetInt(GamePropertyKeys.QuestId),
-                MatchingType = (MatchingTypes)gameProperties.GetInt(GamePropertyKeys.MatchingType)
+                MatchingType = (MatchingTypes)gameProperties.GetInt(GamePropertyKeys.MatchingType),
             };
 
-            EntryConditions conditions = CreateEntryConditions(gameProperties);
+            EntryConditions? conditions = CreateEntryConditions(gameProperties);
+
             if (conditions != null)
+            {
                 result.EntryConditions = conditions;
+            }
 
             return result;
         }
 
-        public static EntryConditions CreateEntryConditions(Hashtable gameProperties)
+        public static EntryConditions? CreateEntryConditions(Hashtable gameProperties)
         {
             if (
                 !gameProperties.TryGetValue(
@@ -52,8 +55,10 @@ namespace DragaliaAPI.Photon.Plugin.Shared.Helpers
                 return null;
             }
 
-            if (!(entryConditionObj is byte[] entryConditionBlob))
+            if (entryConditionObj is not byte[] entryConditionBlob)
+            {
                 return null;
+            }
 
             RoomEntryCondition deserialized = MessagePackSerializer.Deserialize<RoomEntryCondition>(
                 entryConditionBlob,


### PR DESCRIPTION
Closes #799, #667

- Adds the following top-level properties to the `/dungeon_record/record_multi` by inserting these when the request is proxied by the Photon server.:
  - `astral_bet_count`: The astral raid multiplier chosen by the current player when starting the quest.
  - `connecting_viewer_id_list`: The list of viewer IDs all other players in the co-op room.
  - `member_count`: The number of units, including AI units, that the current player used in the quest.
  - `is_host`: Whether the current player was the host of the quest. Obsoletes PhotonStateManager endpoint.
- Fixes Discord plugin not respecting disable setting; if it is not enabled the sub-plugin is set to null.

Example new request for a room in which two players played together with 1 AI unit each:

```json
{
  "connecting_viewer_id_list": [2],
  "astral_bet_count": 10,
  "member_count": 2,
  "is_host": true,
  "play_record": "..."
}
```