### PR TITLE
Show BaaS username in account management dialog

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -33,19 +33,16 @@ public class UserTest : TestFixture
     [Fact]
     public async Task GetNAccountInfo_ReturnsExpectedResponse()
     {
+        this.MockBaasApi.Setup(x => x.GetUsername(It.IsAny<string>())).ReturnsAsync("okada");
+
         (await this.Client.PostMsgpack<UserGetNAccountInfoResponse>("/user/get_n_account_info"))
             .Data.Should()
             .BeEquivalentTo(
                 new UserGetNAccountInfoResponse()
                 {
-                    NAccountInfo = new()
-                    {
-                        Email = "placeholder@email.com",
-                        Nickname = "placeholder nickname",
-                    },
+                    NAccountInfo = new() { Email = "", Nickname = "okada" },
                     UpdateDataList = new(),
-                },
-                opts => opts.Excluding(x => x.UpdateDataList.UserData.Crystal)
+                }
             );
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/UserController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/UserController.cs
@@ -1,61 +1,52 @@
 ﻿using AutoMapper;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Infrastructure;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Services;
+using DragaliaAPI.Services.Api;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("user")]
-public class UserController : DragaliaControllerBase
+public class UserController(
+    IUserDataRepository userDataRepository,
+    IUpdateDataService updateDataService,
+    IBaasApi baasApi,
+    ISessionService sessionService
+) : DragaliaControllerBase
 {
-    private readonly IUserDataRepository userDataRepository;
-    private readonly IUpdateDataService updateDataService;
-    private readonly IMapper mapper;
-
-    public UserController(
-        IUserDataRepository userDataRepository,
-        IUpdateDataService updateDataService,
-        IMapper mapper
-    )
-    {
-        this.userDataRepository = userDataRepository;
-        this.updateDataService = updateDataService;
-        this.mapper = mapper;
-    }
-
     [HttpPost("linked_n_account")]
     public async Task<DragaliaResult> LinkedNAccount(CancellationToken cancellationToken)
     {
         // This controller is meant to be used to set the 'Link a Nintendo Account' mission as complete
-        DbPlayerUserData userData = await this.userDataRepository.UserData.SingleAsync(
+        DbPlayerUserData userData = await userDataRepository.UserData.SingleAsync(
             cancellationToken
         );
 
         userData.Crystal += 12_000;
-        UpdateDataList updateDataList = await this.updateDataService.SaveChangesAsync(
-            cancellationToken
-        );
+        UpdateDataList updateDataList = await updateDataService.SaveChangesAsync(cancellationToken);
 
         return this.Ok(new UserLinkedNAccountResponse() { UpdateDataList = updateDataList });
     }
 
     [HttpPost("get_n_account_info")]
-    public DragaliaResult GetNAccountInfo()
+    public async Task<DragaliaResult<UserGetNAccountInfoResponse>> GetNAccountInfo(
+        [FromHeader(Name = DragaliaHttpConstants.Headers.SessionId)] string sessionId
+    )
     {
-        // TODO: Replace this with an API call to BaaS to return actual information
-        return this.Ok(
-            new UserGetNAccountInfoResponse()
+        string idToken = (await sessionService.LoadSessionSessionId(sessionId)).IdToken;
+
+        return new UserGetNAccountInfoResponse()
+        {
+            NAccountInfo = new()
             {
-                NAccountInfo = new()
-                {
-                    Email = "placeholder@email.com",
-                    Nickname = "placeholder nickname",
-                },
-                UpdateDataList = new(),
-            }
-        );
+                Email = string.Empty, // This being null or empty shows the nickname instead
+                Nickname = await baasApi.GetUsername(idToken),
+            },
+            UpdateDataList = new(),
+        };
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -165,6 +165,7 @@ app.MapWhen(
         {
             applicationBuilder.UsePathBase(prefix);
         }
+
         applicationBuilder.UseMiddleware<HeaderLogContextMiddleware>();
         applicationBuilder.UseSerilogRequestLogging();
         applicationBuilder.UseAuthentication();

--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -149,7 +149,16 @@ public static class ServiceConfiguration
 
         services.AddAllOfType<ISavefileUpdate>();
 
-        services.AddHttpClient<IBaasApi, BaasApi>();
+        services.AddHttpClient<IBaasApi, BaasApi>(
+            (sp, client) =>
+            {
+                IOptionsMonitor<BaasOptions> options = sp.GetRequiredService<
+                    IOptionsMonitor<BaasOptions>
+                >();
+
+                client.BaseAddress = options.CurrentValue.BaasUrlParsed;
+            }
+        );
 
         services.AddHttpClient<IPhotonStateApi, PhotonStateApi>(
             (sp, client) =>

--- a/DragaliaAPI/DragaliaAPI/Services/Api/BaasApi.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Api/BaasApi.cs
@@ -100,14 +100,14 @@ public class BaasApi : IBaasApi
 
         if (response.StatusCode == HttpStatusCode.NotFound)
         {
-            this.logger.LogDebug("GetUserId returned 404 Not Found.");
+            this.logger.LogDebug("/gameplay/v1/user returned 404 Not Found.");
             return null;
         }
 
         if (!response.IsSuccessStatusCode)
         {
             this.logger.LogError(
-                "Received non-200 status code in GetUserId: {Status}",
+                "Received non-200 status code from /gameplay/v1/user: {Status}",
                 response.StatusCode
             );
 
@@ -117,8 +117,42 @@ public class BaasApi : IBaasApi
         return (await response.Content.ReadFromJsonAsync<UserIdResponse>())?.UserId;
     }
 
+    public async Task<string?> GetUsername(string idToken)
+    {
+        HttpRequestMessage request =
+            new(HttpMethod.Get, "/gameplay/v1/webUser")
+            {
+                Headers = { Authorization = new AuthenticationHeaderValue("Bearer", idToken) },
+            };
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            this.logger.LogDebug("/gameplay/v1/webUser returned 404 Not Found.");
+            return null;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            this.logger.LogError(
+                "Received non-200 status code from /gameplay/v1/webUser: {Status}",
+                response.StatusCode
+            );
+
+            return null;
+        }
+
+        return (await response.Content.ReadFromJsonAsync<WebUserResponse>())?.Username;
+    }
+
     private class UserIdResponse
     {
-        public required string UserId { get; set; }
+        public required string UserId { get; init; }
+    }
+
+    private class WebUserResponse
+    {
+        public required string Username { get; init; }
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Services/Api/IBaasApi.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Api/IBaasApi.cs
@@ -6,7 +6,7 @@ namespace DragaliaAPI.Services.Api;
 public interface IBaasApi
 {
     Task<IList<SecurityKey>> GetKeys();
-    Task<LoadIndexResponse> GetSavefile(string idToken);
-    Task<string?> GetUserId(string idToken);
-    Task<string?> GetUsername(string idToken);
+    Task<LoadIndexResponse> GetSavefile(string gameIdToken);
+    Task<string?> GetUserId(string webIdToken);
+    Task<string?> GetUsername(string gameIdToken);
 }

--- a/DragaliaAPI/DragaliaAPI/Services/Api/IBaasApi.cs
+++ b/DragaliaAPI/DragaliaAPI/Services/Api/IBaasApi.cs
@@ -8,4 +8,5 @@ public interface IBaasApi
     Task<IList<SecurityKey>> GetKeys();
     Task<LoadIndexResponse> GetSavefile(string idToken);
     Task<string?> GetUserId(string idToken);
+    Task<string?> GetUsername(string idToken);
 }


### PR DESCRIPTION
Uses a new API on the BaaS to retrieve the username of the linked account, and shows this in the 'Account Management' menu.

This will assist in troubleshooting issues with account linking where people cannot log into the website and are getting the 404 error.