### PR TITLE
Don't log errors for user ID not found

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Services/Api/BaasApi.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Api/BaasApi.cs
@@ -98,6 +98,12 @@ public class BaasApi : IBaasApi
 
         HttpResponseMessage response = await client.SendAsync(request);
 
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            this.logger.LogDebug("GetUserId returned 404 Not Found.");
+            return null;
+        }
+
         if (!response.IsSuccessStatusCode)
         {
             this.logger.LogError(


### PR DESCRIPTION
These are spamming the error logs when it's an expected case if someone logs into the website (calling /api/user/me) with a BaaS account that doesn't have a dawnshard device account linked