### PR TITLE
Adjust max present quantity in save editor down

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileEditService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Savefile/SavefileEditService.cs
@@ -45,7 +45,7 @@ internal sealed partial class SavefileEditService(
 
         foreach (PresentFormSubmission present in presents)
         {
-            if (present.Quantity < 1)
+            if (present.Quantity is < 1 or > 999_999)
             {
                 Log.InvalidSinglePresent(logger, present);
                 return false;

--- a/Website/src/routes/(main)/account/save-editor/present/presentWidget.svelte
+++ b/Website/src/routes/(main)/account/save-editor/present/presentWidget.svelte
@@ -141,7 +141,7 @@
             disabled={disableQuantity}
             field={quantity}
             min={1}
-            max={2147483647}
+            max={999999}
             required
             class="
               touched:invalid:border-red-700


### PR DESCRIPTION
Some players have run into an issue where particulary quantities of items e.g. 2,147,483,647 diamantium are not claimable

999,999 is the maximum hustle hammers which is the lowest of all entity types that currently have defined limits. It should be enough for most editing operations, if not it's trivial to just add more presents.