### PR TITLE
Optimize dungeon record using new photon server properties

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -911,9 +911,6 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.MockPhotonStateApi.Setup(x => x.GetGameByViewerId(this.ViewerId))
-            .ReturnsAsync(new Photon.Shared.Models.ApiGame() { Name = roomName });
-
         DungeonStartStartMultiResponse startResponse = (
             await this.Client.PostMsgpack<DungeonStartStartMultiResponse>(
                 "/dungeon_start/start_multi",

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordController.cs
@@ -95,7 +95,7 @@ public class DungeonRecordController(
         (
             IEnumerable<UserSupportList> helperList,
             IEnumerable<AtgenHelperDetailList> helperDetailList
-        ) = await dungeonRecordHelperService.ProcessHelperDataMulti();
+        ) = await dungeonRecordHelperService.ProcessHelperDataMulti(request.ConnectingViewerIdList);
 
         ingameResultData.HelperList = helperList;
         ingameResultData.HelperDetailList = helperDetailList;

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordHelperService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordHelperService.cs
@@ -12,5 +12,10 @@ public interface IDungeonRecordHelperService
     Task<(
         IEnumerable<UserSupportList> HelperList,
         IEnumerable<AtgenHelperDetailList> HelperDetailList
+    )> ProcessHelperDataMulti(IList<long> connectingViewerIdList);
+
+    Task<(
+        IEnumerable<UserSupportList> HelperList,
+        IEnumerable<AtgenHelperDetailList> HelperDetailList
     )> ProcessHelperDataMulti();
 }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/DungeonRecordRecordMultiRequest.cs
@@ -11,7 +11,7 @@ public partial class DungeonRecordRecordMultiRequest
     /// This property is added by the Photon server while proxying the request.
     /// </remarks>
     [Key("connecting_viewer_id_list")]
-    public IList<ulong> ConnectingViewerIdList { get; set; } = [];
+    public IList<long> ConnectingViewerIdList { get; set; } = [];
 
     /// <summary>
     /// Gets the astral raid multiplier used when joining or creating the room.

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Requests.cs
@@ -1301,7 +1301,7 @@ public partial class DungeonRecordRecordMultiRequest
     public DungeonRecordRecordMultiRequest(
         PlayRecord playRecord,
         string dungeonKey,
-        IList<ulong> connectingViewerIdList,
+        IList<long> connectingViewerIdList,
         int noPlayFlg
     )
     {

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/IMatchingService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/IMatchingService.cs
@@ -9,6 +9,5 @@ public interface IMatchingService
     Task<MatchingGetRoomNameResponse?> GetRoomById(int id);
     Task<IEnumerable<RoomList>> GetRoomList();
     Task<IEnumerable<RoomList>> GetRoomList(int questId);
-    Task<string?> GetRoomName();
     Task<IEnumerable<Player>> GetTeammates();
 }

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
@@ -107,22 +107,6 @@ public class MatchingService : IMatchingService
 
         return game.Players.Where(x => x.ViewerId != viewerId);
     }
