### PR TITLE
Add draconic essence drops

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -49,7 +49,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>()
                 {
                     {
                         1,
@@ -222,10 +222,7 @@ public class DungeonRecordTest : TestFixture
                     },
                 },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -273,10 +270,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -335,10 +329,7 @@ public class DungeonRecordTest : TestFixture
                     },
                 },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -399,10 +390,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -454,10 +442,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -501,10 +486,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(exQuestId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -553,10 +535,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -608,10 +587,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -669,10 +645,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -718,10 +691,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -780,7 +750,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>()
                 {
                     {
                         1,
@@ -859,10 +829,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
-                {
-                    { 1, Enumerable.Empty<AtgenEnemy>() },
-                },
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>() { { 1, [] } },
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -983,7 +950,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -1038,7 +1005,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             };
 
         string key = await this.StartDungeon(mockSession);
@@ -1090,7 +1057,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             }
         );
 
@@ -1141,7 +1108,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             }
         );
 
@@ -1177,7 +1144,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             }
         );
 
@@ -1226,7 +1193,7 @@ public class DungeonRecordTest : TestFixture
             {
                 Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
                 QuestData = MasterAsset.QuestData.Get(questId),
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>(),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
             }
         );
 
@@ -1279,6 +1246,185 @@ public class DungeonRecordTest : TestFixture
         presentResponse
             .PresentList.Should()
             .Contain(x => x.MessageId == PresentMessage.SocialReward && x.MessageParamValue1 == 2);
+    }
+
+    [Fact]
+    public async Task Record_DragonEssencesAvailable_GrantsEssences()
+    {
+        // Ch. 5 / 4-3 Dark Terminus (Hard)
+        int questId = 100050209;
+        int existingEssenceQuantity = this
+            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Quantity;
+
+        await this.AddToDatabase(new DbQuest() { QuestId = questId, DailyPlayCount = 0 });
+
+        string dungeonKey = await this.StartDungeon(
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
+            }
+        );
+
+        DungeonRecordRecordRequest request =
+            new()
+            {
+                DungeonKey = dungeonKey,
+                PlayRecord = new PlayRecord
+                {
+                    Time = 10,
+                    TreasureRecord = new List<AtgenTreasureRecord>()
+                    {
+                        new() { AreaIdx = 1, Enemy = [] },
+                    },
+                    LiveUnitNoList = new List<int>(),
+                    DamageRecord = [],
+                    DragonDamageRecord = [],
+                    BattleRoyalRecord = new AtgenBattleRoyalRecord(),
+                },
+            };
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+        ).Data;
+
+        response.UpdateDataList.MaterialList.Should().NotBeNull();
+        response
+            .UpdateDataList.MaterialList.Should()
+            .Contain(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Which.Quantity.Should()
+            .Be(existingEssenceQuantity + 1);
+    }
+
+    [Fact]
+    public async Task Record_DragonEssencesNotAvailable_StopsGivingEssence()
+    {
+        // Ch. 5 / 4-3 Dark Terminus (Hard)
+        int questId = 100050209;
+        int existingEssenceQuantity = this
+            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Quantity;
+
+        await this.AddToDatabase(
+            new DbQuest()
+            {
+                QuestId = questId,
+                DailyPlayCount = 2,
+                LastDailyResetTime = DateTimeOffset.UtcNow,
+            }
+        );
+
+        string dungeonKey = await this.StartDungeon(
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
+            }
+        );
+
+        DungeonRecordRecordRequest request =
+            new()
+            {
+                DungeonKey = dungeonKey,
+                PlayRecord = new PlayRecord
+                {
+                    Time = 10,
+                    TreasureRecord = new List<AtgenTreasureRecord>()
+                    {
+                        new() { AreaIdx = 1, Enemy = [] },
+                    },
+                    LiveUnitNoList = new List<int>(),
+                    DamageRecord = [],
+                    DragonDamageRecord = [],
+                    BattleRoyalRecord = new AtgenBattleRoyalRecord(),
+                },
+            };
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+        ).Data;
+
+        response.UpdateDataList.MaterialList.Should().NotBeNull();
+        response
+            .UpdateDataList.MaterialList.Should()
+            .Contain(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Which.Quantity.Should()
+            .Be(existingEssenceQuantity + 1);
+
+        request.DungeonKey = await this.StartDungeon(
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
+            }
+        );
+
+        DungeonRecordRecordResponse secondResponse = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+        ).Data;
+
+        secondResponse.UpdateDataList.MaterialList.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Record_DragonEssencesEarnedBeforeReset_ResetsAndGrantsEssence()
+    {
+        // Ch. 5 / 4-3 Dark Terminus (Hard)
+        int questId = 100050209;
+        int existingEssenceQuantity = this
+            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Quantity;
+
+        await this.AddToDatabase(
+            new DbQuest()
+            {
+                QuestId = questId,
+                DailyPlayCount = 3,
+                LastDailyResetTime = DateTimeOffset.UtcNow.AddDays(-2),
+            }
+        );
+
+        string dungeonKey = await this.StartDungeon(
+            new()
+            {
+                Party = new List<PartySettingList>() { new() { CharaId = Charas.ThePrince } },
+                QuestData = MasterAsset.QuestData.Get(questId),
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>(),
+            }
+        );
+
+        DungeonRecordRecordRequest request =
+            new()
+            {
+                DungeonKey = dungeonKey,
+                PlayRecord = new PlayRecord
+                {
+                    Time = 10,
+                    TreasureRecord = new List<AtgenTreasureRecord>()
+                    {
+                        new() { AreaIdx = 1, Enemy = [] },
+                    },
+                    LiveUnitNoList = new List<int>(),
+                    DamageRecord = [],
+                    DragonDamageRecord = [],
+                    BattleRoyalRecord = new AtgenBattleRoyalRecord(),
+                },
+            };
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+        ).Data;
+
+        response.UpdateDataList.MaterialList.Should().NotBeNull();
+        response
+            .UpdateDataList.MaterialList.Should()
+            .Contain(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Which.Quantity.Should()
+            .Be(existingEssenceQuantity + 1);
     }
 
     private async Task<string> StartDungeon(DungeonSession session)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -272,6 +272,38 @@ public class DungeonSkipTest : TestFixture
     }
 
     [Fact]
