### PR TITLE
Add debug logging to fort error cases

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -429,7 +429,9 @@ public class FortServiceTest
             .Setup(x => x.GetFortDetail())
             .ReturnsAsync(new DbFortDetail() { ViewerId = 1, CarpenterNum = 1 });
         mockFortRepository.Setup(x => x.GetActiveCarpenters()).ReturnsAsync(1);
-        mockFortRepository.Setup(x => x.Builds).Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
+        mockFortRepository
+            .Setup(x => x.Builds)
+            .Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
 
         await fortService
             .Invoking(x => x.BuildStart(FortPlants.BlueFlowers, 2, 3))
@@ -508,7 +510,9 @@ public class FortServiceTest
             .ReturnsAsync(new DbFortDetail() { ViewerId = 1, CarpenterNum = 1 });
         mockFortRepository.Setup(x => x.GetActiveCarpenters()).ReturnsAsync(1);
         mockFortRepository.Setup(x => x.GetBuilding(1)).ReturnsAsync(build);
-        mockFortRepository.Setup(x => x.Builds).Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
+        mockFortRepository
+            .Setup(x => x.Builds)
+            .Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
 
         await fortService
             .Invoking(x => x.LevelupStart(1))

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortServiceTest.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
 using MockQueryable;
+using NSubstitute;
 using Range = Moq.Range;
 
 namespace DragaliaAPI.Test.Features.Fort;
@@ -428,6 +429,7 @@ public class FortServiceTest
             .Setup(x => x.GetFortDetail())
             .ReturnsAsync(new DbFortDetail() { ViewerId = 1, CarpenterNum = 1 });
         mockFortRepository.Setup(x => x.GetActiveCarpenters()).ReturnsAsync(1);
+        mockFortRepository.Setup(x => x.Builds).Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
 
         await fortService
             .Invoking(x => x.BuildStart(FortPlants.BlueFlowers, 2, 3))
@@ -506,6 +508,7 @@ public class FortServiceTest
             .ReturnsAsync(new DbFortDetail() { ViewerId = 1, CarpenterNum = 1 });
         mockFortRepository.Setup(x => x.GetActiveCarpenters()).ReturnsAsync(1);
         mockFortRepository.Setup(x => x.GetBuilding(1)).ReturnsAsync(build);
+        mockFortRepository.Setup(x => x.Builds).Returns(Array.Empty<DbFortBuild>().AsQueryable().BuildMock());
 
         await fortService
             .Invoking(x => x.LevelupStart(1))

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
@@ -503,9 +503,20 @@ public class FortService(
         // Check Carpenter available
         if (fortDetail.WorkingCarpenterNum >= fortDetail.CarpenterNum)
         {
+            List<DbFortBuild> builds = await fortRepository
+                .Builds.Where(x => x.BuildEndDate != DateTimeOffset.UnixEpoch)
+                .ToListAsync();
+
+            logger.LogDebug(
+                "Failed to perform upgrade {@PlantDetail} - carpenters busy",
+                plantDetail
+            );
+            logger.LogDebug("FortDetail: {@FortDetail}", fortDetail);
+            logger.LogDebug("Currently in progress builds: {@Builds}", builds);
+
             throw new DragaliaException(
                 ResultCode.FortBuildCarpenterBusy,
-                $"All carpenters are currently busy"
+                "All carpenters are currently busy"
             );
         }
 

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
@@ -357,7 +357,14 @@ public class FortService(
         {
             logger.LogDebug(
                 "Building {@Build} has not finished levelling up. Current time: {Time}",
-                build,
+                new
+                {
+                    build.BuildId,
+                    build.PlantId,
+                    build.Level,
+                    build.BuildStartDate,
+                    build.BuildEndDate,
+                },
                 time
             );
             throw new InvalidOperationException($"This building has not completed levelling up.");
@@ -509,8 +516,16 @@ public class FortService(
         // Check Carpenter available
         if (fortDetail.WorkingCarpenterNum >= fortDetail.CarpenterNum)
         {
-            List<DbFortBuild> builds = await fortRepository
+            var builds = await fortRepository
                 .Builds.Where(x => x.BuildEndDate != DateTimeOffset.UnixEpoch)
+                .Select(x => new
+                {
+                    x.BuildId,
+                    x.PlantId,
+                    x.Level,
+                    x.BuildStartDate,
+                    x.BuildEndDate,
+                })
                 .ToListAsync();
 
             logger.LogDebug(

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
@@ -351,11 +351,16 @@ public class FortService(
 
         DbFortBuild build = await fortRepository.GetBuilding(buildId);
 
+        DateTimeOffset time = dateTimeProvider.GetUtcNow();
+        
         if (
             build.BuildStatus is not FortBuildStatus.LevelUp
-            || dateTimeProvider.GetUtcNow() < build.BuildEndDate
+            || time < build.BuildEndDate
         )
+        {
+            logger.LogDebug("Building {@Build} has not finished levelling up. Current time: {Time}", build, time);
             throw new InvalidOperationException($"This building has not completed levelling up.");
+        }
 
         await FinishUpgrade(build, true);
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Fort/FortService.cs
@@ -352,13 +352,14 @@ public class FortService(
         DbFortBuild build = await fortRepository.GetBuilding(buildId);
 
         DateTimeOffset time = dateTimeProvider.GetUtcNow();
-        
-        if (
-            build.BuildStatus is not FortBuildStatus.LevelUp
-            || time < build.BuildEndDate
-        )
+
+        if (build.BuildStatus is not FortBuildStatus.LevelUp || time < build.BuildEndDate)
         {
-            logger.LogDebug("Building {@Build} has not finished levelling up. Current time: {Time}", build, time);
+            logger.LogDebug(
+                "Building {@Build} has not finished levelling up. Current time: {Time}",
+                build,
+                time
+            );
             throw new InvalidOperationException($"This building has not completed levelling up.");
         }
 


### PR DESCRIPTION
Investigating as part of #436.

Adds some debug logging to indicate the state of the fort at the time these exceptions get thrown.