### PR TITLE
Fix server error when claiming amber before initializing kaleidoscape

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -208,5 +208,9 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbPlayerDiamondData>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbPlayerDmodeInfo>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -699,6 +699,49 @@ public class PresentTest : TestFixture
     }
 
     [Fact]
+    public async Task Receive_DmodePoint_InitializesKaleidoscapeData()
+    {
+        this.ApiContext.PlayerDmodeInfos.ExecuteDelete();
+        this.ApiContext.PlayerDmodeDungeons.ExecuteDelete();
+        this.ApiContext.PlayerDmodeExpeditions.ExecuteDelete();
+
+        List<DbPlayerPresent> presents =
+        [
+            new DbPlayerPresent()
+            {
+                EntityType = EntityTypes.DmodePoint,
+                EntityId = (int)DmodePoint.Point1,
+                EntityQuantity = 100,
+            },
+            new DbPlayerPresent()
+            {
+                EntityType = EntityTypes.DmodePoint,
+                EntityId = (int)DmodePoint.Point1,
+                EntityQuantity = 100,
+            },
+            new DbPlayerPresent()
+            {
+                EntityType = EntityTypes.DmodePoint,
+                EntityId = (int)DmodePoint.Point2,
+                EntityQuantity = 200,
+            },
+        ];
+
+        await this.AddRangeToDatabase(presents);
+
+        IEnumerable<ulong> presentIdList = presents.Select(x => (ulong)x.PresentId);
+
+        DragaliaResponse<PresentReceiveResponse> response =
+            await this.Client.PostMsgpack<PresentReceiveResponse>(
+                $"{Controller}/receive",
+                new PresentReceiveRequest() { PresentIdList = presentIdList }
+            );
+
+        response.Data.UpdateDataList.DmodeInfo.DmodePoint1.Should().Be(200);
+        response.Data.UpdateDataList.DmodeInfo.DmodePoint2.Should().Be(200);
+    }
+
+    [Fact]
     public async Task GetPresentHistoryList_IsPagedCorrectly()
     {
         List<DbPlayerPresentHistory> presentHistories = Enumerable

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -105,6 +105,13 @@ public class GlobalQueryFilterTest : TestFixture
         await TestGlobalQueryFilter<DbFortBuild>();
 
     [Fact]
+    public async Task DbPlayerDmodeInfo_HasGlobalQueryFilter()
+    {
+        await this.ApiContext.PlayerDmodeInfos.ExecuteDeleteAsync();
+        await TestGlobalQueryFilter<DbPlayerDmodeInfo>();
+    }
+
+    [Fact]
     public async Task DbPlayerDiamondData_HasGlobalQueryFilter()
     {
         this.ApiContext.Players.Add(new() { ViewerId = this.ViewerId + 1, AccountId = "other" });

--- a/DragaliaAPI/DragaliaAPI/Extensions/ServiceCollectionExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Extensions/ServiceCollectionExtensions.cs
@@ -12,8 +12,14 @@ public static class ServiceCollectionExtensions
     {
         foreach (Type type in Assembly.GetExecutingAssembly().GetTypes())
         {
-            if (type.GetInterfaces().Contains(typeof(TInterface)))
+            if (
+                type.GetInterfaces().Contains(typeof(TInterface))
+                && !type.IsInterface
+                && !type.IsAbstract
+            )
+            {
                 serviceCollection.Add(new ServiceDescriptor(typeof(TInterface), type, lifetime));
+            }
         }
 
         return serviceCollection;

--- a/DragaliaAPI/DragaliaAPI/Features/Dmode/DmodeRepository.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dmode/DmodeRepository.cs
@@ -9,8 +9,7 @@ namespace DragaliaAPI.Features.Dmode;
 public class DmodeRepository(ApiContext apiContext, IPlayerIdentityService playerIdentityService)
     : IDmodeRepository
 {
-    public IQueryable<DbPlayerDmodeInfo> Info =>
-        apiContext.PlayerDmodeInfos.Where(x => x.ViewerId == playerIdentityService.ViewerId);
+    public IQueryable<DbPlayerDmodeInfo> Info => apiContext.PlayerDmodeInfos;
 
     public IQueryable<DbPlayerDmodeChara> Charas =>
         apiContext.PlayerDmodeCharas.Where(x => x.ViewerId == playerIdentityService.ViewerId);

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DmodePointRewardHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DmodePointRewardHandler.cs
@@ -1,0 +1,69 @@
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Features.Dmode;
+using DragaliaAPI.Shared.Definitions.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.Reward.Handlers;
+
+internal sealed class DmodePointRewardHandler(
+    ApiContext apiContext,
+    IDmodeRepository dmodeRepository
+) : IBatchRewardHandler
+{
+    private const int MaxDmodePoint = 999_999_999;
+
+    public IReadOnlyList<EntityTypes> SupportedTypes { get; } = [EntityTypes.DmodePoint];
+
+    public async Task<IDictionary<TKey, GrantReturn>> GrantRange<TKey>(
+        IDictionary<TKey, Entity> entities
+    )
+        where TKey : struct
+    {
+        DbPlayerDmodeInfo info = await this.GetOrCreateDmodeInfo();
+        Dictionary<TKey, GrantReturn> result = new(entities.Count);
+
+        foreach ((TKey key, Entity entity) in entities)
+        {
+            if (entity.Id == (int)DmodePoint.Point1)
+            {
+                if (info.Point1Quantity + entity.Quantity > MaxDmodePoint)
+                {
+                    result.Add(key, GrantReturn.Limit());
+                    continue;
+                }
+
+                info.Point1Quantity += entity.Quantity;
+            }
+            else if (entity.Id == (int)DmodePoint.Point2)
+            {
+                if (info.Point2Quantity + entity.Quantity > MaxDmodePoint)
+                {
+                    result.Add(key, GrantReturn.Limit());
+                    continue;
+                }
+
+                info.Point2Quantity += entity.Quantity;
+            }
+            else
+            {
+                throw new InvalidOperationException("Invalid entity ID for DmodePoint!");
+            }
+        }
+
+        return result;
+    }
+
+    private async Task<DbPlayerDmodeInfo> GetOrCreateDmodeInfo()
+    {
+        DbPlayerDmodeInfo? info = await apiContext.PlayerDmodeInfos.FirstOrDefaultAsync();
+
+        if (info is null)
+        {
+            dmodeRepository.InitializeForPlayer();
+            info = apiContext.PlayerDmodeInfos.Local.First();
+        }
+
+        return info;
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DmodePointRewardHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/DmodePointRewardHandler.cs
@@ -34,6 +34,7 @@ internal sealed class DmodePointRewardHandler(
                 }
 
                 info.Point1Quantity += entity.Quantity;
+                result.Add(key, GrantReturn.Added());
             }
             else if (entity.Id == (int)DmodePoint.Point2)
             {
@@ -44,6 +45,7 @@ internal sealed class DmodePointRewardHandler(
                 }
 
                 info.Point2Quantity += entity.Quantity;
+                result.Add(key, GrantReturn.Added());
             }
             else
             {

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/GenericRewardHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/GenericRewardHandler.cs
@@ -44,8 +44,7 @@ public class GenericRewardHandler(
             EntityTypes.ExHunterEventItem,
             EntityTypes.BattleRoyalEventItem,
             EntityTypes.EarnEventItem,
-            EntityTypes.CombatEventItem,
-            EntityTypes.DmodePoint
+            EntityTypes.CombatEventItem
         );
 
     public async Task<GrantReturn> Grant(Entity entity)

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/IBatchRewardHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/Handlers/IBatchRewardHandler.cs
@@ -2,10 +2,16 @@ using DragaliaAPI.Shared.Definitions.Enums;
 
 namespace DragaliaAPI.Features.Reward.Handlers;
 
-public interface IBatchRewardHandler
+public interface IBatchRewardHandler : IRewardHandler
 {
-    public IReadOnlyList<EntityTypes> SupportedTypes { get; }
-
     public Task<IDictionary<TKey, GrantReturn>> GrantRange<TKey>(IDictionary<TKey, Entity> entities)
         where TKey : struct;
+
+    async Task<GrantReturn> IRewardHandler.Grant(Entity entity)
+    {
+        Dictionary<int, Entity> dict = new() { [1] = entity };
+        IDictionary<int, GrantReturn> result = await GrantRange(dict);
+
+        return result.First().Value;
+    }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Reward/RewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/RewardService.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Database.Entities;
+﻿using System.Diagnostics;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Reward.Handlers;
 using DragaliaAPI.Features.Talisman;
@@ -70,6 +71,11 @@ public class RewardService(
             {
                 IDictionary<TKey, GrantReturn> batchResult = await batchRewardHandler.GrantRange(
                     dictionary
+                );
+
+                Debug.Assert(
+                    batchResult.Count == dictionary.Count,
+                    "Batch reward handler returned incorrect number of results"
                 );
 
                 foreach ((TKey key, GrantReturn grantReturn) in batchResult)


### PR DESCRIPTION
Currently the server throws an error if you try and claim a present orother reward containing Kaleidoscape amber before unlocking the Kaleidoscape mode. This is because it can't find the DbPlayerDmodeInfo
to update.

This was never really a problem until the introduction of the save editor, where people seem to be quite commonly hitting this case.

Introduce a reward handler for these which can initialize the Kaleidoscape data when attempting to claim a present.

It seems that having any kaleidoscape data initialized will then lead the game to skip the kaleidoscape intro (and calling /dmode/entry) so there shouldn't be any PK conflicts.