### PR TITLE
Fix smithywyrm cost

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -157,7 +157,7 @@ public class FortServiceTest
     [Theory]
     [InlineData(2, 250)]
     [InlineData(3, 400)]
-    [InlineData(4, 750)]
+    [InlineData(4, 700)]
     public async Task AddCarpenter_Success_AddsCarpenterWithExpectedCost(
         int existingCarpenters,
         int expectedCost

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
@@ -53,7 +53,7 @@ public class FortService(
             < 2 => 0,
             2 => 250,
             3 => 400,
-            4 => 750,
+            4 => 700,
             _
                 => throw new DragaliaException(
                     ResultCode.FortExtendCarpenterLimit,


### PR DESCRIPTION
The cost of the final smithywyrm has always been incorrect at 750. The wiki confirms it is 700. This has started to cause errors in the logs about failed payments now that diamantium is available and wyrmite is limited.