### PR TITLE
Use batch reward handler to claim presents

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Present/PresentControllerService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Present/PresentControllerService.cs
@@ -77,26 +77,35 @@ public class PresentControllerService(
             ? presentsQuery.Where(x => x.ReceiveLimitTime != null)
             : presentsQuery.Where(x => x.ReceiveLimitTime == null);
 
-        List<DbPlayerPresent> presents = await presentsQuery.ToListAsync();
+        Dictionary<long, DbPlayerPresent> presents = await presentsQuery.ToDictionaryAsync(
+            x => x.PresentId,
+            x => x
+        );
+        Dictionary<long, Entity> presentEntities = presents.ToDictionary(
+            x => x.Key,
+            x => new Entity(
+                x.Value.EntityType,
+                x.Value.EntityId,
+                x.Value.EntityQuantity,
+                x.Value.EntityLimitBreakCount,
+                BuildupCount: 0,
+                EquipableCount: 1
+            )
+        );
 
         List<long> receivedIds = [];
         List<long> notReceivedIds = [];
         List<long> removedIds = [];
 
-        foreach (DbPlayerPresent present in presents)
-        {
-            RewardGrantResult result = await rewardService.GrantReward(
-                new(
-                    present.EntityType,
-                    present.EntityId,
-                    present.EntityQuantity,
-                    present.EntityLimitBreakCount,
-                    0,
-                    1
-                )
-            );
+        IDictionary<long, RewardGrantResult> result = await rewardService.BatchGrantRewards(
+            presentEntities
+        );
 
-            switch (result)
+        foreach ((long presentId, RewardGrantResult grantResult) in result)
+        {
+            DbPlayerPresent present = presents[presentId];
+
+            switch (grantResult)
             {
                 case RewardGrantResult.Added:
                     receivedIds.Add(present.PresentId);
@@ -114,7 +123,7 @@ public class PresentControllerService(
 
             logger.LogDebug("Claimed present {@present}", present);
 
-            if (result is RewardGrantResult.Added or RewardGrantResult.Converted)
+            if (grantResult is RewardGrantResult.Added or RewardGrantResult.Converted)
             {
                 apiContext.PlayerPresents.Remove(present);
                 apiContext.PlayerPresentHistory.Add(present.MapToPresentHistory());


### PR DESCRIPTION
On testing the save editor I was hitting a fail point I added when attempting to grant multiple dragons without using the batch handler.

https://github.com/SapiensAnatis/Dawnshard/blob/8f25035986ee218d3b9b024b61e42f4323323a14/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DragonHandler.cs#L17-L25

We need to use the batch handler for presents to ensure all types of presents can be claimed - I suspect multiple dragons in one present was not possible before the editor.