### PR TITLE
Add try/catch to website healthcheck

### DIFF
--- a/Website/src/routes/health/+server.ts
+++ b/Website/src/routes/health/+server.ts
@@ -4,10 +4,16 @@ import type { RequestHandler } from './$types';
 
 export const GET: RequestHandler = async ({ fetch }) => {
   const apiPingUrl = new URL('/ping', env.DAWNSHARD_API_URL_SSR);
-  const apiPing = await fetch(apiPingUrl);
 
-  if (!apiPing.ok) {
-    console.error(`Failed to ping ${apiPingUrl}: status ${apiPing.status}`);
+  try {
+    const apiPing = await fetch(apiPingUrl);
+
+    if (!apiPing.ok) {
+      console.error(`Failed to ping ${apiPingUrl}: status ${apiPing.status}`);
+      return new Response('Unhealthy', { status: 503 });
+    }
+  } catch (e) {
+    console.error(`Fetch failed when pinging ${apiPingUrl}`, e);
     return new Response('Unhealthy', { status: 503 });
   }
 


### PR DESCRIPTION
We don't want the website to return an Internal Error page for the healthcheck if the fetch fails to get a response