-
-    public async Task<string?> GetRoomName()
-    {
-        long viewerId = this.playerIdentityService.ViewerId;
-
-        ApiGame? game = await this.photonStateApi.GetGameByViewerId(viewerId);
-
-        if (game is null)
-        {
-            this.logger.LogWarning("Failed to retrieve game for ID {viewerId}", viewerId);
-            return null;
-        }
-
-        return game.Name;
-    }
-
     public async Task<bool> GetIsHost()
     {
         long viewerId = this.playerIdentityService.ViewerId;

--- a/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Photon/MatchingService.cs
@@ -13,7 +13,6 @@ namespace DragaliaAPI.Services.Photon;
 public class MatchingService : IMatchingService
 {
     private readonly IPhotonStateApi photonStateApi;
-    private readonly IUnitRepository unitRepository;
     private readonly IPartyRepository partyRepository;
     private readonly IUserDataRepository userDataRepository;
     private readonly ILogger<MatchingService> logger;
@@ -22,7 +21,6 @@ public class MatchingService : IMatchingService
 
     public MatchingService(
         IPhotonStateApi photonStateApi,
-        IUnitRepository unitRepository,
         IPartyRepository partyRepository,
         IUserDataRepository userDataRepository,
         ILogger<MatchingService> logger,
@@ -31,7 +29,6 @@ public class MatchingService : IMatchingService
     )
     {
         this.photonStateApi = photonStateApi;
-        this.unitRepository = unitRepository;
         this.partyRepository = partyRepository;
         this.userDataRepository = userDataRepository;
         this.logger = logger;
@@ -107,6 +104,7 @@ public class MatchingService : IMatchingService
 
         return game.Players.Where(x => x.ViewerId != viewerId);
     }
+
     public async Task<bool> GetIsHost()
     {
         long viewerId = this.playerIdentityService.ViewerId;

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/DragaliaAPI.Photon.Plugin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
-    <AssemblyVersion>3.3.0</AssemblyVersion>
+    <AssemblyVersion>3.3.1</AssemblyVersion>
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GameLogicPlugin.cs
@@ -646,6 +646,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
 
             deserialized["connecting_viewer_id_list"] = this
                 .PluginHost.GameActors.Where(x => x.ActorNr != actorNr)
+                .OrderBy(x => x.ActorNr)
                 .Select(x => x.GetViewerId())
                 .ToArray();
 

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/EntryConditionsTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/EntryConditionsTest.cs
@@ -43,25 +43,18 @@ public class EntryConditionsTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
         EntryConditions newConditions =
             new()
             {
-                UnacceptedElementTypeList = new List<int>() { 1 },
-                UnacceptedWeaponTypeList = new List<int>() { 9 },
+                UnacceptedElementTypeList = [1],
+                UnacceptedWeaponTypeList = [9],
                 RequiredPartyPower = 12000,
                 ObjectiveTextId = 2,
             };

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCloseTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCloseTest.cs
@@ -40,19 +40,12 @@ public class GameCloseTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCreateTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCreateTest.cs
@@ -43,12 +43,12 @@ public class GameCreateTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>() { }
+                Players = []
             };
 
         RedisGame expectedGame =
@@ -62,19 +62,12 @@ public class GameCreateTest : TestFixture
                 StartEntryTime = game.StartEntryTime,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
 
         HttpResponseMessage response = await this.Client.PostAsJsonAsync<GameCreateRequest>(
@@ -82,11 +75,7 @@ public class GameCreateTest : TestFixture
             new()
             {
                 Game = game,
-                Player = new()
-                {
-                    ViewerId = 2,
-                    PartyNoList = new List<int>() { 40 }
-                }
+                Player = new() { ViewerId = 2, PartyNoList = [40] }
             }
         );
 

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameJoinTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameJoinTest.cs
@@ -40,19 +40,12 @@ public class GameJoinTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);
@@ -62,11 +55,7 @@ public class GameJoinTest : TestFixture
             new()
             {
                 GameName = game.Name,
-                Player = new()
-                {
-                    ViewerId = 22,
-                    PartyNoList = new List<int>() { 1, 2 }
-                }
+                Player = new() { ViewerId = 22, PartyNoList = [1, 2] }
             }
         );
 
@@ -79,16 +68,8 @@ public class GameJoinTest : TestFixture
             .BeEquivalentTo(
                 new List<Player>()
                 {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    },
-                    new()
-                    {
-                        ViewerId = 22,
-                        PartyNoList = new List<int>() { 1, 2 }
-                    }
+                    new() { ViewerId = 2, PartyNoList = [40] },
+                    new() { ViewerId = 22, PartyNoList = [1, 2] }
                 }
             );
     }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
@@ -40,24 +40,16 @@ public class GameLeaveTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    },
-                    new()
-                    {
-                        ViewerId = 5,
-                        PartyNoList = new List<int>() { 20 }
-                    }
-                }
+                Players =
+                [
+                    new() { ViewerId = 2, PartyNoList = [40] },
+                    new() { ViewerId = 5, PartyNoList = [20] }
+                ]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);
@@ -78,11 +70,7 @@ public class GameLeaveTest : TestFixture
             .BeEquivalentTo(
                 new List<Player>()
                 {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
+                    new() { ViewerId = 2, PartyNoList = [40] }
                 }
             );
         storedGame!.MatchingType.Should().Be(MatchingTypes.Anyone);
