### PR TITLE
Default chara.list_view_flag to true

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
@@ -144,7 +144,7 @@ public class DbPlayerCharaData : DbPlayerData
     public ushort ManaNodeUnlockCount { get; private set; }
 
     [Column("ListViewFlag")]
-    public bool ListViewFlag { get; set; }
+    public bool ListViewFlag { get; set; } = true;
 
     [Column("GetTime")]
     public DateTimeOffset GetTime { get; set; } = DateTimeOffset.UtcNow;

--- a/DragaliaAPI/DragaliaAPI/Features/StorySkip/StorySkipService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/StorySkip/StorySkipService.cs
@@ -299,7 +299,6 @@ public class StorySkipService(
                         ExAbilityLevel = 1,
                         ExAbility2Level = 1,
                         IsTemporary = false,
-                        ListViewFlag = false
                     };
                 newUserCharas.Add(newUserChara);
             }


### PR DESCRIPTION
This should be true for all characters except those that are temporary and whose event has ended, judging by the endgame savefile.

It does not make any difference at the minute since we don't support temporary adventurers, but the save editor complains about it