+    public async Task DungeonSkipStart_RewardsCorrectDragonEssences()
+    {
+        // Ch. 5 / 4-3 Dark Terminus (Hard)
+        int questId = 100050209;
+        int existingEssenceQuantity = this
+            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Quantity;
+
+        await this.AddToDatabase(new DbQuest() { QuestId = questId, DailyPlayCount = 0 });
+
+        DungeonSkipStartResponse response = (
+            await this.Client.PostMsgpack<DungeonSkipStartResponse>(
+                $"{Endpoint}/start",
+                new DungeonSkipStartRequest()
+                {
+                    PartyNo = 1,
+                    PlayCount = 4,
+                    SupportViewerId = 1000,
+                    QuestId = questId,
+                }
+            )
+        ).Data;
+
+        response.UpdateDataList.MaterialList.Should().NotBeNull();
+        response
+            .UpdateDataList.MaterialList.Should()
+            .Contain(x => x.MaterialId == Materials.ChthoniussEssence)
+            .Which.Quantity.Should()
+            .Be(existingEssenceQuantity + 3);
+    }
+
+    [Fact]
     public async Task DungeonSkipStart_CompletesDailyMissions()
     {
         int questId = 100010201; // Save the Paladyn (Hard)

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestRewards/QuestRewardData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestRewards/QuestRewardData.cs
@@ -39,7 +39,8 @@ public record QuestRewardData(
     int FirstClearSetEntityQuantity4,
     EntityTypes FirstClearSetEntityType5,
     int FirstClearSetEntityId5,
-    int FirstClearSetEntityQuantity5
+    int FirstClearSetEntityQuantity5,
+    Materials DropLimitBreakMaterialId
 )
 {
     [IgnoreMember]

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordRewardServiceTest.cs
@@ -129,7 +129,7 @@ public class DungeonRecordRewardServiceTest
             {
                 QuestData = null!,
                 Party = null!,
-                EnemyList = new Dictionary<int, IEnumerable<AtgenEnemy>>()
+                EnemyList = new Dictionary<int, IList<AtgenEnemy>>()
                 {
                     {
                         0,

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
@@ -186,6 +186,8 @@ public class DungeonRecordServiceTest
                     eventDrops
                 )
             );
+        this.mockDungeonRewardService.Setup(x => x.ProcessDraconicEssenceDrops(session))
+            .ReturnsAsync([]);
 
         this.mockQuestService.Setup(x => x.GetQuestStamina(lSurtrSoloId, StaminaType.Single))
             .ReturnsAsync(40);

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonSession.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/DungeonSession.cs
@@ -18,7 +18,7 @@ public class DungeonSession
 
     public DateTimeOffset StartTime { get; init; }
 
-    public Dictionary<int, IEnumerable<AtgenEnemy>> EnemyList { get; set; } = new();
+    public Dictionary<int, IList<AtgenEnemy>> EnemyList { get; set; } = new();
 
     public int PlayCount { get; init; } = 1;
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/IQuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/IQuestEnemyService.cs
@@ -4,7 +4,7 @@ namespace DragaliaAPI.Features.Dungeon;
 
 public interface IQuestEnemyService
 {
-    IEnumerable<AtgenEnemy> BuildQuestEnemyList(int questId, int areaNum);
+    IList<AtgenEnemy> BuildQuestEnemyList(int questId, int areaNum);
 
-    IEnumerable<AtgenEnemy> BuildQuestWallEnemyList(int wallId, int wallLevel);
+    IList<AtgenEnemy> BuildQuestWallEnemyList(int wallId, int wallLevel);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -19,7 +19,7 @@ public class QuestEnemyService : IQuestEnemyService
         this.logger = logger;
     }
 
-    public IEnumerable<AtgenEnemy> BuildQuestEnemyList(int questId, int areaNum)
+    public IList<AtgenEnemy> BuildQuestEnemyList(int questId, int areaNum)
     {
         AtgenEnemy[] enemyList = this.GetEnemyList(questId, areaNum);
 
@@ -34,7 +34,7 @@ public class QuestEnemyService : IQuestEnemyService
             return enemyList;
         }
 
-        int areaCount = MasterAsset.QuestData[questId].AreaInfo.Count();
+        int areaCount = MasterAsset.QuestData[questId].AreaInfo.Count;
         int totalQuantity = (int)Math.Round(questDropInfo.Drops.Sum(x => x.Quantity) / areaCount);
 
         int totalRupies = AddVariance(questDropInfo.Rupies) / areaCount;
@@ -105,7 +105,7 @@ public class QuestEnemyService : IQuestEnemyService
     }
 
     // Mercurial Gauntlet
-    public IEnumerable<AtgenEnemy> BuildQuestWallEnemyList(int wallId, int wallLevel)
+    public IList<AtgenEnemy> BuildQuestWallEnemyList(int wallId, int wallLevel)
     {
         List<AtgenEnemy> enemyList = GetWallEnemyList(wallId, wallLevel).ToList();
         // should handle enemy drops but eh

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -68,12 +68,16 @@ public class DungeonRecordService(
         ingameResultData.RewardRecord.MissionsClearSet = missionStatus.MissionsClearSet;
         ingameResultData.RewardRecord.MissionComplete = missionStatus.MissionCompleteSet;
 
+        IList<AtgenDropAll> essenceDrops =
+            await dungeonRecordRewardService.ProcessDraconicEssenceDrops(session);
+
         (IEnumerable<AtgenDropAll> dropList, int manaDrop, int coinDrop) =
             await dungeonRecordRewardService.ProcessEnemyDrops(playRecord, session);
 
         ingameResultData.RewardRecord.TakeCoin = coinDrop;
         ingameResultData.GrowRecord.TakeMana = manaDrop;
         ingameResultData.RewardRecord.DropAll.AddRange(dropList);
+        ingameResultData.RewardRecord.DropAll.AddRange(essenceDrops);
 
         (
             IEnumerable<AtgenScoreMissionSuccessList> scoreMissionSuccessList,

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
@@ -20,4 +20,5 @@ public interface IDungeonRecordRewardService
     );
 
     AtgenFirstMeeting ProcessFirstMeetingRewards(IList<long> connectingViewerIdList);
+    Task<IList<AtgenDropAll>> ProcessDraconicEssenceDrops(DungeonSession session);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Skip/DungeonSkipController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Skip/DungeonSkipController.cs
@@ -211,7 +211,7 @@ public class DungeonSkipController(
                 PlayCount = playCount,
             };
 
-        Dictionary<int, IEnumerable<AtgenEnemy>> enemyList = new(questData.AreaInfo.Count);
+        Dictionary<int, IList<AtgenEnemy>> enemyList = new(questData.AreaInfo.Count);
 
         for (int areaIndex = 0; areaIndex < questData.AreaInfo.Count; areaIndex++)
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Present/Present.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Present/Present.cs
@@ -1,4 +1,5 @@
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Features.Reward;
 using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Features.Presents;
@@ -23,6 +24,16 @@ public record Present(
     int EntityLimitBreakCount = 0
 )
 {
+    public Present(PresentMessage messageId, Entity entity)
+        : this(
+            messageId,
+            entity.Type,
+            entity.Id,
+            entity.Quantity,
+            entity.BuildupCount ?? 0,
+            entity.LimitBreakCount ?? 0
+        ) { }
+
     public DateTimeOffset CreateTime { get; } = DateTimeOffset.UtcNow;
 
     public TimeSpan? ExpiryTime { get; init; }

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -9473,9 +9473,6 @@ public partial class OddsInfo
     [Key("drop_obj")]
     public IEnumerable<AtgenDropObj> DropObj { get; set; } = [];
 
-    [Key("enemy")]
-    public IEnumerable<AtgenEnemy> Enemy { get; set; } = [];
-
     [Key("grade")]
     public IEnumerable<AtgenGrade> Grade { get; set; } = [];
 
@@ -9483,7 +9480,7 @@ public partial class OddsInfo
         int areaIndex,
         int reactionObjCount,
         IEnumerable<AtgenDropObj> dropObj,
-        IEnumerable<AtgenEnemy> enemy,
+        IList<AtgenEnemy> enemy,
         IEnumerable<AtgenGrade> grade
     )
     {

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/OddsInfo.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/OddsInfo.cs
@@ -1,0 +1,9 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class OddsInfo
+{
+    [Key("enemy")]
+    public IList<AtgenEnemy> Enemy { get; set; } = [];
+}


### PR DESCRIPTION
Add drops of draconic essences to hard / very hard main story quests.

The visual indicator of the number of essence available is driven by `quest_list[].daily_play_count`, which we already handle correctly in `QuestService.ProcessQuestCompletion`. So the only change that needs to be made is checking whether the quest drops essence, and whether our play count is low enough, and then granting it.