### PR TITLE
Prevent access to /tool/auth with valid session ID and invalid token

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -16,7 +16,6 @@ public class ToolTest : TestFixture
     public ToolTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        this.Client.DefaultRequestHeaders.Remove("SID");
         this.SetupSaveImport();
     }
 

--- a/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/TransitionController.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/Dragalia/TransitionController.cs
@@ -8,8 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace DragaliaAPI.Controllers.Dragalia;
 
 [Route("transition")]
-[AllowAnonymous]
-internal sealed class TransitionController : DragaliaControllerBase
+internal sealed class TransitionController : DragaliaControllerBaseCore
 {
     private readonly IAuthService authService;
 

--- a/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
+++ b/DragaliaAPI/DragaliaAPI/Controllers/DragaliaControllerBase.cs
@@ -17,7 +17,6 @@ namespace DragaliaAPI.Controllers;
 /// should be used.
 /// </remarks>
 [ApiController]
-[Authorize(AuthenticationSchemes = AuthConstants.SchemeNames.Session)]
 [Consumes("application/octet-stream")]
 [Produces("application/x-msgpack")]
 [ServiceFilter<SetResultCodeActionFilter>(Order = 2)]
@@ -66,6 +65,7 @@ public abstract class DragaliaControllerBaseCore : ControllerBase
 /// <remarks>
 /// Not to be used for endpoints that make up the title screen (/tool/*, /version/*, etc.) to prevent infinite loops.
 /// </remarks>
+[Authorize(AuthenticationSchemes = AuthConstants.SchemeNames.Session)]
 [ServiceFilter<ResourceVersionActionFilter>(Order = 1)]
 [ServiceFilter<MaintenanceActionFilter>(Order = 1)]
 public abstract class DragaliaControllerBase : DragaliaControllerBaseCore { }

--- a/DragaliaAPI/DragaliaAPI/Features/Tool/ToolController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Tool/ToolController.cs
@@ -7,6 +7,7 @@ using DragaliaAPI.Services.Exceptions;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using static DragaliaAPI.Infrastructure.Authentication.AuthConstants;
 
 namespace DragaliaAPI.Features.Tool;
 
@@ -22,7 +23,7 @@ internal sealed class ToolController(IAuthService authService) : DragaliaControl
     }
 
     [HttpPost("signup")]
-    [Authorize(AuthenticationSchemes = AuthConstants.SchemeNames.GameJwt)]
+    [Authorize(AuthenticationSchemes = SchemeNames.GameJwt)]
     public async Task<DragaliaResult> Signup()
     {
         if (this.User.HasDawnshardIdentity())
@@ -45,7 +46,7 @@ internal sealed class ToolController(IAuthService authService) : DragaliaControl
     }
 
     [HttpPost("auth")]
-    [Authorize(AuthenticationSchemes = AuthConstants.SchemeNames.GameJwt)]
+    [Authorize(AuthenticationSchemes = SchemeNames.GameJwt)]
     public async Task<DragaliaResult> Auth()
     {
         if (!this.User.HasDawnshardIdentity())
@@ -71,7 +72,7 @@ internal sealed class ToolController(IAuthService authService) : DragaliaControl
     }
 
     [HttpPost("reauth")]
-    [Authorize(AuthenticationSchemes = AuthConstants.SchemeNames.GameJwt)]
+    [Authorize(AuthenticationSchemes = SchemeNames.GameJwt)]
     public async Task<DragaliaResult> Reauth()
     {
         (long viewerId, string sessionId) = await authService.DoLogin(this.User);

--- a/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
@@ -40,7 +40,7 @@ public static partial class FeatureExtensions
         serviceCollection
             .AddAuthorizationBuilder()
             .AddPolicy(
-                PolicyNames.RequireValidJwt,
+                PolicyNames.RequireValidWebJwt,
                 builder =>
                     builder.RequireAuthenticatedUser().AddAuthenticationSchemes(SchemeNames.WebJwt)
             )

--- a/DragaliaAPI/DragaliaAPI/Features/Web/Users/UserController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Users/UserController.cs
@@ -11,7 +11,7 @@ public class UserController(UserService userService, ILogger<UserController> log
     : ControllerBase
 {
     [HttpGet("me")]
-    [Authorize(Policy = PolicyNames.RequireValidJwt)]
+    [Authorize(Policy = PolicyNames.RequireValidWebJwt)]
     public async Task<ActionResult<User>> GetSelf(CancellationToken cancellationToken)
     {
         if (!this.User.HasDawnshardIdentity())

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/AuthConstants.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/AuthConstants.cs
@@ -4,14 +4,14 @@ public static class AuthConstants
 {
     public static class PolicyNames
     {
-        public const string RequireValidJwt = nameof(RequireValidJwt);
+        public const string RequireValidWebJwt = "RequireValidWebJwt";
 
-        public const string RequireDawnshardIdentity = nameof(RequireDawnshardIdentity);
+        public const string RequireDawnshardIdentity = "RequireDawnshardIdentity";
     }
 
     public static class IdentityLabels
     {
-        public const string Dawnshard = nameof(Dawnshard);
+        public const string Dawnshard = "Dawnshard";
     }
 
     public static class SchemeNames

--- a/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
+++ b/DragaliaAPI/DragaliaAPI/ServiceConfiguration.cs
@@ -25,9 +25,6 @@ using DragaliaAPI.Features.TimeAttack;
 using DragaliaAPI.Features.Tool;
 using DragaliaAPI.Features.Trade;
 using DragaliaAPI.Features.Version;
-using DragaliaAPI.Features.Web;
-using DragaliaAPI.Features.Zena;
-using DragaliaAPI.Infrastructure;
 using DragaliaAPI.Infrastructure.Authentication;
 using DragaliaAPI.Infrastructure.Middleware;
 using DragaliaAPI.Models.Options;
@@ -38,14 +35,12 @@ using DragaliaAPI.Services.Health;
 using DragaliaAPI.Services.Photon;
 using Hangfire;
 using Hangfire.PostgreSql;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
-using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
-using AuthService = DragaliaAPI.Features.Tool.AuthService;
+using static DragaliaAPI.Infrastructure.Authentication.AuthConstants;
 
 namespace DragaliaAPI;
 
@@ -236,21 +231,15 @@ public static class ServiceConfiguration
         services
             .AddAuthentication(opts =>
             {
-                opts.AddScheme<SessionAuthenticationHandler>(
-                    AuthConstants.SchemeNames.Session,
-                    null
-                );
-                opts.AddScheme<DeveloperAuthenticationHandler>(
-                    AuthConstants.SchemeNames.Developer,
-                    null
-                );
+                opts.AddScheme<SessionAuthenticationHandler>(SchemeNames.Session, null);
+                opts.AddScheme<DeveloperAuthenticationHandler>(SchemeNames.Developer, null);
                 opts.AddScheme<PhotonAuthenticationHandler>(
                     nameof(PhotonAuthenticationHandler),
                     null
                 );
             })
             .AddJwtBearer(
-                AuthConstants.SchemeNames.GameJwt,
+                SchemeNames.GameJwt,
                 options =>
                 {
                     options.Events = new()


### PR DESCRIPTION
After #1135 I noticed from the logs that SessionAuthentication runs when accessing `/tool/auth`, `/tool/reauth`, `/tool/signup`, etc.

This allows you to access the controller with a valid session ID but invalid token, which causes `DoLogin` to crash on failing to retrieve the subject, as you have no JWT identity.

Fix this by removing the implicit SessionAuthentication from DragaliaControllerBaseCore.
