### PR TITLE
Exclude completed buildings from working_carpenter_num

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/DragaliaAPI.Database.Test.csproj
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/DragaliaAPI.Database.Test.csproj
@@ -4,6 +4,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MockQueryable.EntityFrameworkCore" />
     <PackageReference Include="MockQueryable.Moq" />

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -605,7 +605,7 @@ public class FortTest : TestFixture
             .Data.UpdateDataList.MissionNotice.DailyMissionNotice.NewCompleteMissionIdList.Should()
             .Contain(15070201);
     }
-    
+
     [Fact]
     public async Task BuildStart_NoBuildersAvailable_ReturnsError()
     {
@@ -620,22 +620,18 @@ public class FortTest : TestFixture
                     BuildEndDate = DateTimeOffset.UtcNow.AddDays(1),
                 })
         );
-        
-       DragaliaResponse<FortBuildStartResponse> response = (
+
+        DragaliaResponse<FortBuildStartResponse> response = (
             await this.Client.PostMsgpack<FortBuildStartResponse>(
                 "/fort/build_start",
-                new FortBuildStartRequest(
-                    FortPlants.FlameAltar,
-                    1,
-                    1
-               ),
+                new FortBuildStartRequest(FortPlants.FlameAltar, 1, 1),
                 ensureSuccessHeader: false
             )
         );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.FortBuildCarpenterBusy);
     }
-    
+
     [Fact]
     public async Task BuildStart_OtherCompletedBuildings_DoesNotErrorOnTooFewBuilders()
     {
@@ -650,15 +646,11 @@ public class FortTest : TestFixture
                     BuildEndDate = DateTimeOffset.UtcNow.AddDays(-1),
                 })
         );
-        
+
         DragaliaResponse<FortBuildStartResponse> response = (
             await this.Client.PostMsgpack<FortBuildStartResponse>(
                 "/fort/build_start",
-                new FortBuildStartRequest(
-                    FortPlants.FlameAltar,
-                    1,
-                    1
-                )
+                new FortBuildStartRequest(FortPlants.FlameAltar, 1, 1)
             )
         );
 


### PR DESCRIPTION
Contributes to #436. Changes the used carpenter count calculation to be based on the number of buildings currently under construction which aren't finished, rather than any building that has a non-zero BuildEndDate.

This is because if you start an upgrade that takes e.g. 10 seconds, we report you have 3/4 builders. That's fine. But 10 seconds later, when the client sees that build complete using its internal timer, it then believes 4/4 builders are available, but we currently would say it's still 3/4 until you actually call levelup_end by tapping the building. I believe this desync is what causes the FortBuildCarpenterBusy exception.