### PR TITLE
FIx result code being logged as null if returning an object directly

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -153,8 +153,8 @@ public class PartyTest : TestFixture
             .Should()
             .BeEquivalentTo(
                 new DragaliaResponse<ResultCodeResponse>(
-                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort),
-                    new ResultCodeResponse(ResultCode.PartySwitchSettingCharaShort)
+                    new ResultCodeResponse(ResultCode.PartySwitchSettingCharaShort),
+                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort)
                 )
             );
     }
@@ -184,8 +184,8 @@ public class PartyTest : TestFixture
             .Should()
             .BeEquivalentTo(
                 new DragaliaResponse<ResultCodeResponse>(
-                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort),
-                    new ResultCodeResponse(ResultCode.PartySwitchSettingCharaShort)
+                    new ResultCodeResponse(ResultCode.PartySwitchSettingCharaShort),
+                    new DataHeaders(ResultCode.PartySwitchSettingCharaShort)
                 )
             );
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/ToolTest.cs
@@ -119,8 +119,8 @@ public class ToolTest : TestFixture
             .Should()
             .BeEquivalentTo(
                 new DragaliaResponse<ResultCodeResponse>(
-                    new DataHeaders(ResultCode.IdTokenError),
-                    new(ResultCode.IdTokenError)
+                    new(ResultCode.IdTokenError),
+                    new DataHeaders(ResultCode.IdTokenError)
                 )
             );
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
@@ -34,8 +34,8 @@ public class ExceptionHandlerMiddlewareTest : TestFixture
         data.Should()
             .BeEquivalentTo(
                 new DragaliaResponse<ResultCodeResponse>(
-                    new DataHeaders(ResultCode.AbilityCrestBuildupPieceShortLevel),
-                    new ResultCodeResponse(ResultCode.AbilityCrestBuildupPieceShortLevel)
+                    new ResultCodeResponse(ResultCode.AbilityCrestBuildupPieceShortLevel),
+                    new DataHeaders(ResultCode.AbilityCrestBuildupPieceShortLevel)
                 )
             );
     }
@@ -72,8 +72,8 @@ public class ExceptionHandlerMiddlewareTest : TestFixture
             .Should()
             .BeEquivalentTo(
                 new DragaliaResponse<ResultCodeResponse>(
-                    new DataHeaders(ResultCode.CommonAuthError),
-                    new ResultCodeResponse(ResultCode.CommonAuthError)
+                    new ResultCodeResponse(ResultCode.CommonAuthError),
+                    new DataHeaders(ResultCode.CommonAuthError)
                 )
             );
     }

--- a/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -20,6 +20,7 @@ namespace DragaliaAPI.Controllers;
 [Authorize(AuthenticationSchemes = SchemeName.Session)]
 [Consumes("application/octet-stream")]
 [Produces("application/x-msgpack")]