@@ -102,19 +90,12 @@ public class GameLeaveTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 5,
-                        PartyNoList = new List<int>() { 20 }
-                    }
-                }
+                Players = [new() { ViewerId = 5, PartyNoList = [20] }]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/MatchingTypeTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/MatchingTypeTest.cs
@@ -40,19 +40,12 @@ public class MatchingTypeTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
         MatchingTypes newMatchingType = MatchingTypes.ById;
 

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/RoomIdTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/RoomIdTest.cs
@@ -30,19 +30,12 @@ public class RoomIdTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/VisibleTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/VisibleTest.cs
@@ -32,19 +32,12 @@ public class VisibleTest : TestFixture
                 StartEntryTime = DateTimeOffset.UtcNow,
                 EntryConditions = new()
                 {
-                    UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                    UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
                     RequiredPartyPower = 11700,
                     ObjectiveTextId = 1,
                 },
-                Players = new List<Player>()
-                {
-                    new()
-                    {
-                        ViewerId = 2,
-                        PartyNoList = new List<int>() { 40 }
-                    }
-                }
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
             };
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(game);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByViewerIdTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByViewerIdTest.cs
@@ -1,4 +1,4 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Http.Json;
 using DragaliaAPI.Photon.Shared.Enums;
 using DragaliaAPI.Photon.Shared.Models;
@@ -7,15 +7,15 @@ using Xunit.Abstractions;
 
 namespace DragaliaAPI.Photon.StateManager.Test.Get;
 
-public class ByIdTest : TestFixture
+public class ByViewerIdTest : TestFixture
 {
-    private const string Endpoint = "/Get/ById";
+    private const string Endpoint = "/Get/ByViewerId";
 
-    public ByIdTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+    public ByViewerIdTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
     [Fact]
-    public async Task ById_ReturnsGame()
+    public async Task ByViewerId_Found_ReturnsGame()
     {
         RedisGame game =
             new()
@@ -38,7 +38,7 @@ public class ByIdTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/12345");
+        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/2");
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
         (await response.Content.ReadFromJsonAsync<ApiGame>())
@@ -47,9 +47,30 @@ public class ByIdTest : TestFixture
     }
 
     [Fact]
-    public async Task ById_NotFound_Returns404()
+    public async Task ByViewerId_NotFound_Returns404()
     {
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/56789");
+        RedisGame game =
+            new()
+            {
+                RoomId = 12345,
+                Name = "151de85a-200a-4952-8757-e0f868bbf28b",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
+                {
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
+                },
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
+            };
+
+        this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
+
+        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/88888");
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
@@ -18,86 +18,65 @@ public class GameListTest : TestFixture
     public async Task GameList_GetsVisibleAndOpenGames()
     {
         List<RedisGame> games =
+        [
             new()
             {
-                // Should be returned
-                new()
+                RoomId = 12345,
+                Name = "639d263a-e05a-4432-952f-fa941e7f7f40",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
                 {
-                    RoomId = 12345,
-                    Name = "639d263a-e05a-4432-952f-fa941e7f7f40",
-                    MatchingCompatibleId = 36,
-                    MatchingType = MatchingTypes.Anyone,
-                    QuestId = 301010103,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 2,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    }
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
                 },
-                // Non-public matching
-                new()
-                {
-                    RoomId = 12345,
-                    Name = "0023679c-c449-45bd-881d-3e29a9d982ac",
-                    MatchingCompatibleId = 36,
-                    MatchingType = MatchingTypes.ById,
-                    QuestId = 301010103,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 3,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    }
-                },
-                // Visible = false
+                Players = (List<RedisPlayer>)[new() { ViewerId = 2, PartyNoList = [40] }]
+            },
+            // Non-public matching
 
-                new()
+            new()
+            {
+                RoomId = 12345,
+                Name = "0023679c-c449-45bd-881d-3e29a9d982ac",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.ById,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
                 {
-                    RoomId = 12345,
-                    Name = "04e2c5dd-055c-4c3b-85d0-29b4ea90b03e",
-                    MatchingCompatibleId = 36,
-                    MatchingType = MatchingTypes.Anyone,
-                    QuestId = 301010103,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 3,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    },
-                    Visible = false,
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
                 },
-            };
+                Players = [new() { ViewerId = 3, PartyNoList = [40] }]
+            },
+            // Visible = false
+
+
+            new()
+            {
+                RoomId = 12345,
+                Name = "04e2c5dd-055c-4c3b-85d0-29b4ea90b03e",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
+                {
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
+                },
+                Players = (List<RedisPlayer>)[new() { ViewerId = 3, PartyNoList = [40] }],
+                Visible = false,
+            }
+        ];
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(games);
 
