### PR TITLE
Don't cache requests without a SID header

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Infrastructure/OutputCaching/RepeatedRequestPolicy.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/OutputCaching/RepeatedRequestPolicy.cs
@@ -76,6 +76,12 @@ internal class RepeatedRequestPolicy(ILogger<RepeatedRequestPolicy> logger) : IO
             return false;
         }
 
+        // We do not want to cache requests globally - make sure this request can be keyed to a particular user.
+        if (!request.Headers.ContainsKey(Headers.SessionId))
+        {
+            return false;
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
Prevents unauthenticated requests becoming cached for all users. The Request-Token is not as random as we thought. It is calculated by

`(CurrentRequestId + 1) & 0xFFFFFF | (UnixTime(DateTime.UtcNow) << 24)`

which could mean that two clients making a series of unauthenticated requests at the same time could receive the same token, i.e. it is not actually pseudo- random as originally assumed.