### PR TITLE
Re-use challengeString cookie if it is already set

### DIFF
--- a/Website/src/routes/(main)/headerContents.svelte
+++ b/Website/src/routes/(main)/headerContents.svelte
@@ -33,5 +33,7 @@
 {#if hasValidJwt}
   <Button href="/logout" variant="secondary" data-sveltekit-reload>Log out</Button>
 {:else}
-  <Button href={`/login?originalPage=${$page.url.pathname}`}>Login</Button>
+  <Button href={`/login?originalPage=${$page.url.pathname}`} data-sveltekit-preload-data="off">
+    Login
+  </Button>
 {/if}


### PR DESCRIPTION
The cause of the login issues appears to be Chrome specifically re-generating the challenge string when it visits /oauth, causing it to not match the hash we sent to BaaS.