### PR TITLE
Implement NerdBank.GitVersioning

### DIFF
--- a/.github/workflows/build-manual.yaml
+++ b/.github/workflows/build-manual.yaml
@@ -15,10 +15,6 @@ on:
         required: true
         type: string
         description: Docker image name
-      image-tag:
-        required: true
-        type: string
-        description: Docker image tag
 
 env:
   HUSKY: 0
@@ -30,5 +26,4 @@ jobs:
       ref: ${{ inputs.ref }}
       dockerfile: ${{ inputs.dockerfile }}
       image-name: ${{ inputs.image-name }}
-      image-tag: ${{ inputs.image-tag }}
     secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,6 @@ on:
         required: true
         type: string
         description: Docker image name
-      image-tag:
-        required: false
-        default: "undefined"
-        type: string
-        description: Docker image tag
 
 env:
   HUSKY: 0
@@ -33,15 +28,16 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
       - name: Get NerdBank version
         uses: dotnet/nbgv@v0.4.2
         id: nbgv
         with:
           path: ${{ inputs.dockerfile }}
-        
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,30 +33,12 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Derive image tag
-        id: derive-tag
-        run: |
-          TAG_REGEX="[\w]+?@v(.*)"
-          echo "Ref: ${{ inputs.ref }}"
-          echo "Tag: ${{ inputs.image-tag }}"
-
-          if [ ${{ inputs.image-tag }} != "undefined" ]
-          then
-            echo "tag=${{ inputs.image-tag }}" >> "$GITHUB_OUTPUT"
-            exit 0;
-          fi
-
-          if [ ${{ inputs.ref }} = "main" ]
-          then
-             echo "tag=latest" >> "$GITHUB_OUTPUT"
-          elif [[ ${{ inputs.ref }} =~ $TAG_REGEX ]]
-          then
-             echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-          else
-            echo "No image-tag provided and failed to derive image tag from ref"
-            exit 1;
-          fi
-
+      - name: Get NerdBank version
+        uses: dotnet/nbgv@v0.4.2
+        id: nbgv
+        with:
+          path: ${{ inputs.dockerfile }}
+        
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
@@ -73,6 +55,6 @@ jobs:
           context: .
           push: true
           file: ${{ inputs.dockerfile }}
-          tags: ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.derive-tag.outputs.tag }}
+          tags: ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.nbgv.outputs.SemVer2 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
-          sparse-checkout: ${{ inputs.dockerfile }}/../../
 
       - name: Get NerdBank version
         uses: dotnet/nbgv@v0.4.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
+          fetch-depth: 0
+          sparse-checkout: ${{ inputs.dockerfile }}/../../
 
       - name: Get NerdBank version
         uses: dotnet/nbgv@v0.4.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: dotnet/nbgv@v0.4.2
         id: nbgv
         with:
