### PR TITLE
Fix co-op softlock for player 2

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/OutputCachingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/OutputCachingTest.cs
@@ -27,7 +27,6 @@ public class OutputCachingTest : TestFixture
 
         await this.AddToDatabase(build);
 
-        this.Client.DefaultRequestHeaders.Remove(Headers.DisableOutputCaching);
         this.Client.DefaultRequestHeaders.Add(Headers.RequestToken, "1234");
 
         DragaliaResponse<FortBuildEndResponse> response =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -208,8 +208,6 @@ public class TestFixture
             );
 
         client.DefaultRequestHeaders.Add(Headers.SessionId, SessionId);
-        client.DefaultRequestHeaders.Add(Headers.DisableOutputCaching, "true");
-
         client.DefaultRequestHeaders.Add("Platform", "2");
         client.DefaultRequestHeaders.Add("Res-Ver", "y2XM6giU6zz56wCm");
 

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/DragaliaHttpConstants.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/DragaliaHttpConstants.cs
@@ -30,13 +30,5 @@ public static class DragaliaHttpConstants
         /// Header containing a unique device identifier.
         /// </summary>
         public const string DeviceId = "DeviceId";
-
-        /// <summary>
-        /// Header to disable output caching.
-        /// </summary>
-        /// <remarks>
-        /// Not used by the game client, but used by the integration tests to avoid being served cached data.
-        /// </remarks>
-        public const string DisableOutputCaching = "Disable-OutputCaching";
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/OutputCaching/RepeatedRequestPolicy.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/OutputCaching/RepeatedRequestPolicy.cs
@@ -70,15 +70,11 @@ internal class RepeatedRequestPolicy(ILogger<RepeatedRequestPolicy> logger) : IO
         //     return false;
         // }
 
-#if DEBUG || TEST
-        // Integration test workaround. It's not easy to vary the Request-Token automatically using
-        // WebApplicationFactory - or at least I can't see a good way. So, they set this header to override the
-        // caching policy.
-        if (request.Headers.ContainsKey(Headers.DisableOutputCaching))
+        // Request likely did not come from a game client. Could be from an integration test or Photon Server.
+        if (!request.Headers.ContainsKey(Headers.RequestToken))
         {
             return false;
         }
-#endif
 
         return true;
     }


### PR DESCRIPTION
Incoming /dungeon_record/record_multi requests were being subjected to output caching after #1016, because the Photon server does not set Request-Token or SID so the vary-by headers were always the same. This lead to P2 being served P1's response which lead to a softlock.

Fix this by only caching requests where a Request-Token was present in the first place. This also replaces the existing workaround to disable output caching in the automated tests.