@@ -107,64 +86,49 @@ public class GameListTest : TestFixture
         (await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>())
             .Should()
             .HaveCount(1)
-            .And.BeEquivalentTo(new List<ApiGame>() { new(games[0]) });
+            .And.BeEquivalentTo([games[0].ToApiGame()]);
     }
 
     [Fact]
     public async Task GameList_QuestIdSpecified_FiltersByQuest()
     {
         List<RedisGame> games =
+        [
             new()
             {
-                new()
+                RoomId = 12345,
+                Name = "d4592641-6f07-46d9-8b45-21059b27d1e2",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
                 {
-                    RoomId = 12345,
-                    Name = "d4592641-6f07-46d9-8b45-21059b27d1e2",
-                    MatchingCompatibleId = 36,
-                    MatchingType = MatchingTypes.Anyone,
-                    QuestId = 301010103,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 2,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    }
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
                 },
-                new()
+                Players = [new() { ViewerId = 2, PartyNoList = [40] }]
+            },
+            new()
+            {
+                RoomId = 12345,
+                Name = "c7c494cc-0ffc-46d6-a19b-cbfcad903225",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 219010102,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new()
                 {
-                    RoomId = 12345,
-                    Name = "c7c494cc-0ffc-46d6-a19b-cbfcad903225",
-                    MatchingCompatibleId = 36,
-                    MatchingType = MatchingTypes.Anyone,
-                    QuestId = 219010102,
-                    StartEntryTime = DateTimeOffset.UtcNow,
-                    EntryConditions = new()
-                    {
-                        UnacceptedElementTypeList = new List<int>() { 2, 3, 4, 5 },
-                        UnacceptedWeaponTypeList = new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8 },
-                        RequiredPartyPower = 11700,
-                        ObjectiveTextId = 1,
-                    },
-                    Players = new List<Player>()
-                    {
-                        new()
-                        {
-                            ViewerId = 3,
-                            PartyNoList = new List<int>() { 40 }
-                        }
-                    }
+                    UnacceptedElementTypeList = [2, 3, 4, 5],
+                    UnacceptedWeaponTypeList = [1, 2, 3, 4, 5, 6, 7, 8],
+                    RequiredPartyPower = 11700,
+                    ObjectiveTextId = 1,
                 },
-            };
+                Players = [new() { ViewerId = 3, PartyNoList = [40] }]
+            }
+        ];
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(games);
 
@@ -176,6 +140,6 @@ public class GameListTest : TestFixture
         (await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>())
             .Should()
             .HaveCount(1)
-            .And.BeEquivalentTo(new List<ApiGame>() { new(games[1]) });
+            .And.BeEquivalentTo(new List<ApiGame>() { games[1].ToApiGame() });
     }
 }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/IsHostTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/IsHostTest.cs
