### PR TITLE
Update Imperial Onslaught quest drops

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Reward/RewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Reward/RewardService.cs
@@ -105,8 +105,17 @@ public class RewardService(
         switch (grantReturn.Result)
         {
             case RewardGrantResult.Added:
-                this.newEntities.Add(entity);
+            {
+                if (entity.Type != EntityTypes.Material)
+                {
+                    // Material exception stops every material showing as 'New!' in quest drops.
+                    // I think new_get_entity_list is intended for entities that have never been seen before.
+                    // TODO: We probably want a different RewardGrantResult so that materials that were unowned can show this.
+                    this.newEntities.Add(entity);
+                }
+
                 break;
+            }
             case RewardGrantResult.Converted:
             {
                 if (grantReturn.ConvertedEntity is null)
@@ -125,17 +134,25 @@ public class RewardService(
                 break;
             }
             case RewardGrantResult.Discarded:
+            {
                 this.discardedEntities.Add(entity);
                 break;
+            }
             case RewardGrantResult.Limit:
+            {
                 break;
+            }
             case RewardGrantResult.FailError:
+            {
                 logger.LogError("Granting of entity {@entity} failed.", entity);
                 throw new InvalidOperationException("Failed to grant reward");
+            }
             default:
+            {
                 throw new InvalidOperationException(
                     $"RewardGrantResult {grantReturn.Result} out of range"
                 );
+            }
         }
     }
 

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/AtgenDropAll.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/AtgenDropAll.cs
@@ -1,0 +1,24 @@
+using MessagePack;
+
+namespace DragaliaAPI.Models.Generated;
+
+public partial class AtgenDropAll
+{
+    /// <summary>
+    /// Gets or sets a value that causes an additional pop-up against the drop
+    /// </summary>
+    /// <remarks>
+    /// Known values:
+    /// <ul>
+    /// <li>0: Normal</li>
+    /// <li>1: Capacity Reached + Rainbow effect (???)</li>
+    /// <li>9: Bonus</li>
+    /// </ul>
+    /// Might correspond to RewardItemPlaceType in il2cpp.
+    /// </remarks>
+    [Key("place")]
+    public int Place { get; set; }
+
+    [Key("factor")]
+    public float Factor { get; set; }
+}

--- a/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
+++ b/DragaliaAPI/DragaliaAPI/Models/Generated/Components.cs
@@ -2566,12 +2566,6 @@ public partial class AtgenDropAll
     [Key("quantity")]
     public int Quantity { get; set; }
 
-    [Key("place")]
-    public int Place { get; set; }
-
-    [Key("factor")]
-    public float Factor { get; set; }
-
     public AtgenDropAll(int id, EntityTypes type, int quantity, int place, float factor)
     {
         this.Id = id;


### PR DESCRIPTION
This is the start of the work to replace the existing 50-of-everything drop tables with hand-picked values.

For these drops I've used the clears helpfully uploaded here https://www.youtube.com/watch?v=PBA7tQtd5Kw as a reference, with some fudging to round numbers since we are supplying averages.

Also a minor visual fix for every drop having a 'New!' adornment on the drops screen