-          path: ${{ inputs.dockerfile }}
+          path: ${{ inputs.dockerfile }}/../../
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,6 +27,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      tag: ${{ steps.output-tag.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,3 +57,7 @@ jobs:
           tags: ghcr.io/sapiensanatis/${{ inputs.image-name }}:${{ steps.nbgv.outputs.SemVer2 }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          
+      - name: Output tag
+        id: output-tag
+        run: echo "tag=${{ steps.nbgv.outputs.SemVer2 }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,6 +7,10 @@ on:
         type: string
         required: true
         description: "GitHub environment name"
+      version:
+        type: string
+        required: true
+        description: "Version to deploy"
 
 jobs:
   deploy:
@@ -31,5 +35,6 @@ jobs:
             export NOMAD_ADDR="https://10.0.0.2:4646"
             export NOMAD_CACERT="/srv/certs/cluster-agent-ca.pem"
             export NOMAD_TOKEN="${{ secrets.NOMAD_TOKEN }}"
+            nomad var put nomad/jobs/${{ vars.JOB_NAME }}/ version="${{ inputs.version }}"
             cd "${{ vars.JOB_DIRECTORY }}"
             nomad job run "${{ vars.JOB_FILE_NAME }}"

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -51,7 +51,11 @@ jobs:
         id: get-name
         run: >
           echo ${{ inputs.project }} | sed 's/.*\//name=/' >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/publish-api.yaml
+++ b/.github/workflows/publish-api.yaml
@@ -27,4 +27,5 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       github-environment: "Dawnshard"
+      version: ${{ needs.build.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/publish-statemanager.yaml
+++ b/.github/workflows/publish-statemanager.yaml
@@ -27,4 +27,5 @@ jobs:
     uses: ./.github/workflows/deploy.yaml
     with:
       github-environment: "PhotonStateManager"
+      version: ${{ needs.build.outputs.tag }}
     secrets: inherit

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,11 @@ jobs:
         id: get-name
         run: >
           echo ${{ inputs.project }} | sed 's/.*\//name=/' >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+        
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -67,6 +67,7 @@
     <PackageVersion Include="GraphQL.Client.Serializer.SystemTextJson" Version="6.1.0" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.4.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.141" />
     <PackageVersion Include="Respawn" Version="6.2.1" />
     <PackageVersion Include="Snapshooter.Xunit" Version="0.14.1" />
     <PackageVersion Include="Testcontainers" Version="3.9.0" />

--- a/DragaliaAPI.sln
+++ b/DragaliaAPI.sln
@@ -52,6 +52,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PhotonStateManager", "Photo
 	ProjectSection(SolutionItems) = preProject
 		PhotonStateManager\Directory.Build.props = PhotonStateManager\Directory.Build.props
 		PhotonStateManager\README.md = PhotonStateManager\README.md
+		PhotonStateManager\version.json = PhotonStateManager\version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DragaliaAPI.Integration.Test", "DragaliaAPI\DragaliaAPI.Integration.Test\DragaliaAPI.Integration.Test.csproj", "{CA0AE7C5-2742-4FC9-B668-BC7459E4BCE5}"
@@ -81,6 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "DragaliaAPI", "DragaliaAPI"
 	ProjectSection(SolutionItems) = preProject
 		DragaliaAPI\Directory.Build.props = DragaliaAPI\Directory.Build.props
 		DragaliaAPI\README.md = DragaliaAPI\README.md
+		DragaliaAPI\version.json = DragaliaAPI\version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DragaliaAPI.MasterAssetConverter", "DragaliaAPI\DragaliaAPI.MasterAssetConverter\DragaliaAPI.MasterAssetConverter.csproj", "{F0DFB899-ADC2-407E-AB32-647BA1C4122C}"

--- a/DragaliaAPI/Directory.Build.props
+++ b/DragaliaAPI/Directory.Build.props
@@ -5,30 +5,31 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest-minimum</AnalysisLevel>
   </PropertyGroup>
-
   <PropertyGroup>
     <!-- Define the TEST condition to allow test runs in release mode to access conditionally
     compiled controllers. -->
     <DefineConstants Condition="$(AUTOMATED_TESTING) == 'true'">TEST;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
-
   <PropertyGroup>
     <MasterAssetResources>$(MSBuildThisFileDirectory)DragaliaAPI.Shared\Resources\</MasterAssetResources>
     <ApiOutputDirectory>$(MSBuildThisFileDirectory)DragaliaAPI\bin\$(Configuration)\$(TargetFramework)\</ApiOutputDirectory>
   </PropertyGroup>
-
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.6.141</Version>
+    </PackageReference>
+  </ItemGroup>
   <Target Name="CopyApiMsgpackFiles" AfterTargets="Build" Condition="$(DependsOnApiMsgpackFiles) == 'true'">
     <ItemGroup>
       <MasterAssetMsgpackFiles Include="$(ApiOutputDirectory)Resources\**\*.msgpack" />
     </ItemGroup>
     <Copy SourceFiles="@(MasterAssetMsgpackFiles)" DestinationFolder="$(OutDir)Resources\%(RecursiveDir)" />
   </Target>
-
   <Target Name="CleanMsgpackFiles" AfterTargets="Clean" Condition="$(DependsOnApiMsgpackFiles) == 'true'">
     <ItemGroup>
       <FilesToDelete Include="$(OutDir)Resources\**\*.msgpack" />
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
   </Target>
-
 </Project>

--- a/DragaliaAPI/Directory.Build.props
+++ b/DragaliaAPI/Directory.Build.props
@@ -17,7 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
-      <Version>3.6.141</Version>
     </PackageReference>
   </ItemGroup>
   <Target Name="CopyApiMsgpackFiles" AfterTargets="Build" Condition="$(DependsOnApiMsgpackFiles) == 'true'">

--- a/DragaliaAPI/version.json
+++ b/DragaliaAPI/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "4.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}

--- a/PhotonStateManager/Directory.Build.props
+++ b/PhotonStateManager/Directory.Build.props
@@ -5,4 +5,10 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest-minimum</AnalysisLevel>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
+      <PrivateAssets>all</PrivateAssets>
+      <Version>3.6.141</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/PhotonStateManager/Directory.Build.props
+++ b/PhotonStateManager/Directory.Build.props
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
-      <Version>3.6.141</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/PhotonStateManager/version.json
+++ b/PhotonStateManager/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "3.0",
+  "publicReleaseRefSpec": [
+    "^refs/heads/main$",
+    "^refs/heads/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
Implements [NerdBank.GitVersioning](https://github.com/dotnet/nerdbank.gitversioning) to derive tags.

This will allow us to maintain immutable image tags rather than just re-tagging `:latest` repeatedly, which should help with version immutability and allow me to remove some hacks that make Nomad force re-pull the image on job resubmission.