@@ -1,0 +1,115 @@
+using System.Net;
+using System.Net.Http.Json;
+using DragaliaAPI.Photon.Shared.Enums;
+using DragaliaAPI.Photon.StateManager.Models;
+using Xunit.Abstractions;
+
+namespace DragaliaAPI.Photon.StateManager.Test.Get;
+
+public class IsHostTest : TestFixture
+{
+    private const string Endpoint = "/Get/IsHost";
+
+    public IsHostTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task IsHost_HostFound_ReturnsTrue()
+    {
+        RedisGame game =
+            new()
+            {
+                RoomId = 12345,
+                Name = "151de85a-200a-4952-8757-e0f868bbf28b",
+                EntryConditions = new(),
+                Players =
+                [
+                    new()
+                    {
+                        ViewerId = 2,
+                        ActorNr = 1,
+                        PartyNoList = [40]
+                    },
+                    new()
+                    {
+                        ViewerId = 3,
+                        ActorNr = 2,
+                        PartyNoList = [40]
+                    }
+                ]
+            };
+
+        this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
+
+        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/2");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(true);
+    }
+
+    [Fact]
+    public async Task IsHost_IngameButNotHost_ReturnsFalse()
+    {
+        RedisGame game =
+            new()
+            {
+                RoomId = 12345,
+                Name = "151de85a-200a-4952-8757-e0f868bbf28b",
+                EntryConditions = new(),
+                Players =
+                [
+                    new()
+                    {
+                        ViewerId = 2,
+                        ActorNr = 1,
+                        PartyNoList = [40]
+                    },
+                    new()
+                    {
+                        ViewerId = 3,
+                        ActorNr = 2,
+                        PartyNoList = [40]
+                    }
+                ]
+            };
+
+        this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
+
+        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/3");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(false);
+    }
+
+    [Fact]
+    public async Task IsHost_NotInGame_ReturnsFalse()
+    {
+        RedisGame game =
+            new()
+            {
+                RoomId = 12345,
+                Name = "151de85a-200a-4952-8757-e0f868bbf28b",
+                MatchingCompatibleId = 36,
+                MatchingType = MatchingTypes.Anyone,
+                QuestId = 301010103,
+                StartEntryTime = DateTimeOffset.UtcNow,
+                EntryConditions = new() { },
+                Players =
+                [
+                    new()
+                    {
+                        ViewerId = 2,
+                        ActorNr = 1,
+                        PartyNoList = [40]
+                    }
+                ]
+            };
+
+        this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
+
+        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/8888");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(false);
+    }
+}

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Controllers/EventController.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Controllers/EventController.cs
@@ -52,7 +52,7 @@ public class EventController : ControllerBase
     public async Task<IActionResult> GameCreate(GameCreateRequest request)
     {
         RedisGame newGame = new(request.Game);
-        newGame.Players.Add(request.Player);
+        newGame.Players.Add(new RedisPlayer(request.Player));
 
         await this.Games.InsertAsync(newGame, this.KeyExpiry);
         await this.Games.SaveAsync();
@@ -100,7 +100,7 @@ public class EventController : ControllerBase
             return this.Conflict();
         }
 
-        game.Players.Add(request.Player);
+        game.Players.Add(new RedisPlayer(request.Player));
         await this.Games.UpdateAsync(game);
 
         this.logger.LogInformation("Added player {@player} to game {@game}", request.Player, game);
@@ -124,7 +124,10 @@ public class EventController : ControllerBase
             return this.NotFound();
         }
 