+[ServiceFilter<SetResultCodeActionFilter>(Order = 2)]
 public abstract class DragaliaControllerBaseCore : ControllerBase
 {
     protected string DeviceAccountId =>
@@ -34,10 +35,6 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public override OkObjectResult Ok(object? value)
     {
-        // Controller unit tests will not set the HttpContext properly
-        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
-        this.HttpContext?.Items.Add(nameof(ResultCode), ResultCode.Success);
-
         return base.Ok(
             new DragaliaResponse<object>(
                 value ?? throw new ArgumentNullException(nameof(value)),
@@ -48,14 +45,10 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 
     public OkObjectResult Code(ResultCode code, string message)
     {
-        // Controller unit tests will not set the HttpContext properly
-        // ReSharper disable once ConditionalAccessQualifierIsNonNullableAccordingToAPIContract
-        this.HttpContext?.Items.Add(nameof(ResultCode), code);
-
         return base.Ok(
             new DragaliaResponse<object>(
-                dataHeaders: new DataHeaders(code),
-                new ResultCodeResponse(code, message)
+                new ResultCodeResponse(code, message),
+                dataHeaders: new DataHeaders(code)
             )
         );
     }
@@ -73,6 +66,6 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 /// <remarks>
 /// Not to be used for endpoints that make up the title screen (/tool/*, /version/*, etc.) to prevent infinite loops.
 /// </remarks>
-[ServiceFilter<ResourceVersionActionFilter>]
-[ServiceFilter<MaintenanceActionFilter>]
+[ServiceFilter<ResourceVersionActionFilter>(Order = 1)]
+[ServiceFilter<MaintenanceActionFilter>(Order = 1)]
 public abstract class DragaliaControllerBase : DragaliaControllerBaseCore { }

--- a/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileController.cs
@@ -16,8 +16,8 @@ public class SavefileController(ILoadService loadService) : ControllerBase
     {
         DragaliaResponse<LoadIndexResponse> savefile =
             new(
-                new DataHeaders(ResultCode.Success),
-                await loadService.BuildIndexData(cancellationToken)
+                await loadService.BuildIndexData(cancellationToken),
+                new DataHeaders(ResultCode.Success)
             );
 
         return this.File(

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/MaintenanceActionFilter.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/MaintenanceActionFilter.cs
@@ -30,8 +30,8 @@ public class MaintenanceActionFilter(
 
         context.Result = new OkObjectResult(
             new DragaliaResponse<object>(
-                dataHeaders: new DataHeaders(MaintenanceCode),
-                new ResultCodeResponse(MaintenanceCode)
+                new ResultCodeResponse(MaintenanceCode),
+                dataHeaders: new DataHeaders(MaintenanceCode)
             )
         );
     }

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/NotFoundHandlerMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/NotFoundHandlerMiddleware.cs
@@ -39,7 +39,7 @@ public class NotFoundHandlerMiddleware
         context.Items[nameof(ResultCode)] = NotFoundCode;
 
         DragaliaResponse<ResultCodeResponse> gameResponse =
-            new(new DataHeaders(NotFoundCode), new(NotFoundCode));
+            new(new(NotFoundCode), new DataHeaders(NotFoundCode));
 
         await context.Response.Body.WriteAsync(
             MessagePackSerializer.Serialize(gameResponse, CustomResolver.Options)

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResourceVersionActionFilter.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResourceVersionActionFilter.cs
@@ -38,8 +38,8 @@ public class ResourceVersionActionFilter(
 
             context.Result = new OkObjectResult(
                 new DragaliaResponse<object>(
-                    dataHeaders: new DataHeaders(ResultCode.CommonResourceVersionError),
-                    new ResultCodeResponse(ResultCode.CommonResourceVersionError)
+                    new ResultCodeResponse(ResultCode.CommonResourceVersionError),
+                    dataHeaders: new DataHeaders(ResultCode.CommonResourceVersionError)
                 )
             );
         }

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/SetResultCodeActionFilter.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/SetResultCodeActionFilter.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace DragaliaAPI.Infrastructure.Middleware;
+
+/// <summary>
+/// Service filter for populating <see cref="HttpContext.Items"/> with the result code of the response,
+/// so that it can be logged out in <see cref="ResultCodeLoggingMiddleware"/>.
+/// </summary>
+public class SetResultCodeActionFilter : IActionFilter
+{
+    public void OnActionExecuting(ActionExecutingContext context) { }
+
+    public void OnActionExecuted(ActionExecutedContext context)
+    {
+        if (context.Result is not ObjectResult { Value: DragaliaResponse dragaliaResponse })
+        {
+            return;
+        }
+
+        context.HttpContext.Items[nameof(ResultCode)] = dragaliaResponse.DataHeaders.ResultCode;
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Models/Results/DragaliaResponse.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Results/DragaliaResponse.cs
@@ -1,29 +1,35 @@
 ﻿using System.Text.Json.Serialization;
+using DragaliaAPI.Infrastructure;
 using MessagePack;
 
 namespace DragaliaAPI.Models.Results;
 
-[MessagePackObject]
-public class DragaliaResponse<TData>
-    where TData : class
+public abstract class DragaliaResponse
 {
     [Key("data_headers")]
-    public DataHeaders DataHeaders { get; init; }
+    public DataHeaders DataHeaders { get; }
 
+    protected DragaliaResponse(DataHeaders dataHeaders)
+    {
+        this.DataHeaders = dataHeaders;
+    }
+}
+
+[MessagePackObject]
+public class DragaliaResponse<TData> : DragaliaResponse
+    where TData : class
+{
     [Key("data")]
-    public TData Data { get; init; }
+    public TData Data { get; }
 
     public DragaliaResponse(TData data, ResultCode resultCode = ResultCode.Success)
-    {
-        this.Data = data;
-        this.DataHeaders = new(resultCode);
-    }
+        : this(data, new DataHeaders(resultCode)) { }
 
     [JsonConstructor]
     [SerializationConstructor]
-    public DragaliaResponse(DataHeaders dataHeaders, TData data)
+    public DragaliaResponse(TData data, DataHeaders dataHeaders)
+        : base(dataHeaders)
     {
-        this.DataHeaders = dataHeaders;
         this.Data = data;
     }
 }

--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -173,7 +173,10 @@ public static class ServiceConfiguration
         );
         services.AddScoped<IMatchingService, MatchingService>();
 
-        services.AddScoped<ResourceVersionActionFilter>().AddScoped<MaintenanceActionFilter>();
+        services
+            .AddScoped<ResourceVersionActionFilter>()
+            .AddScoped<MaintenanceActionFilter>()
+            .AddScoped<SetResultCodeActionFilter>();
 
         return services;
     }


### PR DESCRIPTION
Modern controllers tend to return a `TData` directly, by having a signature of `DragaliaResult<TData>` which returns an `IActionResult` by implementing `IConvertToActionResult`. This bypasses the mechanism implemented in #1016 inside `DragaliaControllerBase` which sets the `ResultCode` based on the use of `Ok()` or `Code()`.

To have the result code set in these cases, use an action filter that runs after all actions and attempts to determine if the result is a `DragaliaResponse` and, if it is, extract the result code. I've had to implement an abstract class for this as it wouldn't be possible to pass a value for the generic argument.

This mechanism replaces any need to set the result code manually in `DragaliaControllerBase`.

Also changed the constructors of `DragaliaResponse` to make them a tad more consistent.