### PR TITLE
Refactor exception handler middleware

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -16,7 +16,6 @@ namespace DragaliaAPI.Controllers;
 /// should be used.
 /// </remarks>
 [ApiController]
-[SerializeException]
 [Authorize(AuthenticationSchemes = SchemeName.Session)]
 [Consumes("application/octet-stream")]
 [Produces("application/x-msgpack")]

--- a/DragaliaAPI/DragaliaAPI/Controllers/SerializeExceptionAttribute.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/SerializeExceptionAttribute.cs
@@ -1,4 +1,0 @@
-﻿namespace DragaliaAPI.Controllers;
-
-[AttributeUsage(AttributeTargets.Class)]
-public class SerializeExceptionAttribute : Attribute { }

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -160,7 +160,9 @@ app.MapWhen(
         applicationBuilder.UseMiddleware<ResultCodeLoggingMiddleware>();
         applicationBuilder.UseOutputCache();
         applicationBuilder.UseMiddleware<NotFoundHandlerMiddleware>();
-        applicationBuilder.UseMiddleware<ExceptionHandlerMiddleware>();
+        applicationBuilder.UseExceptionHandler(cfg =>
+            cfg.Run(ExceptionHandlerMiddleware.HandleAsync)
+        );
         applicationBuilder.UseMiddleware<DailyResetMiddleware>();
         applicationBuilder.UseEndpoints(endpoints =>
         {


### PR DESCRIPTION
After adding metrics, our 'unhandled exception' counter never increases, probably because we handle all exceptions in ExceptionHandlerMiddleware

Put the exception handler middleware as a dedicated exception handler rather than just a generic middleware with try/catch to ensure ASP.NET increments the unhandled exception counter