-        Player? toRemove = game.Players.FirstOrDefault(x => x.ViewerId == request.Player.ViewerId);
+        RedisPlayer? toRemove = game.Players.FirstOrDefault(x =>
+            x.ViewerId == request.Player.ViewerId
+        );
+
         if (toRemove is null)
         {
             this.logger.LogInformation(

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/RedisGame.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/RedisGame.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
 using DragaliaAPI.Photon.Shared.Enums;
 using DragaliaAPI.Photon.Shared.Models;
 using Redis.OM.Modeling;
@@ -6,63 +7,25 @@ using Redis.OM.Modeling;
 namespace DragaliaAPI.Photon.StateManager.Models;
 
 /// <summary>
-/// Implementation of <see cref="IGame"/> with Redis metadata.
+/// Represents a game as stored in Redis.
 /// </summary>
 [Document(StorageType = StorageType.Json)]
-public class RedisGame : IGame
+public class RedisGame
 {
-    /// <inheritdoc/>
-    [Indexed]
-    public int RoomId { get; set; }
-
-    /// <inheritdoc/>
-    [RedisIdField]
-    public string Name { get; set; } = string.Empty;
-
-    /// <inheritdoc/>
-    [Indexed]
-    public int MatchingCompatibleId { get; set; }
-
-    /// <inheritdoc/>
-    [Indexed(Sortable = true)]
-    public MatchingTypes MatchingType { get; set; }
-
-    /// <inheritdoc/>
-    [Indexed]
-    public int QuestId { get; set; }
-
-    /// <summary>
-    /// Determines whether a game should be visible or not. Redis-only property.
-    /// </summary>
-    [Indexed]
-    public bool Visible { get; set; } = true;
-
-    /// <inheritdoc/>
-    public DateTimeOffset StartEntryTime { get; set; } = DateTimeOffset.UtcNow;
-
-    [Indexed(Sortable = true)]
-    public long StartEntryTimestamp => StartEntryTime.ToUnixTimeSeconds();
-
-    /// <inheritdoc/>
-    public EntryConditions EntryConditions { get; set; } = new EntryConditions();
-
-    /// <inheritdoc/>
-    [Indexed(CascadeDepth = 1)]
-    public List<Player> Players { get; set; } = new List<Player>();
-
     /// <summary>
     /// Create a new instance of the <see cref="RedisGame"/> class.
     /// </summary>
     /// <param name="game">Base game, e.g. <see cref="GameBase"/>.</param>
+    [SetsRequiredMembers]
     public RedisGame(IGame game)
     {
-        RoomId = game.RoomId;
         Name = game.Name;
+        RoomId = game.RoomId;
         MatchingCompatibleId = game.MatchingCompatibleId;
         QuestId = game.QuestId;
         StartEntryTime = game.StartEntryTime;
         EntryConditions = game.EntryConditions;
-        Players = game.Players;
+        Players = game.Players.Select(p => new RedisPlayer(p)).ToList();
         MatchingType = game.MatchingType;
     }
 
@@ -71,4 +34,73 @@ public class RedisGame : IGame
     /// </summary>
     [JsonConstructor]
     public RedisGame() { }
+
+    /// <summary>
+    /// Gets or sets the unique room name / identifier.
+    /// </summary>
+    [RedisIdField]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the room passcode.
+    /// </summary>
+    [Indexed]
+    public int RoomId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the room version compatibility ID.
+    /// </summary>
+    [Indexed]
+    public int MatchingCompatibleId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the room privacy setting.
+    /// </summary>
+    [Indexed(Sortable = true)]
+    public MatchingTypes MatchingType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the room's quest ID.
+    /// </summary>
+    [Indexed]
+    public int QuestId { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a game should be visible or not. Redis-only property.
+    /// </summary>
+    [Indexed]
+    public bool Visible { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the starting time of the room.
+    /// </summary>
+    public DateTimeOffset StartEntryTime { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>
+    /// Gets or sets the room's requirements to join.
+    /// </summary>
+    public required EntryConditions EntryConditions { get; set; }
+
+    /// <summary>
+    /// Gets or sets a list of players in the room.
+    /// </summary>
+    [Indexed(JsonPath = $"$.{nameof(RedisPlayer.ViewerId)}")]
+    public required List<RedisPlayer> Players { get; set; }
+
+    /// <summary>
+    /// Maps a game to a <see cref="ApiGame"/>.
+    /// </summary>
+    /// <returns>An instance of <see cref="ApiGame"/>.</returns>
+    public ApiGame ToApiGame() =>
+        new()
+        {
+            Name = this.Name,
+            RoomId = this.RoomId,
+            MatchingCompatibleId = this.MatchingCompatibleId,
+            MatchingType = this.MatchingType,
+            QuestId = this.QuestId,
+            StartEntryTime = this.StartEntryTime,
+            EntryConditions = this.EntryConditions,
+            Players = this.Players.Select(x => x.ToPlayer()).ToList()
+        };
 }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/RedisPlayer.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Models/RedisPlayer.cs
@@ -1,0 +1,40 @@
+using DragaliaAPI.Photon.Shared.Models;
+using Redis.OM.Modeling;
+
+namespace DragaliaAPI.Photon.StateManager.Models;
+
+/// <summary>
+/// Represents a player as stored in Redis.
+/// </summary>
+public class RedisPlayer
+{
+    public RedisPlayer(Player player)
+    {
+        this.ActorNr = player.ActorNr;
+        this.ViewerId = player.ViewerId;
+        this.PartyNoList = player.PartyNoList;
+    }
+
+    public RedisPlayer() { }
+
+    /// <summary>
+    /// Gets or sets the player's actor number.
+    /// </summary>
+    public int ActorNr { get; set; }
+
+    /// <summary>
+    /// Gets or sets the player's viewer ID.
+    /// </summary>
+    [Indexed]
+    public long ViewerId { get; set; }
+
+    public IEnumerable<int> PartyNoList { get; set; } = [];
+
+    public Player ToPlayer() =>
+        new()
+        {
+            ViewerId = this.ViewerId,
+            ActorNr = this.ActorNr,
+            PartyNoList = this.PartyNoList
+        };
+}


### PR DESCRIPTION
- Use ConnectingViewerIdList to save an API call on record
- Make /Get/ByViewerId /Get/IsHost more efficient by only retrieving one
game

Might fix #385 as the new list should be ordered by actor number but we will see