### PR TITLE
Fix lack of ordering on summon history query

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
@@ -234,7 +234,8 @@ public sealed partial class SummonService(
 
     public async Task<IList<SummonHistoryList>> GetSummonHistory() =>
         await apiContext
-            .PlayerSummonHistory.Take(30) // See: https://dragalialost.wiki/w/Version_Changelog/Ver_1.18.0_Version_Update#Summon_History
+            .PlayerSummonHistory.OrderByDescending(x => x.ExecDate)
+            .Take(30) // See: https://dragalialost.wiki/w/Version_Changelog/Ver_1.18.0_Version_Update#Summon_History
             .Select(x => x.ToSummonHistoryList())
             .ToListAsync();
 


### PR DESCRIPTION
Resolves EF core warning: `The query uses a row limiting operator ('Skip'/'Take') without an 'OrderBy' operator. This may lead to unpredictable results.`