### PR TITLE
Pass cancellation token in tests

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
@@ -106,7 +106,12 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
 
         await this.fortRepository.UpdateFortMaximumCarpenter(4);
 
-        (await this.fixture.ApiContext.PlayerFortDetails.FindAsync(DbTestFixture.ViewerId))!
+        (
+            await this.fixture.ApiContext.PlayerFortDetails.FindAsync(
+                DbTestFixture.ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )!
             .CarpenterNum.Should()
             .Be(4);
 
@@ -169,7 +174,14 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
             new() { ViewerId = DbTestFixture.ViewerId, BuildId = 12 }
         );
 
-        (await this.fixture.ApiContext.PlayerFortBuilds.FindAsync(12L)).Should().NotBeNull();
+        (
+            await this.fixture.ApiContext.PlayerFortBuilds.FindAsync(
+                12L,
+                TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .NotBeNull();
     }
 
     [Fact]
@@ -187,9 +199,16 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
         await this.fixture.AddToDatabase(build);
 
         this.fortRepository.DeleteBuild(build);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.fixture.ApiContext.PlayerFortBuilds.FindAsync(44L)).Should().BeNull();
+        (
+            await this.fixture.ApiContext.PlayerFortBuilds.FindAsync(
+                44L,
+                TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .BeNull();
     }
 
     [Fact]
@@ -271,7 +290,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
     public async Task InitializeFort_InitializesFort()
     {
         await this.fortRepository.InitializeFort();
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerFortDetails.Should()
             .ContainEquivalentOf(
@@ -290,7 +309,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
     public async Task InitializeFort_DataExists_DoesNotThrow()
     {
         await this.fortRepository.InitializeFort();
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.fortRepository.Invoking(x => x.InitializeFort()).Should().NotThrowAsync();
 
@@ -301,7 +320,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
     public async Task AddDojos_AddsDojos()
     {
         await this.fortRepository.AddDojos();
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortPlants[] plants =
         {
@@ -344,7 +363,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
                 },
             }
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.fortRepository.AddToStorage(
             FortPlants.FlameDracolith,
@@ -352,7 +371,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
             isTotalQuantity: true,
             level: 4
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerFortBuilds.Should()
             .Contain(x =>
@@ -372,7 +391,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
                 new() { ViewerId = DbTestFixture.ViewerId, PlantId = FortPlants.WindDracolith },
             }
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.fortRepository.AddToStorage(
             FortPlants.WindDracolith,
@@ -380,7 +399,7 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
             isTotalQuantity: true,
             level: 4
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerFortBuilds.Should()
             .ContainSingle(x => x.PlantId == FortPlants.WindDracolith);

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
@@ -33,7 +33,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
                 ViewerId,
-                Materials.WaterwyrmsGreatsphere
+                TestContext.Current.CancellationToken
             )
         )!
             .Quantity.Should()
@@ -49,17 +49,18 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
                 ViewerId = ViewerId,
                 MaterialId = Materials.FirestormPrism,
                 Quantity = 0,
-            }
+            },
+            TestContext.Current.CancellationToken
         );
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.inventoryRepository.UpdateQuantity(Materials.FirestormPrism, 10);
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
                 ViewerId,
-                Materials.FirestormPrism
+                TestContext.Current.CancellationToken
             )
         )!
             .Quantity.Should()
@@ -74,14 +75,19 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
             5
         );
 
-        (await this.fixture.ApiContext.PlayerMaterials.FindAsync(ViewerId, Materials.SunlightOre))!
+        (
+            await this.fixture.ApiContext.PlayerMaterials.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )!
             .Quantity.Should()
             .Be(5);
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
                 ViewerId,
-                Materials.SunlightStone
+                TestContext.Current.CancellationToken
             )
         )!
             .Quantity.Should()
@@ -106,10 +112,11 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
                     MaterialId = Materials.AbaddonOrb,
                     Quantity = 50,
                 },
-            }
+            },
+            TestContext.Current.CancellationToken
         );
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (await this.inventoryRepository.GetMaterial(Materials.AbaddonOrb))
             .Should()
@@ -149,12 +156,17 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
                     MaterialId = Materials.InfernoOrb,
                     Quantity = 50,
                 },
-            }
+            },
+            TestContext.Current.CancellationToken
         );
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.inventoryRepository.Materials.ToListAsync())
+        (
+            await this.inventoryRepository.Materials.ToListAsync(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .ContainEquivalentOf( // Savefile creation adds materials
                 new DbPlayerMaterial()
@@ -202,7 +214,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
             new Dictionary<Materials, int>() { { Materials.Valor, 1 }, { Materials.Acclaim, 3 } }
         );
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerMaterials.Single(x =>
                 x.ViewerId == IdentityTestUtils.ViewerId && x.MaterialId == Materials.Valor
@@ -241,7 +253,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
             .Should()
             .ThrowAsync<InvalidOperationException>();
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerMaterials.Single(x =>
                 x.ViewerId == IdentityTestUtils.ViewerId

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
@@ -32,8 +32,8 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                ViewerId,
-                TestContext.Current.CancellationToken
+                [ViewerId],
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )!
             .Quantity.Should()
@@ -59,7 +59,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!
@@ -77,7 +77,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!
@@ -86,7 +86,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/InventoryRepositoryTest.cs
@@ -32,7 +32,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                [ViewerId],
+                [ViewerId, Materials.WaterwyrmsGreatsphere],
                 cancellationToken: TestContext.Current.CancellationToken
             )
         )!
@@ -59,7 +59,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                [ViewerId],
+                [ViewerId, Materials.FirestormPrism],
                 TestContext.Current.CancellationToken
             )
         )!
@@ -77,7 +77,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                [ViewerId],
+                [ViewerId, Materials.SunlightOre],
                 TestContext.Current.CancellationToken
             )
         )!
@@ -86,7 +86,7 @@ public class InventoryRepositoryTest : IClassFixture<DbTestFixture>
 
         (
             await this.fixture.ApiContext.PlayerMaterials.FindAsync(
-                [ViewerId],
+                [ViewerId, Materials.SunlightStone],
                 TestContext.Current.CancellationToken
             )
         )!

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/PartyRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/PartyRepositoryTest.cs
@@ -29,7 +29,9 @@ public class PartyRepositoryTest : IClassFixture<DbTestFixture>
     [Fact]
     public async Task GetParties_Returns54Entries_AndPartyUnitsAreOrdered()
     {
-        IEnumerable<DbParty> result = await this.partyRepository.Parties.ToListAsync();
+        IEnumerable<DbParty> result = await this.partyRepository.Parties.ToListAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         result.Should().HaveCount(54);
 
@@ -58,7 +60,7 @@ public class PartyRepositoryTest : IClassFixture<DbTestFixture>
         DbParty dbEntry = await this
             .fixture.ApiContext.PlayerParties.Where(x => x.ViewerId == ViewerId && x.PartyNo == 3)
             .Include(x => x.Units)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         // Units list will be filled with default values
         dbEntry.Should().BeEquivalentTo(toAdd, options => options.Excluding(x => x.Units));
@@ -93,7 +95,7 @@ public class PartyRepositoryTest : IClassFixture<DbTestFixture>
         DbParty dbEntry = await this
             .fixture.ApiContext.PlayerParties.Where(x => x.ViewerId == ViewerId && x.PartyNo == 5)
             .Include(x => x.Units)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         dbEntry
             .Units.Select(x => (x.UnitNo, x.CharaId))

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/UserDataRepositoryTest.cs
@@ -44,10 +44,13 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
     public async Task CheckCoin_ReturnsExpectedResult(long checkValue, bool expectedResult)
     {
         DbPlayerUserData userData = (
-            await this.fixture.ApiContext.PlayerUserData.FindAsync(IdentityTestUtils.ViewerId)
+            await this.fixture.ApiContext.PlayerUserData.FindAsync(
+                IdentityTestUtils.ViewerId,
+                TestContext.Current.CancellationToken
+            )
         )!;
         userData.Coin = 200;
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (await this.userDataRepository.CheckCoin(checkValue)).Should().Be(expectedResult);
     }
@@ -58,15 +61,15 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
         long oldCoin = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.Coin)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this.userDataRepository.UpdateCoin(2000);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         long newCoin = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.Coin)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         newCoin.Should().Be(oldCoin + 2000);
     }
@@ -77,15 +80,15 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
         int oldDewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this.userDataRepository.UpdateDewpoint(4000);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int newDewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         newDewpoint.Should().Be(oldDewpoint + 4000);
     }
@@ -94,19 +97,19 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
     public async Task UpdateDewpoint_ThrowsExceptionWhenNegativeDewpoint()
     {
         await this.userDataRepository.SetDewpoint(1000);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
             () => this.userDataRepository.UpdateDewpoint(-1500)
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         exception.Message.Should().Be("Player cannot have negative eldwater");
 
         int dewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         dewpoint.Should().Be(1000);
     }
@@ -118,7 +121,7 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
     public async Task CheckDewpoint_ReturnsExpectedBool(int quantity, bool expectedValue)
     {
         await this.userDataRepository.SetDewpoint(1000);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         bool output = await this.userDataRepository.CheckDewpoint(quantity);
         output.Should().Be(expectedValue);
@@ -128,12 +131,12 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
     public async Task SetDewpoint_SetsDewpointValue()
     {
         await this.userDataRepository.SetDewpoint(10001);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int dewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         dewpoint.Should().Be(10001);
     }
@@ -144,19 +147,19 @@ public class UserDataRepositoryTest : IClassFixture<DbTestFixture>
         int oldDewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         ArgumentException exception = await Assert.ThrowsAsync<ArgumentException>(
             () => this.userDataRepository.SetDewpoint(-1)
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         exception.Message.Should().Be("Player cannot have negative eldwater");
 
         int newDewpoint = await this
             .fixture.ApiContext.PlayerUserData.Where(x => x.ViewerId == IdentityTestUtils.ViewerId)
             .Select(x => x.DewPoint)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         newDewpoint.Should().Be(oldDewpoint);
     }

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
@@ -38,7 +38,11 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
             }
         );
 
-        (await this.weaponRepository.WeaponBodies.ToListAsync())
+        (
+            await this.weaponRepository.WeaponBodies.ToListAsync(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .AllSatisfy(x => x.ViewerId.Should().Be(1));
     }
@@ -63,7 +67,7 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
     public async Task Add_AddsToDatabase()
     {
         await this.weaponRepository.Add(WeaponBodies.Arondight);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerWeapons.Single(x =>
                 x.WeaponBodyId == WeaponBodies.Arondight && x.ViewerId == IdentityTestUtils.ViewerId
@@ -144,7 +148,7 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
         WeaponPassiveAbility passiveAbility = MasterAsset.WeaponPassiveAbility.Get(passiveId);
 
         await this.weaponRepository.AddPassiveAbility(WeaponBodies.InfernoApogee, passiveAbility);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerWeapons.Single(x =>
                 x.WeaponBodyId == WeaponBodies.InfernoApogee
@@ -189,7 +193,7 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
     public async Task AddSkin_AddsSkin()
     {
         await this.weaponRepository.AddSkin(4);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerWeaponSkins.Should()
             .ContainEquivalentOf(
@@ -207,12 +211,12 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
     public async Task AddSkin_DuplicateSkins_NoPkException()
     {
         await this.weaponRepository.AddSkin(6);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         Func<Task> act = async () =>
         {
             await this.weaponRepository.AddSkin(6);
-            await this.fixture.ApiContext.SaveChangesAsync();
+            await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         };
 
         await act.Invoking(x => x.Invoke()).Should().NotThrowAsync();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
@@ -17,7 +17,8 @@ public class CastleStoryTest : TestFixture
         CastleStoryReadResponse data = (
             await this.Client.PostMsgpack<CastleStoryReadResponse>(
                 "/castle_story/read",
-                new CastleStoryReadRequest() { CastleStoryId = 1 }
+                new CastleStoryReadRequest() { CastleStoryId = 1 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -56,12 +57,13 @@ public class CastleStoryTest : TestFixture
                 StoryType = StoryTypes.Castle,
             }
         );
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         CastleStoryReadResponse data = (
             await this.Client.PostMsgpack<CastleStoryReadResponse>(
                 "/castle_story/read",
-                new CastleStoryReadRequest() { CastleStoryId = 2 }
+                new CastleStoryReadRequest() { CastleStoryId = 2 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -78,12 +80,13 @@ public class CastleStoryTest : TestFixture
             .ApiContext.PlayerUserData.AsNoTracking()
             .Where(x => x.ViewerId == ViewerId)
             .Select(x => x.Crystal)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         CastleStoryReadResponse data = (
             await this.Client.PostMsgpack<CastleStoryReadResponse>(
                 "/castle_story/read",
-                new CastleStoryReadRequest() { CastleStoryId = 3 }
+                new CastleStoryReadRequest() { CastleStoryId = 3 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -91,7 +94,7 @@ public class CastleStoryTest : TestFixture
             .ApiContext.PlayerUserData.AsNoTracking()
             .Where(x => x.ViewerId == ViewerId)
             .Select(x => x.Crystal)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         newCrystal.Should().Be(oldCrystal + 50);
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CharaTest.cs
@@ -46,7 +46,8 @@ public class CharaTest : TestFixture
         CharaAwakeResponse response = (
             await this.Client.PostMsgpack<CharaAwakeResponse>(
                 "chara/awake",
-                new CharaAwakeRequest(Charas.Celliera, 5)
+                new CharaAwakeRequest(Charas.Celliera, 5),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -70,7 +71,7 @@ public class CharaTest : TestFixture
         {
             charaData = await this
                 .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Celliera)
-                .FirstAsync();
+                .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
             matQuantity = (
                 await this
@@ -88,7 +89,8 @@ public class CharaTest : TestFixture
                     {
                         new AtgenEnemyPiece() { Id = Materials.GoldCrystal, Quantity = 300 },
                     }
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -126,7 +128,8 @@ public class CharaTest : TestFixture
             new CharaBuildupRequest(
                 Charas.Gauld,
                 [new AtgenEnemyPiece() { Id = Materials.GoldCrystal, Quantity = 10 }]
-            )
+            ),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         byte currentLevel = this
@@ -139,7 +142,8 @@ public class CharaTest : TestFixture
             new CharaBuildupRequest(
                 Charas.Gauld,
                 [new AtgenEnemyPiece() { Id = Materials.BronzeCrystal, Quantity = 1 }]
-            )
+            ),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerCharaData.AsNoTracking()
@@ -171,7 +175,8 @@ public class CharaTest : TestFixture
                     Charas.Celliera,
                     new List<int>() { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
                     false
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -207,7 +212,8 @@ public class CharaTest : TestFixture
         DragaliaResponse<CharaBuildupManaResponse> response = (
             await this.Client.PostMsgpack<CharaBuildupManaResponse>(
                 "chara/buildup_mana",
-                new CharaBuildupManaRequest(Charas.GalaAudric, new List<int>() { 5 }, false)
+                new CharaBuildupManaRequest(Charas.GalaAudric, new List<int>() { 5 }, false),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 
@@ -235,7 +241,8 @@ public class CharaTest : TestFixture
         CharaLimitBreakResponse response = (
             await this.Client.PostMsgpack<CharaLimitBreakResponse>(
                 "chara/limit_break",
-                new CharaLimitBreakRequest(Charas.Celliera, 1, false)
+                new CharaLimitBreakRequest(Charas.Celliera, 1, false),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -284,7 +291,8 @@ public class CharaTest : TestFixture
                     2,
                     new List<int>() { 21, 22, 24, 25, 28 },
                     false
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -347,7 +355,8 @@ public class CharaTest : TestFixture
                     4,
                     Enumerable.Range(1, 50).ToList(),
                     false
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -385,13 +394,19 @@ public class CharaTest : TestFixture
 
         await this.Client.PostMsgpack<CharaLimitBreakResponse>(
             "chara/limit_break",
-            new CharaLimitBreakRequest(Charas.Delphi, 5, false)
+            new CharaLimitBreakRequest(Charas.Delphi, 5, false),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         CharaBuildupManaResponse postSpiralResponse = (
             await this.Client.PostMsgpack<CharaBuildupManaResponse>(
                 "chara/buildup_mana",
-                new CharaBuildupManaRequest(Charas.Delphi, Enumerable.Range(51, 20).ToList(), false)
+                new CharaBuildupManaRequest(
+                    Charas.Delphi,
+                    Enumerable.Range(51, 20).ToList(),
+                    false
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -434,7 +449,8 @@ public class CharaTest : TestFixture
         CharaBuildupPlatinumResponse response = (
             await this.Client.PostMsgpack<CharaBuildupPlatinumResponse>(
                 "chara/buildup_platinum",
-                new CharaBuildupPlatinumRequest(Charas.SummerCelliera)
+                new CharaBuildupPlatinumRequest(Charas.SummerCelliera),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -466,7 +482,8 @@ public class CharaTest : TestFixture
         CharaBuildupPlatinumResponse response = (
             await this.Client.PostMsgpack<CharaBuildupPlatinumResponse>(
                 "chara/buildup_platinum",
-                new CharaBuildupPlatinumRequest(Charas.Harle)
+                new CharaBuildupPlatinumRequest(Charas.Harle),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -511,7 +528,8 @@ public class CharaTest : TestFixture
         {
             await this.Client.PostMsgpack<CharaBuildupManaResponse>(
                 "chara/buildup_mana",
-                new CharaBuildupManaRequest(id, Enumerable.Range(1, manaNodes).ToList(), false)
+                new CharaBuildupManaRequest(id, Enumerable.Range(1, manaNodes).ToList(), false),
+                cancellationToken: TestContext.Current.CancellationToken
             );
         }
         else
@@ -523,14 +541,16 @@ public class CharaTest : TestFixture
                     limitBreak,
                     Enumerable.Range(1, manaNodes).ToList(),
                     false
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
         }
 
         CharaBuildupPlatinumResponse response = (
             await this.Client.PostMsgpack<CharaBuildupPlatinumResponse>(
                 "chara/buildup_platinum",
-                new CharaBuildupPlatinumRequest(id)
+                new CharaBuildupPlatinumRequest(id),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -594,7 +614,8 @@ public class CharaTest : TestFixture
         {
             await this.Client.PostMsgpack<CharaBuildupManaResponse>(
                 "chara/buildup_mana",
-                new CharaBuildupManaRequest(id, Enumerable.Range(1, manaNodes).ToList(), false)
+                new CharaBuildupManaRequest(id, Enumerable.Range(1, manaNodes).ToList(), false),
+                cancellationToken: TestContext.Current.CancellationToken
             );
         }
         else
@@ -606,14 +627,16 @@ public class CharaTest : TestFixture
                     limitBreak,
                     Enumerable.Range(1, manaNodes).ToList(),
                     false
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
         }
 
         CharaBuildupPlatinumResponse response = (
             await this.Client.PostMsgpack<CharaBuildupPlatinumResponse>(
                 "chara/buildup_platinum",
-                new CharaBuildupPlatinumRequest(id)
+                new CharaBuildupPlatinumRequest(id),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -666,7 +689,8 @@ public class CharaTest : TestFixture
         CharaGetCharaUnitSetResponse response = (
             await this.Client.PostMsgpack<CharaGetCharaUnitSetResponse>(
                 "chara/get_chara_unit_set",
-                new CharaGetCharaUnitSetRequest(new List<Charas>() { Charas.Celliera })
+                new CharaGetCharaUnitSetRequest(new List<Charas>() { Charas.Celliera }),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -684,7 +708,8 @@ public class CharaTest : TestFixture
                     "Exercise",
                     Charas.Celliera,
                     new AtgenRequestCharaUnitSetData() { DragonKeyId = 5 }
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -169,7 +169,7 @@ public class DragonTest : TestFixture
 
         int augmentCount = (
             await this.ApiContext.PlayerMaterials.FindAsync(
-                [ViewerId],
+                [ViewerId, Materials.AmplifyingDragonscale],
                 TestContext.Current.CancellationToken
             )
         )!.Quantity;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -69,7 +69,7 @@ public class DragonTest : TestFixture
             dbDragonSacrifice = await this.AddToDatabase(testCase.SetupDragons[1]);
         }
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragonBuildupRequest request = new DragonBuildupRequest()
         {
@@ -89,7 +89,11 @@ public class DragonTest : TestFixture
         };
 
         DragonBuildupResponse response = (
-            await this.Client.PostMsgpack<DragonBuildupResponse>("dragon/buildup", request)
+            await this.Client.PostMsgpack<DragonBuildupResponse>(
+                "dragon/buildup",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -114,7 +118,7 @@ public class DragonTest : TestFixture
             .ApiContext.PlayerDragonData.Add(new DbPlayerDragonData(ViewerId, Dragons.Liger))
             .Entity;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragonBuildupRequest request = new DragonBuildupRequest()
         {
@@ -131,7 +135,11 @@ public class DragonTest : TestFixture
         };
 
         DragonBuildupResponse? response = (
-            await this.Client.PostMsgpack<DragonBuildupResponse>("dragon/buildup", request)
+            await this.Client.PostMsgpack<DragonBuildupResponse>(
+                "dragon/buildup",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -150,19 +158,19 @@ public class DragonTest : TestFixture
         dragon.AttackPlusCount = 50;
         dragon = this.ApiContext.PlayerDragonData.Add(dragon).Entity;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.ChangeTracker.Clear();
         DbPlayerUserData userData = await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync();
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         long startCoin = userData.Coin;
 
         int augmentCount = (
             await this.ApiContext.PlayerMaterials.FindAsync(
                 ViewerId,
-                Materials.AmplifyingDragonscale
+                TestContext.Current.CancellationToken
             )
         )!.Quantity;
 
@@ -173,7 +181,11 @@ public class DragonTest : TestFixture
         };
 
         DragonSetLockResponse? response = (
-            await this.Client.PostMsgpack<DragonSetLockResponse>("dragon/reset_plus_count", request)
+            await this.Client.PostMsgpack<DragonSetLockResponse>(
+                "dragon/reset_plus_count",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -198,7 +210,10 @@ public class DragonTest : TestFixture
     public async Task DragonGetContactData_ReturnsValidData()
     {
         DragonGetContactDataResponse? response = (
-            await this.Client.PostMsgpack<DragonGetContactDataResponse>("dragon/get_contact_data")
+            await this.Client.PostMsgpack<DragonGetContactDataResponse>(
+                "dragon/get_contact_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -213,12 +228,12 @@ public class DragonTest : TestFixture
             new DbPlayerDragonReliability(ViewerId, Dragons.HighChthonius)
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.ChangeTracker.Clear();
         DbPlayerUserData userData = await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync();
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         long startCoin = userData.Coin;
 
@@ -235,7 +250,8 @@ public class DragonTest : TestFixture
         DragonBuyGiftToSendMultipleResponse? response = (
             await this.Client.PostMsgpack<DragonBuyGiftToSendMultipleResponse>(
                 "dragon/buy_gift_to_send_multiple",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -276,7 +292,8 @@ public class DragonTest : TestFixture
         DragonBuyGiftToSendResponse? response = (
             await this.Client.PostMsgpack<DragonBuyGiftToSendResponse>(
                 "dragon/buy_gift_to_send",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -313,7 +330,8 @@ public class DragonTest : TestFixture
         DragonSendGiftMultipleResponse? response = (
             await this.Client.PostMsgpack<DragonSendGiftMultipleResponse>(
                 "dragon/send_gift_multiple",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -341,7 +359,8 @@ public class DragonTest : TestFixture
         DragonSendGiftMultipleResponse? response = (
             await this.Client.PostMsgpack<DragonSendGiftMultipleResponse>(
                 "dragon/send_gift_multiple",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -388,7 +407,8 @@ public class DragonTest : TestFixture
                 DragonId = Dragons.Apollo,
                 DragonGiftId = DragonGifts.FourLeafClover,
                 Quantity = 2,
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
@@ -403,7 +423,8 @@ public class DragonTest : TestFixture
                 DragonId = Dragons.Kagutsuchi,
                 DragonGiftId = DragonGifts.FourLeafClover,
                 Quantity = 1,
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
@@ -419,7 +440,8 @@ public class DragonTest : TestFixture
                     DragonId = Dragons.Kagutsuchi,
                     DragonGiftId = DragonGifts.FourLeafClover,
                     Quantity = 200,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -454,7 +476,11 @@ public class DragonTest : TestFixture
         };
 
         DragonSendGiftResponse? response = (
-            await this.Client.PostMsgpack<DragonSendGiftResponse>("dragon/send_gift", request)
+            await this.Client.PostMsgpack<DragonSendGiftResponse>(
+                "dragon/send_gift",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -494,7 +520,8 @@ public class DragonTest : TestFixture
         DragaliaResponse<DragonSendGiftMultipleResponse>? response = (
             await this.Client.PostMsgpack<DragonSendGiftMultipleResponse>(
                 "dragon/send_gift_multiple",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 
@@ -590,7 +617,11 @@ public class DragonTest : TestFixture
         };
 
         DragonBuildupResponse? response = (
-            await this.Client.PostMsgpack<DragonBuildupResponse>("dragon/limit_break", request)
+            await this.Client.PostMsgpack<DragonBuildupResponse>(
+                "dragon/limit_break",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -628,7 +659,11 @@ public class DragonTest : TestFixture
         };
 
         DragonSetLockResponse? response = (
-            await this.Client.PostMsgpack<DragonSetLockResponse>("dragon/set_lock", request)
+            await this.Client.PostMsgpack<DragonSetLockResponse>(
+                "dragon/set_lock",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -652,7 +687,7 @@ public class DragonTest : TestFixture
         DbPlayerUserData uData = await this
             .ApiContext.PlayerUserData.AsNoTracking()
             .Where(x => x.ViewerId == ViewerId)
-            .FirstAsync();
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         long startCoin = uData.Coin;
         long startDew = uData.DewPoint;
@@ -663,7 +698,11 @@ public class DragonTest : TestFixture
         };
 
         DragonSellResponse? response = (
-            await this.Client.PostMsgpack<DragonSellResponse>("dragon/sell", request)
+            await this.Client.PostMsgpack<DragonSellResponse>(
+                "dragon/sell",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -688,14 +727,14 @@ public class DragonTest : TestFixture
 
         dragonStribog.LimitBreakCount = 4;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         DragonData dragonDataSimurgh = MasterAsset.DragonData.Get(Dragons.Simurgh);
         DragonData dragonDataStribog = MasterAsset.DragonData.Get(Dragons.Stribog);
 
         this.ApiContext.ChangeTracker.Clear();
         DbPlayerUserData uData = await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync();
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         long startCoin = uData.Coin;
         long startDew = uData.DewPoint;
@@ -710,7 +749,11 @@ public class DragonTest : TestFixture
         };
 
         DragonSellResponse? response = (
-            await this.Client.PostMsgpack<DragonSellResponse>("dragon/sell", request)
+            await this.Client.PostMsgpack<DragonSellResponse>(
+                "dragon/sell",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -169,7 +169,7 @@ public class DragonTest : TestFixture
 
         int augmentCount = (
             await this.ApiContext.PlayerMaterials.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!.Quantity;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DungeonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DungeonTest.cs
@@ -15,14 +15,16 @@ public class DungeonTest : TestFixture
                 {
                     PartyNoList = new List<int>() { 2 },
                     QuestId = 100010306,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data.IngameData.DungeonKey;
 
         DungeonGetAreaOddsResponse response = (
             await this.Client.PostMsgpack<DungeonGetAreaOddsResponse>(
                 "/dungeon/get_area_odds",
-                new DungeonGetAreaOddsRequest() { AreaIdx = 1, DungeonKey = key }
+                new DungeonGetAreaOddsRequest() { AreaIdx = 1, DungeonKey = key },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -40,14 +42,16 @@ public class DungeonTest : TestFixture
                 {
                     PartyNoList = new List<int>() { 1 },
                     QuestId = 100010207,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data.IngameData.DungeonKey;
 
         DungeonFailResponse response = (
             await this.Client.PostMsgpack<DungeonFailResponse>(
                 "/dungeon/fail",
-                new DungeonFailRequest() { DungeonKey = key }
+                new DungeonFailRequest() { DungeonKey = key },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/EulaTest.cs
@@ -12,7 +12,10 @@ public class EulaTest : TestFixture
     public async Task EulaGetVersionList_ReturnsAllVersions()
     {
         EulaGetVersionListResponse response = (
-            await this.Client.PostMsgpack<EulaGetVersionListResponse>("eula/get_version_list")
+            await this.Client.PostMsgpack<EulaGetVersionListResponse>(
+                "eula/get_version_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -34,7 +37,8 @@ public class EulaTest : TestFixture
         EulaGetVersionResponse response = (
             await this.Client.PostMsgpack<EulaGetVersionResponse>(
                 "eula/get_version",
-                new EulaGetVersionRequest("id_token", "gb", "en_eu")
+                new EulaGetVersionRequest("id_token", "gb", "en_eu"),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -51,7 +55,8 @@ public class EulaTest : TestFixture
         EulaGetVersionResponse response = (
             await this.Client.PostMsgpack<EulaGetVersionResponse>(
                 "eula/get_version",
-                new EulaGetVersionRequest("id_token", "not even a country", "c#")
+                new EulaGetVersionRequest("id_token", "not even a country", "c#"),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
@@ -19,7 +19,8 @@ public class FriendTest : TestFixture
         FriendGetSupportCharaDetailResponse response = (
             await this.Client.PostMsgpack<FriendGetSupportCharaDetailResponse>(
                 "/friend/get_support_chara_detail",
-                new FriendGetSupportCharaDetailRequest() { SupportViewerId = 1001 }
+                new FriendGetSupportCharaDetailRequest() { SupportViewerId = 1001 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -170,7 +171,8 @@ public class FriendTest : TestFixture
         FriendGetSupportCharaDetailResponse response = (
             await this.Client.PostMsgpack<FriendGetSupportCharaDetailResponse>(
                 "/friend/get_support_chara_detail",
-                new FriendGetSupportCharaDetailRequest() { SupportViewerId = 0 }
+                new FriendGetSupportCharaDetailRequest() { SupportViewerId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/GetDeployVersionTest.cs
@@ -10,7 +10,8 @@ public class GetDeployVersionTest : TestFixture
     {
         DeployGetDeployVersionResponse response = (
             await this.Client.PostMsgpack<DeployGetDeployVersionResponse>(
-                "deploy/get_deploy_version"
+                "deploy/get_deploy_version",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/MatchingTest.cs
@@ -49,7 +49,8 @@ public class MatchingTest : TestFixture
         MatchingGetRoomListResponse data = (
             await this.Client.PostMsgpack<MatchingGetRoomListResponse>(
                 $"{EndpointGroup}/get_room_list",
-                new MatchingGetRoomListRequest() { CompatibleId = 36 }
+                new MatchingGetRoomListRequest() { CompatibleId = 36 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -134,7 +135,12 @@ public class MatchingTest : TestFixture
         MatchingGetRoomListByQuestIdResponse data = (
             await this.Client.PostMsgpack<MatchingGetRoomListByQuestIdResponse>(
                 $"{EndpointGroup}/get_room_list_by_quest_id",
-                new MatchingGetRoomListByQuestIdRequest() { CompatibleId = 36, QuestId = 204550501 }
+                new MatchingGetRoomListByQuestIdRequest()
+                {
+                    CompatibleId = 36,
+                    QuestId = 204550501,
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -216,7 +222,8 @@ public class MatchingTest : TestFixture
         MatchingGetRoomNameResponse data = (
             await this.Client.PostMsgpack<MatchingGetRoomNameResponse>(
                 $"{EndpointGroup}/get_room_name",
-                new MatchingGetRoomNameRequest() { RoomId = 911948 }
+                new MatchingGetRoomNameRequest() { RoomId = 911948 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -299,7 +306,8 @@ public class MatchingTest : TestFixture
         MatchingGetRoomNameResponse data = (
             await this.Client.PostMsgpack<MatchingGetRoomNameResponse>(
                 $"{EndpointGroup}/get_room_name",
-                new MatchingGetRoomNameRequest() { RoomId = 911948 }
+                new MatchingGetRoomNameRequest() { RoomId = 911948 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -215,7 +215,7 @@ public class PartyTest : TestFixture
     {
         DbParty party =
             await this.ApiContext.PlayerParties.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             ) ?? throw new NullReferenceException();
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -215,7 +215,7 @@ public class PartyTest : TestFixture
     {
         DbParty party =
             await this.ApiContext.PlayerParties.FindAsync(
-                [ViewerId],
+                [ViewerId, 1],
                 TestContext.Current.CancellationToken
             ) ?? throw new NullReferenceException();
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -40,14 +40,15 @@ public class PartyTest : TestFixture
                 "My New Party",
                 false,
                 0
-            )
+            ),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         ApiContext apiContext = this.Services.GetRequiredService<ApiContext>();
         DbParty dbparty = await apiContext
             .PlayerParties.Include(x => x.Units)
             .Where(x => x.ViewerId == ViewerId && x.PartyNo == 1)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         dbparty
             .Should()
@@ -123,7 +124,8 @@ public class PartyTest : TestFixture
                     "My New Party",
                     false,
                     0
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).DataHeaders.ResultCode.Should().Be(ResultCode.Success);
     }
@@ -147,7 +149,8 @@ public class PartyTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "/party/set_party_setting",
                 request,
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .Should()
@@ -178,7 +181,8 @@ public class PartyTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "/party/set_party_setting",
                 request,
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .Should()
@@ -195,12 +199,13 @@ public class PartyTest : TestFixture
     {
         await this.Client.PostMsgpack<PartySetMainPartyNoResponse>(
             "/party/set_main_party_no",
-            new PartySetMainPartyNoRequest(2)
+            new PartySetMainPartyNoRequest(2),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbPlayerUserData userData = await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         userData.MainPartyNo.Should().Be(2);
     }
@@ -209,15 +214,18 @@ public class PartyTest : TestFixture
     public async Task UpdatePartyName_UpdatesDatabase()
     {
         DbParty party =
-            await this.ApiContext.PlayerParties.FindAsync(ViewerId, 1)
-            ?? throw new NullReferenceException();
+            await this.ApiContext.PlayerParties.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            ) ?? throw new NullReferenceException();
 
         await this.Client.PostMsgpack<PartyUpdatePartyNameResponse>(
             "/party/update_party_name",
-            new PartyUpdatePartyNameRequest() { PartyNo = 1, PartyName = "LIblis Full Auto" }
+            new PartyUpdatePartyNameRequest() { PartyNo = 1, PartyName = "LIblis Full Auto" },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.Entry(party).ReloadAsync();
+        await this.ApiContext.Entry(party).ReloadAsync(TestContext.Current.CancellationToken);
 
         party.PartyName.Should().Be("LIblis Full Auto");
     }
@@ -228,7 +236,8 @@ public class PartyTest : TestFixture
         PartyUpdatePartyNameResponse response = (
             await this.Client.PostMsgpack<PartyUpdatePartyNameResponse>(
                 "/party/update_party_name",
-                new PartyUpdatePartyNameRequest() { PartyNo = 2, PartyName = "LIblis Full Auto" }
+                new PartyUpdatePartyNameRequest() { PartyNo = 2, PartyName = "LIblis Full Auto" },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UpdateTest.cs
@@ -14,7 +14,8 @@ public class UpdateTest : TestFixture
 
         await this.Client.PostMsgpack<UpdateNamechangeResponse>(
             "/update/namechange",
-            new UpdateNamechangeRequest() { Name = newName }
+            new UpdateNamechangeRequest() { Name = newName },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbPlayerUserData userData = this.ApiContext.PlayerUserData.Find(ViewerId)!;
@@ -29,7 +30,8 @@ public class UpdateTest : TestFixture
         UpdateNamechangeResponse response = (
             await this.Client.PostMsgpack<UpdateNamechangeResponse>(
                 "/update/namechange",
-                new UpdateNamechangeRequest() { Name = newName }
+                new UpdateNamechangeRequest() { Name = newName },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -48,7 +50,8 @@ public class UpdateTest : TestFixture
                     {
                         new AtgenTargetList() { TargetName = "emblem", TargetIdList = null },
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UrlListTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UrlListTest.cs
@@ -11,7 +11,8 @@ public class UrlListTest : TestFixture
         WebviewVersionUrlListResponse response = (
             await this.Client.PostMsgpack<WebviewVersionUrlListResponse>(
                 "webview_version/url_list",
-                new WebviewVersionUrlListRequest("region")
+                new WebviewVersionUrlListRequest("region"),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -19,7 +19,12 @@ public class UserTest : TestFixture
 
         UserData expectedUserData = this.Mapper.Map<UserData>(dbUserData);
 
-        (await this.Client.PostMsgpack<UserLinkedNAccountResponse>("/user/linked_n_account"))
+        (
+            await this.Client.PostMsgpack<UserLinkedNAccountResponse>(
+                "/user/linked_n_account",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Data.Should()
             .BeEquivalentTo(
                 new UserLinkedNAccountResponse()
@@ -35,7 +40,12 @@ public class UserTest : TestFixture
     {
         this.MockBaasApi.Setup(x => x.GetUsername(It.IsAny<string>())).ReturnsAsync("okada");
 
-        (await this.Client.PostMsgpack<UserGetNAccountInfoResponse>("/user/get_n_account_info"))
+        (
+            await this.Client.PostMsgpack<UserGetNAccountInfoResponse>(
+                "/user/get_n_account_info",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Data.Should()
             .BeEquivalentTo(
                 new UserGetNAccountInfoResponse()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -31,7 +31,8 @@ public class WeaponBodyTest : TestFixture
         UpdateDataList list = (
             await this.Client.PostMsgpack<WeaponBodyCraftResponse>(
                 $"{EndpointGroup}/craft",
-                new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.AquaticSpiral }
+                new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.AquaticSpiral },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .Data
@@ -70,7 +71,7 @@ public class WeaponBodyTest : TestFixture
             new DbWeaponBody() { ViewerId = 0, WeaponBodyId = WeaponBodies.AbsoluteCrimson }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int oldMatCount1 = GetMaterialCount(Materials.PrimalFlamewyrmsSphere);
         int oldMatCount2 = GetMaterialCount(Materials.PrimalFlamewyrmsGreatsphere);
@@ -79,7 +80,8 @@ public class WeaponBodyTest : TestFixture
 
         await this.Client.PostMsgpack<WeaponBodyCraftResponse>(
             $"{EndpointGroup}/craft",
-            new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.PrimalCrimson }
+            new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.PrimalCrimson },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerWeapons.SingleOrDefault(x =>
@@ -120,13 +122,19 @@ public class WeaponBodyTest : TestFixture
         WeaponBodyBuildupPieceResponse response = (
             await this.Client.PostMsgpack<WeaponBodyBuildupPieceResponse>(
                 $"{EndpointGroup}/buildup_piece",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         // Check coin
-        DbPlayerUserData userData = (await this.ApiContext.PlayerUserData.FindAsync(ViewerId))!;
-        await this.ApiContext.Entry(userData).ReloadAsync();
+        DbPlayerUserData userData = (
+            await this.ApiContext.PlayerUserData.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )!;
+        await this.ApiContext.Entry(userData).ReloadAsync(TestContext.Current.CancellationToken);
 
         if (testCase.ExpCoinLoss != 0)
             response.UpdateDataList.UserData.Coin.Should().Be(oldCoin - testCase.ExpCoinLoss);
@@ -139,10 +147,10 @@ public class WeaponBodyTest : TestFixture
         DbWeaponBody weaponBody = (
             await this.ApiContext.PlayerWeapons.FindAsync(
                 ViewerId,
-                testCase.InitialState.WeaponBodyId
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(weaponBody).ReloadAsync();
+        await this.ApiContext.Entry(weaponBody).ReloadAsync(TestContext.Current.CancellationToken);
 
         weaponBody
             .Should()
@@ -165,7 +173,10 @@ public class WeaponBodyTest : TestFixture
                 );
 
             DbPlayerMaterial dbEntry = (
-                await this.ApiContext.PlayerMaterials.FindAsync(ViewerId, material)
+                await this.ApiContext.PlayerMaterials.FindAsync(
+                    ViewerId,
+                    TestContext.Current.CancellationToken
+                )
             )!;
 
             dbEntry.Quantity.Should().Be(expQuantity);
@@ -210,7 +221,8 @@ public class WeaponBodyTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 $"{EndpointGroup}/buildup_piece",
                 new WeaponBodyBuildupPieceRequest() { WeaponBodyId = WeaponBodies.Carnwennan },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -240,7 +252,8 @@ public class WeaponBodyTest : TestFixture
                         new() { BuildupPieceType = BuildupPieceTypes.Stats, Step = 40 },
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -146,7 +146,7 @@ public class WeaponBodyTest : TestFixture
         // Check weapon
         DbWeaponBody weaponBody = (
             await this.ApiContext.PlayerWeapons.FindAsync(
-                [ViewerId],
+                [ViewerId, testCase.InitialState.WeaponBodyId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -174,7 +174,7 @@ public class WeaponBodyTest : TestFixture
 
             DbPlayerMaterial dbEntry = (
                 await this.ApiContext.PlayerMaterials.FindAsync(
-                    [ViewerId],
+                    [ViewerId, material],
                     TestContext.Current.CancellationToken
                 )
             )!;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -130,7 +130,7 @@ public class WeaponBodyTest : TestFixture
         // Check coin
         DbPlayerUserData userData = (
             await this.ApiContext.PlayerUserData.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -146,7 +146,7 @@ public class WeaponBodyTest : TestFixture
         // Check weapon
         DbWeaponBody weaponBody = (
             await this.ApiContext.PlayerWeapons.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -174,7 +174,7 @@ public class WeaponBodyTest : TestFixture
 
             DbPlayerMaterial dbEntry = (
                 await this.ApiContext.PlayerMaterials.FindAsync(
-                    ViewerId,
+                    [ViewerId],
                     TestContext.Current.CancellationToken
                 )
             )!;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
@@ -41,7 +41,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest abilityCrest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.FromWhenceHeComes],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -142,7 +142,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.HappyNewYear],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -223,7 +223,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.WorthyRivals],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -358,7 +358,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.TwinfoldBonds],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -406,7 +406,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.EndlessWaltz],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -474,7 +474,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.TutelarysDestinyWolfsBoon],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -523,7 +523,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                [ViewerId],
+                [ViewerId, AbilityCrestId.TheGeniusTacticianBowsBoon],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -619,7 +619,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             )
         )
@@ -657,7 +657,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet? dbAbilityCrestSet =
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             );
         dbAbilityCrestSet.Should().NotBeNull();
@@ -674,7 +674,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet dbAbilityCrestSet = (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -707,7 +707,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             )
         )
@@ -728,7 +728,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet? dbAbilityCrestSet =
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             );
         dbAbilityCrestSet.Should().NotBeNull();
@@ -745,7 +745,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet dbAbilityCrestSet = (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, setNo],
                 TestContext.Current.CancellationToken
             )
         )!;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
@@ -23,7 +23,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         AbilityCrestSetFavoriteResponse data = (
             await this.Client.PostMsgpack<AbilityCrestSetFavoriteResponse>(
@@ -32,7 +32,8 @@ public class AbilityCrestTest : TestFixture
                 {
                     AbilityCrestId = AbilityCrestId.FromWhenceHeComes,
                     IsFavorite = true,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -41,10 +42,12 @@ public class AbilityCrestTest : TestFixture
         DbAbilityCrest abilityCrest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.FromWhenceHeComes
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(abilityCrest).ReloadAsync();
+        await this
+            .ApiContext.Entry(abilityCrest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         abilityCrest.IsFavorite.Should().BeTrue();
     }
@@ -60,7 +63,8 @@ public class AbilityCrestTest : TestFixture
                     AbilityCrestId = AbilityCrestId.SweetSurprise,
                     IsFavorite = true,
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -86,7 +90,8 @@ public class AbilityCrestTest : TestFixture
                         },
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -106,7 +111,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         ResultCodeResponse response = (
             await this.Client.PostMsgpack<ResultCodeResponse>(
@@ -130,17 +135,20 @@ public class AbilityCrestTest : TestFixture
                         },
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.HappyNewYear
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         response.ResultCode.Should().Be(ResultCode.AbilityCrestBuildupPieceStepError);
         ability_crest.LimitBreakCount.Should().Be(0);
@@ -158,7 +166,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int oldDewpoint = this.GetDewpoint();
         int oldGoldenKey = this.GetMaterial(Materials.GoldenKey);
@@ -204,7 +212,8 @@ public class AbilityCrestTest : TestFixture
                             Step = 2,
                         },
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         this.GetDewpoint().Should().Be(oldDewpoint - 43_000);
@@ -215,10 +224,12 @@ public class AbilityCrestTest : TestFixture
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.WorthyRivals
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         ability_crest.LimitBreakCount.Should().Be(2);
         ability_crest.AbilityLevel.Should().Be(2);
@@ -245,7 +256,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.Client.PostMsgpack<AbilityCrestBuildupPieceResponse>(
             "ability_crest/buildup_piece",
@@ -261,7 +272,8 @@ public class AbilityCrestTest : TestFixture
                         Step = 2,
                     },
                 ],
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         // Reset
@@ -283,7 +295,8 @@ public class AbilityCrestTest : TestFixture
                         Step = 2,
                     },
                 ],
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
     }
 
@@ -301,7 +314,8 @@ public class AbilityCrestTest : TestFixture
                         new() { PlusCount = 50, PlusCountType = PlusCountType.Hp },
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -323,7 +337,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         ResultCodeResponse response = (
             await this.Client.PostMsgpack<ResultCodeResponse>(
@@ -337,17 +351,20 @@ public class AbilityCrestTest : TestFixture
                         new() { PlusCount = 25, PlusCountType = PlusCountType.Atk },
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.TwinfoldBonds
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         response.ResultCode.Should().Be(ResultCode.AbilityCrestBuildupPlusCountCountError);
         ability_crest.HpPlusCount.Should().Be(0);
@@ -371,7 +388,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.Client.PostMsgpack<ResultCodeResponse>(
             "ability_crest/buildup_plus_count",
@@ -383,16 +400,19 @@ public class AbilityCrestTest : TestFixture
                     new() { PlusCount = 1, PlusCountType = PlusCountType.Hp },
                     new() { PlusCount = 50, PlusCountType = PlusCountType.Atk },
                 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.EndlessWaltz
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         ability_crest.HpPlusCount.Should().Be(1);
         ability_crest.AttackPlusCount.Should().Be(50);
@@ -415,7 +435,8 @@ public class AbilityCrestTest : TestFixture
                         PlusCountType.Atk,
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -436,7 +457,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         ResultCodeResponse response = (
             await this.Client.PostMsgpack<ResultCodeResponse>(
@@ -446,17 +467,20 @@ public class AbilityCrestTest : TestFixture
                     AbilityCrestId = AbilityCrestId.TutelarysDestinyWolfsBoon,
                     PlusCountTypeList = new List<PlusCountType>() { PlusCountType.Hp, 0 },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.TutelarysDestinyWolfsBoon
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         response.ResultCode.Should().Be(ResultCode.CommonInvalidArgument);
         ability_crest.HpPlusCount.Should().Be(40);
@@ -481,7 +505,7 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.Client.PostMsgpack<ResultCodeResponse>(
             "ability_crest/reset_plus_count",
@@ -493,16 +517,19 @@ public class AbilityCrestTest : TestFixture
                     PlusCountType.Hp,
                     PlusCountType.Atk,
                 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
                 ViewerId,
-                AbilityCrestId.TheGeniusTacticianBowsBoon
+                TestContext.Current.CancellationToken
             )
         )!;
-        await this.ApiContext.Entry(ability_crest).ReloadAsync();
+        await this
+            .ApiContext.Entry(ability_crest)
+            .ReloadAsync(TestContext.Current.CancellationToken);
 
         ability_crest.HpPlusCount.Should().Be(0);
         ability_crest.AttackPlusCount.Should().Be(0);
@@ -530,11 +557,12 @@ public class AbilityCrestTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
             await this.Client.PostMsgpack<AbilityCrestGetAbilityCrestSetListResponse>(
-                "ability_crest/get_ability_crest_set_list"
+                "ability_crest/get_ability_crest_set_list",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data!;
 
@@ -582,13 +610,21 @@ public class AbilityCrestTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "ability_crest/set_ability_crest_set",
                 new AbilityCrestSetAbilityCrestSetRequest() { AbilityCrestSetNo = setNo },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo)).Should().BeNull();
+        (
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .BeNull();
         response.ResultCode.Should().Be(ResultCode.CommonInvalidArgument);
     }
 
@@ -597,7 +633,14 @@ public class AbilityCrestTest : TestFixture
     {
         int setNo = 37;
 
-        (await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo)).Should().BeNull();
+        (
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .BeNull();
 
         await this.Client.PostMsgpack<ResultCodeResponse>(
             "ability_crest/set_ability_crest_set",
@@ -606,13 +649,17 @@ public class AbilityCrestTest : TestFixture
                 AbilityCrestSetNo = setNo,
                 AbilityCrestSetName = "",
                 RequestAbilityCrestSetData = new() { TalismanKeyId = 1 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DbAbilityCrestSet? dbAbilityCrestSet =
-            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo);
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            );
         dbAbilityCrestSet.Should().NotBeNull();
         dbAbilityCrestSet!.TalismanKeyId.Should().Be(1);
     }
@@ -623,10 +670,13 @@ public class AbilityCrestTest : TestFixture
         int setNo = 24;
 
         this.ApiContext.PlayerAbilityCrestSets.Add(new DbAbilityCrestSet(ViewerId, setNo));
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DbAbilityCrestSet dbAbilityCrestSet = (
-            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo)
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
         )!;
         dbAbilityCrestSet.CrestSlotType2CrestId2.Should().Be(0);
 
@@ -640,10 +690,13 @@ public class AbilityCrestTest : TestFixture
                 {
                     CrestSlotType2CrestId2 = AbilityCrestId.DragonsNest,
                 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.Entry(dbAbilityCrestSet).ReloadAsync();
+        await this
+            .ApiContext.Entry(dbAbilityCrestSet)
+            .ReloadAsync(TestContext.Current.CancellationToken);
         dbAbilityCrestSet.CrestSlotType2CrestId2.Should().Be(AbilityCrestId.DragonsNest);
     }
 
@@ -652,7 +705,14 @@ public class AbilityCrestTest : TestFixture
     {
         int setNo = 12;
 
-        (await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo)).Should().BeNull();
+        (
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .BeNull();
 
         await this.Client.PostMsgpack<ResultCodeResponse>(
             "ability_crest/update_ability_crest_set_name",
@@ -660,13 +720,17 @@ public class AbilityCrestTest : TestFixture
             {
                 AbilityCrestSetNo = setNo,
                 AbilityCrestSetName = "test",
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DbAbilityCrestSet? dbAbilityCrestSet =
-            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo);
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            );
         dbAbilityCrestSet.Should().NotBeNull();
         dbAbilityCrestSet!.AbilityCrestSetName.Should().Be("test");
     }
@@ -677,10 +741,13 @@ public class AbilityCrestTest : TestFixture
         int setNo = 46;
 
         this.ApiContext.PlayerAbilityCrestSets.Add(new DbAbilityCrestSet(ViewerId, setNo));
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DbAbilityCrestSet dbAbilityCrestSet = (
-            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(ViewerId, setNo)
+            await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
+                ViewerId,
+                TestContext.Current.CancellationToken
+            )
         )!;
         dbAbilityCrestSet.AbilityCrestSetName.Should().Be("");
 
@@ -690,10 +757,13 @@ public class AbilityCrestTest : TestFixture
             {
                 AbilityCrestSetNo = setNo,
                 AbilityCrestSetName = "test",
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.Entry(dbAbilityCrestSet).ReloadAsync();
+        await this
+            .ApiContext.Entry(dbAbilityCrestSet)
+            .ReloadAsync(TestContext.Current.CancellationToken);
         dbAbilityCrestSet.AbilityCrestSetName.Should().Be("test");
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
@@ -141,7 +141,11 @@ public class AbilityCrestTest : TestFixture
         ).Data;
 
         DbAbilityCrest ability_crest = (
-            await this.ApiContext.PlayerAbilityCrests.FindAsync([ViewerId], TestContext.Current.CancellationToken))!;
+            await this.ApiContext.PlayerAbilityCrests.FindAsync(
+                [ViewerId],
+                TestContext.Current.CancellationToken
+            )
+        )!;
         await this
             .ApiContext.Entry(ability_crest)
             .ReloadAsync(TestContext.Current.CancellationToken);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
@@ -635,7 +635,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                [ViewerId],
+                [ViewerId, 37],
                 TestContext.Current.CancellationToken
             )
         )

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/AbilityCrests/AbilityCrestTest.cs
@@ -41,7 +41,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest abilityCrest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -141,11 +141,7 @@ public class AbilityCrestTest : TestFixture
         ).Data;
 
         DbAbilityCrest ability_crest = (
-            await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
-                TestContext.Current.CancellationToken
-            )
-        )!;
+            await this.ApiContext.PlayerAbilityCrests.FindAsync([ViewerId], TestContext.Current.CancellationToken))!;
         await this
             .ApiContext.Entry(ability_crest)
             .ReloadAsync(TestContext.Current.CancellationToken);
@@ -223,7 +219,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -358,7 +354,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -406,7 +402,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -474,7 +470,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -523,7 +519,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrest ability_crest = (
             await this.ApiContext.PlayerAbilityCrests.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -619,7 +615,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )
@@ -635,7 +631,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )
@@ -657,7 +653,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet? dbAbilityCrestSet =
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             );
         dbAbilityCrestSet.Should().NotBeNull();
@@ -674,7 +670,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet dbAbilityCrestSet = (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;
@@ -707,7 +703,7 @@ public class AbilityCrestTest : TestFixture
 
         (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )
@@ -728,7 +724,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet? dbAbilityCrestSet =
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             );
         dbAbilityCrestSet.Should().NotBeNull();
@@ -745,7 +741,7 @@ public class AbilityCrestTest : TestFixture
 
         DbAbilityCrestSet dbAbilityCrestSet = (
             await this.ApiContext.PlayerAbilityCrestSets.FindAsync(
-                ViewerId,
+                [ViewerId],
                 TestContext.Current.CancellationToken
             )
         )!;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -16,7 +16,10 @@ public class DmodeTest : TestFixture
     public async Task GetData_ReturnsData()
     {
         DragaliaResponse<DmodeGetDataResponse> resp =
-            await Client.PostMsgpack<DmodeGetDataResponse>("dmode/get_data");
+            await Client.PostMsgpack<DmodeGetDataResponse>(
+                "dmode/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         resp.Data.DmodeInfo.IsEntry.Should().BeTrue();
         resp.Data.DmodeCharaList.Should().NotBeNull();
@@ -37,7 +40,8 @@ public class DmodeTest : TestFixture
         DragaliaResponse<DmodeReadStoryResponse> resp =
             await Client.PostMsgpack<DmodeReadStoryResponse>(
                 "dmode/read_story",
-                new DmodeReadStoryRequest() { DmodeStoryId = 1 }
+                new DmodeReadStoryRequest() { DmodeStoryId = 1 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.DmodeStoryRewardList.Should()
@@ -95,7 +99,8 @@ public class DmodeTest : TestFixture
                             PassiveLevel = 2,
                         },
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.DmodeServitorPassiveList.Should()
@@ -162,7 +167,8 @@ public class DmodeTest : TestFixture
                         Charas.Empty,
                     },
                     TargetFloorNum = 30,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.DmodeExpedition.Should()
@@ -181,7 +187,8 @@ public class DmodeTest : TestFixture
 
         DragaliaResponse<DmodeExpeditionForceFinishResponse> finishResp =
             await this.Client.PostMsgpack<DmodeExpeditionForceFinishResponse>(
-                "dmode/expedition_force_finish"
+                "dmode/expedition_force_finish",
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         finishResp
@@ -226,7 +233,8 @@ public class DmodeTest : TestFixture
                         Charas.GalaMym,
                     },
                     TargetFloorNum = 30,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.DmodeExpedition.Should()
@@ -246,7 +254,10 @@ public class DmodeTest : TestFixture
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow.AddDays(1));
 
         DragaliaResponse<DmodeExpeditionFinishResponse> finishResp =
-            await this.Client.PostMsgpack<DmodeExpeditionFinishResponse>("dmode/expedition_finish");
+            await this.Client.PostMsgpack<DmodeExpeditionFinishResponse>(
+                "dmode/expedition_finish",
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         finishResp
             .Data.DmodeExpedition.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/DmodeDungeon/DmodeDungeonTest.cs
@@ -26,7 +26,8 @@ public class DmodeDungeonTest : TestFixture
                         Charas.Ranzal,
                         Charas.GalaCleo,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         (await this.GetDungeonState()).Should().Be(DungeonState.WaitingInitEnd);
@@ -34,7 +35,8 @@ public class DmodeDungeonTest : TestFixture
         DragaliaResponse<DmodeDungeonFloorResponse> floorResponse =
             await this.Client.PostMsgpack<DmodeDungeonFloorResponse>(
                 "dmode_dungeon/floor",
-                new DmodeDungeonFloorRequest() { DmodePlayRecord = null }
+                new DmodeDungeonFloorRequest() { DmodePlayRecord = null },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         floorResponse.Data.DmodeFloorData.DmodeAreaInfo.FloorNum.Should().Be(1);
@@ -60,17 +62,22 @@ public class DmodeDungeonTest : TestFixture
                 StartFloorNum = 30,
                 ServitorId = 1,
                 BringEditSkillCharaIdList = new List<Charas>() { Charas.Ranzal, Charas.GalaCleo },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.Client.PostMsgpack<DmodeDungeonFloorSkipResponse>("dmode_dungeon/floor_skip");
+        await this.Client.PostMsgpack<DmodeDungeonFloorSkipResponse>(
+            "dmode_dungeon/floor_skip",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         (await this.GetDungeonState()).Should().Be(DungeonState.WaitingSkipEnd);
 
         DragaliaResponse<DmodeDungeonFloorResponse> floorResponse =
             await this.Client.PostMsgpack<DmodeDungeonFloorResponse>(
                 "dmode_dungeon/floor",
-                new DmodeDungeonFloorRequest() { DmodePlayRecord = null }
+                new DmodeDungeonFloorRequest() { DmodePlayRecord = null },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         floorResponse.Data.DmodeFloorData.DmodeAreaInfo.FloorNum.Should().Be(30);
@@ -108,17 +115,24 @@ public class DmodeDungeonTest : TestFixture
                 StartFloorNum = 1,
                 ServitorId = 1,
                 BringEditSkillCharaIdList = new List<Charas>() { Charas.Ranzal, Charas.GalaCleo },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.Client.PostMsgpack<DmodeDungeonUserHaltResponse>("dmode_dungeon/user_halt");
+        await this.Client.PostMsgpack<DmodeDungeonUserHaltResponse>(
+            "dmode_dungeon/user_halt",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.PlayerDmodeDungeons.AsNoTracking()
             .First(x => x.ViewerId == ViewerId)
             .State.Should()
             .Be(DungeonState.Halting);
 
-        await this.Client.PostMsgpack<DmodeDungeonRestartResponse>("dmode_dungeon/restart");
+        await this.Client.PostMsgpack<DmodeDungeonRestartResponse>(
+            "dmode_dungeon/restart",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         (await this.GetDungeonState()).Should().Be(DungeonState.RestartEnd);
 
@@ -133,16 +147,19 @@ public class DmodeDungeonTest : TestFixture
     {
         await this
             .ApiContext.PlayerDmodeDungeons.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(e =>
-                e.SetProperty(d => d.Floor, 55)
-                    .SetProperty(d => d.State, DungeonState.Halting)
-                    .SetProperty(d => d.CharaId, Charas.Berserker)
+            .ExecuteUpdateAsync(
+                e =>
+                    e.SetProperty(d => d.Floor, 55)
+                        .SetProperty(d => d.State, DungeonState.Halting)
+                        .SetProperty(d => d.CharaId, Charas.Berserker),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         DmodeDungeonFinishResponse response = (
             await this.Client.PostMsgpack<DmodeDungeonFinishResponse>(
                 "dmode_dungeon/finish",
-                new DmodeDungeonFinishRequest() { IsGameOver = false }
+                new DmodeDungeonFinishRequest() { IsGameOver = false },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/AutoRepeatTest.cs
@@ -25,7 +25,8 @@ public class AutoRepeatTest : TestFixture
                         RepeatType = RepeatSettingType.Specified,
                         UseItemList = [UseItem.Honey],
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -39,7 +40,8 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -56,7 +58,8 @@ public class AutoRepeatTest : TestFixture
                     QuestId = 100010103,
                     RepeatState = 1,
                     RepeatSetting = null,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -70,7 +73,8 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse2.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -95,7 +99,8 @@ public class AutoRepeatTest : TestFixture
                         RepeatType = RepeatSettingType.Specified,
                         UseItemList = [UseItem.Honey],
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -111,7 +116,8 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -140,7 +146,8 @@ public class AutoRepeatTest : TestFixture
                         RepeatType = RepeatSettingType.Specified,
                         UseItemList = [UseItem.Honey],
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -152,7 +159,8 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -165,7 +173,8 @@ public class AutoRepeatTest : TestFixture
                     QuestId = 100010103,
                     RepeatState = 1,
                     RepeatSetting = null,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -177,12 +186,16 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse2.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         RepeatEndResponse repeatEndResponse = (
-            await Client.PostMsgpack<RepeatEndResponse>("repeat/end")
+            await Client.PostMsgpack<RepeatEndResponse>(
+                "repeat/end",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         repeatEndResponse.RepeatData.Should().BeNull();
@@ -222,7 +235,8 @@ public class AutoRepeatTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
         DungeonStartStartResponse startResponse = (
             await Client.PostMsgpack<DungeonStartStartResponse>(
@@ -237,7 +251,8 @@ public class AutoRepeatTest : TestFixture
                         RepeatType = RepeatSettingType.Specified,
                         UseItemList = [UseItem.Honey],
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -249,7 +264,8 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [], Wave = 5 },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -262,7 +278,8 @@ public class AutoRepeatTest : TestFixture
                     QuestId = questId,
                     RepeatState = 1,
                     RepeatSetting = null,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -274,12 +291,16 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse2.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [], Wave = 5 },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         RepeatEndResponse repeatEndResponse = (
-            await Client.PostMsgpack<RepeatEndResponse>("repeat/end")
+            await Client.PostMsgpack<RepeatEndResponse>(
+                "repeat/end",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         int expectedPoints =
@@ -329,7 +350,8 @@ public class AutoRepeatTest : TestFixture
                         RepeatType = RepeatSettingType.Specified,
                         UseItemList = [UseItem.Honey],
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -341,12 +363,16 @@ public class AutoRepeatTest : TestFixture
                     DungeonKey = startResponse.IngameData.DungeonKey,
                     PlayRecord = new() { TreasureRecord = [] },
                     RepeatState = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         MypageInfoResponse mypageResponse = (
-            await Client.PostMsgpack<MypageInfoResponse>("mypage/info")
+            await Client.PostMsgpack<MypageInfoResponse>(
+                "mypage/info",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         mypageResponse.RepeatData.Should().BeEquivalentTo(recordResponse.RepeatData);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -42,7 +42,10 @@ public class DungeonRecordTest : TestFixture
 
         DbPlayerUserData oldUserData = await ApiContext
             .PlayerUserData.AsNoTracking()
-            .SingleAsync(x => x.ViewerId == ViewerId);
+            .SingleAsync(
+                x => x.ViewerId == ViewerId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         DungeonSession mockSession =
             new()
@@ -126,7 +129,8 @@ public class DungeonRecordTest : TestFixture
                         DragonDamageRecord = new List<AtgenDamageRecord>(),
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -207,7 +211,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -243,7 +248,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -262,7 +268,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -290,7 +297,8 @@ public class DungeonRecordTest : TestFixture
                         DragonDamageRecord = [],
                         Wave = wave,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -313,7 +321,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -350,7 +359,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -382,7 +392,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -411,7 +422,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -434,7 +446,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -463,7 +476,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -478,7 +492,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -507,7 +522,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -527,7 +543,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -558,7 +575,8 @@ public class DungeonRecordTest : TestFixture
                             5 // Final wave
                         ,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -579,7 +597,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack(
             "/earn_event/entry",
-            new EarnEventEntryRequest() { EventId = eventId }
+            new EarnEventEntryRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -616,7 +635,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 2,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -637,7 +657,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -666,7 +687,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -683,7 +705,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<EarnEventEntryResponse>(
             "/earn_event/entry",
-            new EarnEventEntryRequest() { EventId = eventId }
+            new EarnEventEntryRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -721,7 +744,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -742,7 +766,8 @@ public class DungeonRecordTest : TestFixture
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
             "/earn_event/entry",
-            new EarnEventEntryRequest() { EventId = eventId }
+            new EarnEventEntryRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DungeonSession mockSession =
@@ -809,7 +834,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -850,7 +876,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                         Wave = 3,
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -886,7 +913,8 @@ public class DungeonRecordTest : TestFixture
                 {
                     PartyNoList = new[] { 4 }, // Flame team
                     QuestId = questId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -908,7 +936,8 @@ public class DungeonRecordTest : TestFixture
                     BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                     Wave = 3,
                 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.TimeAttackClears.Should().ContainSingle(x => x.GameId == gameId);
@@ -916,7 +945,10 @@ public class DungeonRecordTest : TestFixture
         DbTimeAttackClear recordedClear = await this
             .ApiContext.TimeAttackClears.Include(x => x.Players)
             .ThenInclude(x => x.Units)
-            .FirstAsync(x => x.GameId == gameId);
+            .FirstAsync(
+                x => x.GameId == gameId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         recordedClear.Time.Should().Be(clearTime);
         recordedClear.QuestId.Should().Be(questId);
@@ -978,7 +1010,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).DataHeaders.ResultCode.Should().Be(ResultCode.QuestStaminaSingleShort);
     }
@@ -1033,7 +1066,8 @@ public class DungeonRecordTest : TestFixture
                         BattleRoyalRecord = new AtgenBattleRoyalRecord(),
                     },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).DataHeaders.ResultCode.Should().Be(ResultCode.Success);
     }
@@ -1080,7 +1114,11 @@ public class DungeonRecordTest : TestFixture
             };
 
         DungeonRecordRecordResponse response = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -1113,7 +1151,11 @@ public class DungeonRecordTest : TestFixture
         );
 
         DungeonRecordRecordResponse response2 = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response2.IngameResultData.RewardRecord.FirstClearSet.Should().BeEmpty();
@@ -1124,8 +1166,13 @@ public class DungeonRecordTest : TestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(e =>
-                e.SetProperty(p => p.TutorialStatus, TutorialService.TutorialStatusIds.CoopTutorial)
+            .ExecuteUpdateAsync(
+                e =>
+                    e.SetProperty(
+                        p => p.TutorialStatus,
+                        TutorialService.TutorialStatusIds.CoopTutorial
+                    ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         int questId = TutorialService.TutorialQuestIds.AvenueToPowerBeginner;
@@ -1167,7 +1214,11 @@ public class DungeonRecordTest : TestFixture
             };
 
         DungeonRecordRecordResponse response = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.UpdateDataList.UserData.Should().NotBeNull();
@@ -1219,7 +1270,8 @@ public class DungeonRecordTest : TestFixture
         DungeonRecordRecordMultiResponse response = (
             await Client.PostMsgpack<DungeonRecordRecordMultiResponse>(
                 "/dungeon_record/record_multi",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -1239,7 +1291,8 @@ public class DungeonRecordTest : TestFixture
         PresentGetPresentListResponse presentResponse = (
             await this.Client.PostMsgpack<PresentGetPresentListResponse>(
                 "present/get_present_list",
-                new PresentGetPresentListRequest()
+                new PresentGetPresentListRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -1287,7 +1340,11 @@ public class DungeonRecordTest : TestFixture
             };
 
         DungeonRecordRecordResponse response = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.UpdateDataList.MaterialList.Should().NotBeNull();
@@ -1344,7 +1401,11 @@ public class DungeonRecordTest : TestFixture
             };
 
         DungeonRecordRecordResponse response = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.UpdateDataList.MaterialList.Should().NotBeNull();
@@ -1364,7 +1425,11 @@ public class DungeonRecordTest : TestFixture
         );
 
         DungeonRecordRecordResponse secondResponse = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         secondResponse.UpdateDataList.MaterialList.Should().BeNull();
@@ -1416,7 +1481,11 @@ public class DungeonRecordTest : TestFixture
             };
 
         DungeonRecordRecordResponse response = (
-            await Client.PostMsgpack<DungeonRecordRecordResponse>("/dungeon_record/record", request)
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.UpdateDataList.MaterialList.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -45,7 +45,8 @@ public class DungeonSkipTest : TestFixture
                     PlayCount = playCount,
                     SupportViewerId = 1000,
                     QuestId = questId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.IngameResultData.RewardRecord.DropAll.Should().NotBeEmpty();
@@ -109,7 +110,8 @@ public class DungeonSkipTest : TestFixture
                     {
                         new() { CharaId = Shared.Definitions.Enums.Charas.ThePrince },
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.IngameResultData.RewardRecord.DropAll.Should().NotBeEmpty();
@@ -171,7 +173,8 @@ public class DungeonSkipTest : TestFixture
                         new() { QuestId = brunhildaMaster, PlayCount = 1 },
                         new() { QuestId = flameIoStandard, PlayCount = 1 },
                     },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.IngameResultData.RewardRecord.DropAll.Should().NotBeEmpty();
@@ -249,7 +252,8 @@ public class DungeonSkipTest : TestFixture
                     PlayCount = playCount,
                     SupportViewerId = 1000,
                     QuestId = questId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -291,7 +295,8 @@ public class DungeonSkipTest : TestFixture
                     PlayCount = 4,
                     SupportViewerId = 1000,
                     QuestId = questId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -336,7 +341,8 @@ public class DungeonSkipTest : TestFixture
                     PlayCount = playCount,
                     SupportViewerId = 1000,
                     QuestId = questId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -38,7 +38,8 @@ public class DungeonStartTest : TestFixture
                 {
                     PartyNoList = new List<int>() { 1 },
                     QuestId = 100010103,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -60,7 +61,8 @@ public class DungeonStartTest : TestFixture
                 {
                     PartyNoList = new List<int>() { 37, 38 },
                     QuestId = 100010103,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -82,7 +84,8 @@ public class DungeonStartTest : TestFixture
                 {
                     PartyNoList = new List<int>() { 38 },
                     QuestId = 100010103,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -141,7 +144,8 @@ public class DungeonStartTest : TestFixture
         DungeonStartStartAssignUnitResponse response = (
             await Client.PostMsgpack<DungeonStartStartAssignUnitResponse>(
                 "/dungeon_start/start_assign_unit",
-                request
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -160,24 +164,29 @@ public class DungeonStartTest : TestFixture
     [InlineData("start_assign_unit")]
     public async Task Start_InsufficientStamina_ReturnsError(string endpoint)
     {
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.StaminaSingle, e => 0)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaSingle, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.StaminaMulti, e => 0)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaMulti, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         (
             await Client.PostMsgpack<DungeonStartStartResponse>(
                 $"/dungeon_start/{endpoint}",
                 new DungeonStartStartRequest() { QuestId = 100010104, PartyNoList = [1] },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .DataHeaders.ResultCode.Should()
@@ -187,19 +196,25 @@ public class DungeonStartTest : TestFixture
     [Fact]
     public async Task Start_ZeroStamina_FirstClearOfMainStory_Allows()
     {
-        await this.ApiContext.PlayerQuests.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerQuests.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.StaminaSingle, e => 0)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaSingle, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.StaminaMulti, e => 0)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaMulti, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(p =>
-            p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         (
@@ -210,7 +225,8 @@ public class DungeonStartTest : TestFixture
                     QuestId = 100260101,
                     PartyNoList = new List<int>() { 1 },
                 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).DataHeaders.ResultCode.Should().Be(ResultCode.Success);
     }
@@ -221,7 +237,8 @@ public class DungeonStartTest : TestFixture
         DragaliaResponse<DungeonStartStartResponse> response =
             await this.Client.PostMsgpack<DungeonStartStartResponse>(
                 $"/dungeon_start/start",
-                new DungeonStartStartRequest() { QuestId = 204270302, PartyNoList = [1] }
+                new DungeonStartStartRequest() { QuestId = 204270302, PartyNoList = [1] },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.OddsInfo.Enemy.Should().Contain(x => x.ParamId == 204130320 && x.IsRare);
@@ -235,7 +252,8 @@ public class DungeonStartTest : TestFixture
         DragaliaResponse<DungeonStartStartResponse> response =
             await this.Client.PostMsgpack<DungeonStartStartResponse>(
                 $"/dungeon_start/start",
-                new DungeonStartStartRequest() { QuestId = earnEventQuestId, PartyNoList = [1] }
+                new DungeonStartStartRequest() { QuestId = earnEventQuestId, PartyNoList = [1] },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.OddsInfo.Enemy.Should().HaveCount(31);
@@ -253,8 +271,13 @@ public class DungeonStartTest : TestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(e =>
-                e.SetProperty(p => p.TutorialStatus, TutorialService.TutorialStatusIds.CoopTutorial)
+            .ExecuteUpdateAsync(
+                e =>
+                    e.SetProperty(
+                        p => p.TutorialStatus,
+                        TutorialService.TutorialStatusIds.CoopTutorial
+                    ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         DragaliaResponse<DungeonStartStartResponse> response =
@@ -264,7 +287,8 @@ public class DungeonStartTest : TestFixture
                 {
                     QuestId = TutorialService.TutorialQuestIds.AvenueToPowerBeginner,
                     PartyNoList = [1],
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.IngameData.IsBotTutorial.Should().BeTrue();
@@ -275,11 +299,13 @@ public class DungeonStartTest : TestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(e =>
-                e.SetProperty(
-                    p => p.TutorialStatus,
-                    TutorialService.TutorialStatusIds.CoopTutorial + 1
-                )
+            .ExecuteUpdateAsync(
+                e =>
+                    e.SetProperty(
+                        p => p.TutorialStatus,
+                        TutorialService.TutorialStatusIds.CoopTutorial + 1
+                    ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         DragaliaResponse<DungeonStartStartResponse> response =
@@ -289,7 +315,8 @@ public class DungeonStartTest : TestFixture
                 {
                     QuestId = TutorialService.TutorialQuestIds.AvenueToPowerBeginner,
                     PartyNoList = [1],
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.IngameData.IsBotTutorial.Should().BeFalse();
@@ -301,7 +328,9 @@ public class DungeonStartTest : TestFixture
         int flameDullRes = 1010104;
         WeaponBodies waterSword = WeaponBodies.AbsoluteAqua;
 
-        await this.ApiContext.PlayerPassiveAbilities.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerPassiveAbilities.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         await this.AddToDatabase(
             new DbWeaponPassiveAbility() { WeaponPassiveAbilityId = flameDullRes }
@@ -309,9 +338,11 @@ public class DungeonStartTest : TestFixture
 
         await this
             .ApiContext.PlayerPartyUnits.Where(x => x.PartyNo == 1 && x.UnitNo == 1)
-            .ExecuteUpdateAsync(e =>
-                e.SetProperty(u => u.EquipWeaponBodyId, waterSword)
-                    .SetProperty(u => u.CharaId, Charas.ThePrince)
+            .ExecuteUpdateAsync(
+                e =>
+                    e.SetProperty(u => u.EquipWeaponBodyId, waterSword)
+                        .SetProperty(u => u.CharaId, Charas.ThePrince),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         DragaliaResponse<DungeonStartStartResponse> response =
@@ -321,7 +352,8 @@ public class DungeonStartTest : TestFixture
                 {
                     QuestId = TutorialService.TutorialQuestIds.AvenueToPowerBeginner,
                     PartyNoList = [1],
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
@@ -24,7 +24,8 @@ public class BuildEventTest : TestFixture
         DragaliaResponse<BuildEventGetEventDataResponse> evtData =
             await Client.PostMsgpack<BuildEventGetEventDataResponse>(
                 "build_event/get_event_data",
-                new BuildEventGetEventDataRequest(EventId)
+                new BuildEventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData.Data.BuildEventRewardList.Should().NotBeNull();
@@ -39,8 +40,9 @@ public class BuildEventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x =>
-                x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         pointItem.Quantity += 10;
@@ -49,12 +51,13 @@ public class BuildEventTest : TestFixture
             ApiContext.PlayerEventRewards.Where(x => x.EventId == EventId)
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<BuildEventReceiveBuildPointRewardResponse> evtResp =
             await Client.PostMsgpack<BuildEventReceiveBuildPointRewardResponse>(
                 "build_event/receive_build_point_reward",
-                new BuildEventReceiveBuildPointRewardRequest(EventId)
+                new BuildEventReceiveBuildPointRewardRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
@@ -27,7 +27,8 @@ public class Clb01EventTest : TestFixture
         DragaliaResponse<Clb01EventGetEventDataResponse> evtData =
             await Client.PostMsgpack<Clb01EventGetEventDataResponse>(
                 $"{Prefix}/get_event_data",
-                new Clb01EventGetEventDataRequest(EventId)
+                new Clb01EventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData.Data.Clb01EventUserData.Should().NotBeNull();
@@ -39,8 +40,9 @@ public class Clb01EventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x =>
-                x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         pointItem.Quantity += 20;
@@ -49,12 +51,13 @@ public class Clb01EventTest : TestFixture
             ApiContext.PlayerEventRewards.Where(x => x.EventId == EventId)
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<Clb01EventReceiveClb01PointRewardResponse> evtResp =
             await Client.PostMsgpack<Clb01EventReceiveClb01PointRewardResponse>(
                 $"{Prefix}/receive_clb01_point_reward",
-                new Clb01EventReceiveClb01PointRewardRequest(EventId)
+                new Clb01EventReceiveClb01PointRewardRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
@@ -27,7 +27,8 @@ public class CombatEventTest : TestFixture
         DragaliaResponse<CombatEventGetEventDataResponse> evtData =
             await Client.PostMsgpack<CombatEventGetEventDataResponse>(
                 $"{Prefix}/get_event_data",
-                new CombatEventGetEventDataRequest(EventId)
+                new CombatEventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData.Data.CombatEventUserData.Should().NotBeNull();
@@ -41,8 +42,9 @@ public class CombatEventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x =>
-                x.EventId == EventId && x.Type == (int)CombatEventItemType.EventPoint
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)CombatEventItemType.EventPoint,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         pointItem.Quantity += 1000;
@@ -51,12 +53,13 @@ public class CombatEventTest : TestFixture
             ApiContext.PlayerEventRewards.Where(x => x.EventId == EventId)
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<CombatEventReceiveEventPointRewardResponse> evtResp =
             await Client.PostMsgpack<CombatEventReceiveEventPointRewardResponse>(
                 $"{Prefix}/receive_event_point_reward",
-                new CombatEventReceiveEventPointRewardRequest(EventId)
+                new CombatEventReceiveEventPointRewardRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp.Data.EventRewardEntityList.Should().HaveCount(1);
@@ -71,8 +74,9 @@ public class CombatEventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x =>
-                x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         pointItem.Quantity += 500;
@@ -90,12 +94,13 @@ public class CombatEventTest : TestFixture
             }
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<CombatEventReceiveEventLocationRewardResponse> evtResp =
             await Client.PostMsgpack<CombatEventReceiveEventLocationRewardResponse>(
                 $"{Prefix}/receive_event_location_reward",
-                new CombatEventReceiveEventLocationRewardRequest(EventId, 2221302)
+                new CombatEventReceiveEventLocationRewardRequest(EventId, 2221302),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp.Data.EventLocationRewardEntityList.Should().HaveCount(9);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
@@ -39,7 +39,8 @@ public class EarnEventTest : TestFixture
 
         await this.Client.PostMsgpack<BuildEventEntryResponse>(
             "earn_event/entry",
-            new EarnEventEntryRequest(EventId)
+            new EarnEventEntryRequest(EventId),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerEventData.Should()
@@ -74,7 +75,8 @@ public class EarnEventTest : TestFixture
         DragaliaResponse<EarnEventGetEventDataResponse> evtData =
             await Client.PostMsgpack<EarnEventGetEventDataResponse>(
                 "earn_event/get_event_data",
-                new EarnEventGetEventDataRequest(EventId)
+                new EarnEventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData
@@ -87,13 +89,15 @@ public class EarnEventTest : TestFixture
     {
         await this.Client.PostMsgpack<BuildEventEntryResponse>(
             "earn_event/entry",
-            new EarnEventEntryRequest(EventId)
+            new EarnEventEntryRequest(EventId),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<EarnEventGetEventDataResponse> evtData =
             await Client.PostMsgpack<EarnEventGetEventDataResponse>(
                 "earn_event/get_event_data",
-                new EarnEventGetEventDataRequest(EventId)
+                new EarnEventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData
@@ -117,13 +121,15 @@ public class EarnEventTest : TestFixture
     {
         await this.Client.PostMsgpack<BuildEventEntryResponse>(
             "earn_event/entry",
-            new EarnEventEntryRequest(EventId)
+            new EarnEventEntryRequest(EventId),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x =>
-                x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         pointItem.Quantity += 10;
@@ -132,12 +138,13 @@ public class EarnEventTest : TestFixture
             ApiContext.PlayerEventRewards.Where(x => x.EventId == EventId)
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<EarnEventReceiveEventPointRewardResponse> evtResp =
             await Client.PostMsgpack<EarnEventReceiveEventPointRewardResponse>(
                 "earn_event/receive_event_point_reward",
-                new EarnEventReceiveEventPointRewardRequest(EventId)
+                new EarnEventReceiveEventPointRewardRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/MemoryEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/MemoryEventTest.cs
@@ -13,7 +13,8 @@ public class MemoryEventTest : TestFixture
         MemoryEventActivateResponse result = (
             await this.Client.PostMsgpack<MemoryEventActivateResponse>(
                 "memory_event/activate",
-                new MemoryEventActivateRequest() { EventId = eventId }
+                new MemoryEventActivateRequest() { EventId = eventId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -32,11 +33,15 @@ public class MemoryEventTest : TestFixture
 
         await this.Client.PostMsgpack<MemoryEventActivateResponse>(
             "memory_event/activate",
-            new MemoryEventActivateRequest() { EventId = eventId }
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         MissionGetMissionListResponse missionListResponse = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         missionListResponse

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -29,7 +29,8 @@ public class RaidEventTest : TestFixture
         DragaliaResponse<RaidEventGetEventDataResponse> evtData =
             await Client.PostMsgpack<RaidEventGetEventDataResponse>(
                 $"{Prefix}/get_event_data",
-                new RaidEventGetEventDataRequest(EventId)
+                new RaidEventGetEventDataRequest(EventId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtData.Data.RaidEventUserData.Should().NotBeNull();
@@ -41,7 +42,10 @@ public class RaidEventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
-            .SingleAsync(x => x.EventId == EventId && x.Type == (int)RaidEventItemType.RaidPoint1);
+            .SingleAsync(
+                x => x.EventId == EventId && x.Type == (int)RaidEventItemType.RaidPoint1,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         pointItem.Quantity += 500;
 
@@ -49,12 +53,13 @@ public class RaidEventTest : TestFixture
             ApiContext.PlayerEventRewards.Where(x => x.EventId == EventId)
         );
 
-        await ApiContext.SaveChangesAsync();
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<RaidEventReceiveRaidPointRewardResponse> evtResp =
             await Client.PostMsgpack<RaidEventReceiveRaidPointRewardResponse>(
                 $"{Prefix}/receive_raid_point_reward",
-                new RaidEventReceiveRaidPointRewardRequest(EventId, new[] { 1001 })
+                new RaidEventReceiveRaidPointRewardRequest(EventId, new[] { 1001 }),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         evtResp.Data.RaidEventRewardList.Should().HaveCount(1);
@@ -70,13 +75,15 @@ public class RaidEventTest : TestFixture
 
         await this.Client.PostMsgpack(
             "memory_event/activate",
-            new MemoryEventActivateRequest(fracturedFuturesId)
+            new MemoryEventActivateRequest(fracturedFuturesId),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<RaidEventGetEventDataResponse> response =
             await this.Client.PostMsgpack<RaidEventGetEventDataResponse>(
                 "raid_event/get_event_data",
-                new RaidEventGetEventDataRequest(fracturedFuturesId)
+                new RaidEventGetEventDataRequest(fracturedFuturesId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.RaidEventUserData.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -38,9 +38,14 @@ public class FortTest : TestFixture
                 LastIncomeDate = income, // Axe dojos don't make you money but let's pretend they do
             }
         );
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data", cancellationToken: TestContext.Current.CancellationToken))
+        (
+            await this.Client.PostMsgpack<FortGetDataResponse>(
+                "/fort/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Data.BuildList.Should()
             .ContainEquivalentOf(
                 new BuildList()
@@ -71,9 +76,17 @@ public class FortTest : TestFixture
             .ApiContext.PlayerDragonGifts.Where(x =>
                 x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.FreshBread
             )
-            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 1));
+            .ExecuteUpdateAsync(
+                e => e.SetProperty(p => p.Quantity, 1),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
-        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
+        (
+            await this.Client.PostMsgpack<FortGetDataResponse>(
+                "/fort/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Data.DragonContactFreeGiftCount.Should()
             .Be(1);
 
@@ -81,9 +94,17 @@ public class FortTest : TestFixture
             .ApiContext.PlayerDragonGifts.Where(x =>
                 x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.FreshBread
             )
-            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 0));
+            .ExecuteUpdateAsync(
+                e => e.SetProperty(p => p.Quantity, 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
-        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
+        (
+            await this.Client.PostMsgpack<FortGetDataResponse>(
+                "/fort/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Data.DragonContactFreeGiftCount.Should()
             .Be(0);
     }
@@ -98,7 +119,8 @@ public class FortTest : TestFixture
         FortAddCarpenterResponse response = (
             await this.Client.PostMsgpack<FortAddCarpenterResponse>(
                 "/fort/add_carpenter",
-                new FortAddCarpenterRequest(PaymentTypes.Wyrmite)
+                new FortAddCarpenterRequest(PaymentTypes.Wyrmite),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -125,12 +147,13 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortBuildAtOnceResponse response = (
             await this.Client.PostMsgpack<FortBuildAtOnceResponse>(
                 "/fort/build_at_once",
-                new FortBuildAtOnceRequest(build.BuildId, PaymentTypes.Wyrmite)
+                new FortBuildAtOnceRequest(build.BuildId, PaymentTypes.Wyrmite),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -161,11 +184,12 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.Client.PostMsgpack<FortBuildCancelResponse>(
             "/fort/build_cancel",
-            new FortBuildCancelRequest(build.BuildId)
+            new FortBuildCancelRequest(build.BuildId),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerFortBuilds.AsNoTracking()
@@ -195,7 +219,8 @@ public class FortTest : TestFixture
         FortBuildEndResponse response = (
             await this.Client.PostMsgpack<FortBuildEndResponse>(
                 "/fort/build_end",
-                new FortBuildEndRequest(build.BuildId)
+                new FortBuildEndRequest(build.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -220,7 +245,8 @@ public class FortTest : TestFixture
                     FortPlants.FlameAltar,
                     expectedPositionX,
                     expectedPositionZ
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -252,12 +278,13 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupAtOnceResponse response = (
             await this.Client.PostMsgpack<FortLevelupAtOnceResponse>(
                 "/fort/levelup_at_once",
-                new FortLevelupAtOnceRequest(build.BuildId, PaymentTypes.Wyrmite)
+                new FortLevelupAtOnceRequest(build.BuildId, PaymentTypes.Wyrmite),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -274,18 +301,22 @@ public class FortTest : TestFixture
     {
         DbFortBuild halidom = await this
             .ApiContext.PlayerFortBuilds.AsTracking()
-            .SingleAsync(x => x.PlantId == FortPlants.TheHalidom);
+            .SingleAsync(
+                x => x.PlantId == FortPlants.TheHalidom,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         halidom.BuildStartDate = DateTimeOffset.FromUnixTimeSeconds(1287924543);
         halidom.BuildEndDate = DateTimeOffset.FromUnixTimeSeconds(1388924543);
         halidom.Level = 10;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupAtOnceResponse response = (
             await this.Client.PostMsgpack<FortLevelupAtOnceResponse>(
                 "/fort/levelup_at_once",
-                new FortLevelupAtOnceRequest(halidom.BuildId, PaymentTypes.Wyrmite)
+                new FortLevelupAtOnceRequest(halidom.BuildId, PaymentTypes.Wyrmite),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -297,18 +328,22 @@ public class FortTest : TestFixture
     {
         DbFortBuild smithy = await this
             .ApiContext.PlayerFortBuilds.AsTracking()
-            .SingleAsync(x => x.PlantId == FortPlants.Smithy);
+            .SingleAsync(
+                x => x.PlantId == FortPlants.Smithy,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         smithy.BuildStartDate = DateTimeOffset.FromUnixTimeSeconds(1287924543);
         smithy.BuildEndDate = DateTimeOffset.FromUnixTimeSeconds(1388924543);
         smithy.Level = 1;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupAtOnceResponse response = (
             await this.Client.PostMsgpack<FortLevelupAtOnceResponse>(
                 "/fort/levelup_at_once",
-                new FortLevelupAtOnceRequest(smithy.BuildId, PaymentTypes.Wyrmite)
+                new FortLevelupAtOnceRequest(smithy.BuildId, PaymentTypes.Wyrmite),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -334,12 +369,13 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupCancelResponse response = (
             await this.Client.PostMsgpack<FortLevelupCancelResponse>(
                 "/fort/levelup_cancel",
-                new FortLevelupCancelRequest(build.BuildId)
+                new FortLevelupCancelRequest(build.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -371,12 +407,13 @@ public class FortTest : TestFixture
             )
             .Entity;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupEndResponse response = (
             await this.Client.PostMsgpack<FortLevelupEndResponse>(
                 "/fort/levelup_end",
-                new FortLevelupEndRequest(build.BuildId)
+                new FortLevelupEndRequest(build.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -392,18 +429,22 @@ public class FortTest : TestFixture
     {
         DbFortBuild smithy = await this
             .ApiContext.PlayerFortBuilds.AsTracking()
-            .SingleAsync(x => x.PlantId == FortPlants.Smithy);
+            .SingleAsync(
+                x => x.PlantId == FortPlants.Smithy,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         smithy.BuildStartDate = DateTimeOffset.FromUnixTimeSeconds(1287924543);
         smithy.BuildEndDate = DateTimeOffset.FromUnixTimeSeconds(1388924543);
         smithy.Level = 1;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupEndResponse response = (
             await this.Client.PostMsgpack<FortLevelupEndResponse>(
                 "/fort/levelup_end",
-                new FortLevelupEndRequest(smithy.BuildId)
+                new FortLevelupEndRequest(smithy.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -415,18 +456,22 @@ public class FortTest : TestFixture
     {
         DbFortBuild halidom = await this
             .ApiContext.PlayerFortBuilds.AsTracking()
-            .SingleAsync(x => x.PlantId == FortPlants.TheHalidom);
+            .SingleAsync(
+                x => x.PlantId == FortPlants.TheHalidom,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         halidom.BuildStartDate = DateTimeOffset.FromUnixTimeSeconds(1287924543);
         halidom.BuildEndDate = DateTimeOffset.FromUnixTimeSeconds(1388924543);
         halidom.Level = 10;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupEndResponse response = (
             await this.Client.PostMsgpack<FortLevelupEndResponse>(
                 "/fort/levelup_end",
-                new FortLevelupEndRequest(halidom.BuildId)
+                new FortLevelupEndRequest(halidom.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -452,12 +497,13 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         FortLevelupStartResponse response = (
             await this.Client.PostMsgpack<FortLevelupStartResponse>(
                 "/fort/levelup_start",
-                new FortLevelupStartRequest(build.BuildId)
+                new FortLevelupStartRequest(build.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -489,14 +535,15 @@ public class FortTest : TestFixture
                 }
             )
             .Entity;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int expectedPositionX = 4;
         int expectedPositionZ = 4;
         FortMoveResponse response = (
             await this.Client.PostMsgpack<FortMoveResponse>(
                 "/fort/move",
-                new FortMoveRequest(build.BuildId, expectedPositionX, expectedPositionZ)
+                new FortMoveRequest(build.BuildId, expectedPositionX, expectedPositionZ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -541,7 +588,7 @@ public class FortTest : TestFixture
             .First(x => x.PlantId == FortPlants.TheHalidom && x.ViewerId == ViewerId);
         halidom.LastIncomeDate = lastIncome;
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<FortGetMultiIncomeResponse> response =
             await this.Client.PostMsgpack<FortGetMultiIncomeResponse>(
@@ -549,7 +596,8 @@ public class FortTest : TestFixture
                 new FortGetMultiIncomeRequest()
                 {
                     BuildIdList = new[] { rupieMine.BuildId, dragonTree.BuildId, halidom.BuildId },
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.AddCoinList.Should().NotBeEmpty();
@@ -598,7 +646,8 @@ public class FortTest : TestFixture
         DragaliaResponse<FortGetMultiIncomeResponse> response =
             await this.Client.PostMsgpack<FortGetMultiIncomeResponse>(
                 "/fort/get_multi_income",
-                new FortGetMultiIncomeRequest() { BuildIdList = new[] { rupieMine.BuildId } }
+                new FortGetMultiIncomeRequest() { BuildIdList = new[] { rupieMine.BuildId } },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -625,7 +674,8 @@ public class FortTest : TestFixture
             await this.Client.PostMsgpack<FortBuildStartResponse>(
                 "/fort/build_start",
                 new FortBuildStartRequest(FortPlants.FlameAltar, 1, 1),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 
@@ -650,7 +700,8 @@ public class FortTest : TestFixture
         DragaliaResponse<FortBuildStartResponse> response = (
             await this.Client.PostMsgpack<FortBuildStartResponse>(
                 "/fort/build_start",
-                new FortBuildStartRequest(FortPlants.FlameAltar, 1, 1)
+                new FortBuildStartRequest(FortPlants.FlameAltar, 1, 1),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 
@@ -688,7 +739,8 @@ public class FortTest : TestFixture
             await this.Client.PostMsgpack<FortLevelupStartResponse>(
                 "/fort/levelup_start",
                 new FortLevelupStartRequest(build.BuildId),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.FortBuildCarpenterBusy);
@@ -723,7 +775,8 @@ public class FortTest : TestFixture
         DragaliaResponse<FortLevelupStartResponse> response =
             await this.Client.PostMsgpack<FortLevelupStartResponse>(
                 "/fort/levelup_start",
-                new FortLevelupStartRequest(build.BuildId)
+                new FortLevelupStartRequest(build.BuildId),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -40,7 +40,7 @@ public class FortTest : TestFixture
         );
         await this.ApiContext.SaveChangesAsync();
 
-        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data"))
+        (await this.Client.PostMsgpack<FortGetDataResponse>("/fort/get_data", cancellationToken: TestContext.Current.CancellationToken))
             .Data.BuildList.Should()
             .ContainEquivalentOf(
                 new BuildList()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/GraphQL/GraphQlTest.cs
@@ -23,7 +23,13 @@ public class GraphQlTest : GraphQlTestFixture
     {
         this.Client.DefaultRequestHeaders.Clear();
 
-        (await this.Client.PostAsync(Endpoint, new StringContent(string.Empty)))
+        (
+            await this.Client.PostAsync(
+                Endpoint,
+                new StringContent(string.Empty),
+                TestContext.Current.CancellationToken
+            )
+        )
             .StatusCode.Should()
             .Be(HttpStatusCode.Unauthorized);
     }
@@ -45,7 +51,8 @@ public class GraphQlTest : GraphQlTestFixture
                     }
                 }
                 """,
-            }
+            },
+            TestContext.Current.CancellationToken
         );
 
         response.Errors.Should().BeNullOrEmpty();
@@ -60,9 +67,12 @@ public class GraphQlTest : GraphQlTestFixture
         (
             await this
                 .ApiContext.PlayerCharaData.AsNoTracking()
-                .SingleAsync(x => x.ViewerId == ViewerId && x.CharaId == Charas.ThePrince)
+                .SingleAsync(
+                    x => x.ViewerId == ViewerId && x.CharaId == Charas.ThePrince,
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
         ).Level = 100;
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         GraphQLResponse<object> response = await this.GraphQlHttpClient.SendQueryAsync<object>(
             new GraphQLRequest
@@ -74,7 +84,8 @@ public class GraphQlTest : GraphQlTestFixture
                     }
                 }
                 """,
-            }
+            },
+            TestContext.Current.CancellationToken
         );
 
         response.Errors.Should().BeNullOrEmpty();
@@ -82,7 +93,10 @@ public class GraphQlTest : GraphQlTestFixture
         (
             await this
                 .ApiContext.PlayerCharaData.AsNoTracking()
-                .SingleAsync(x => x.ViewerId == ViewerId && x.CharaId == Charas.ThePrince)
+                .SingleAsync(
+                    x => x.ViewerId == ViewerId && x.CharaId == Charas.ThePrince,
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
         )
             .Level.Should()
             .Be(1);
@@ -102,7 +116,8 @@ public class GraphQlTest : GraphQlTestFixture
                         }
                     }
                     """,
-                }
+                },
+                TestContext.Current.CancellationToken
             );
 
         response.Errors.Should().BeNullOrEmpty();
@@ -112,7 +127,12 @@ public class GraphQlTest : GraphQlTestFixture
             .GetProperty("presentId")
             .GetInt32();
 
-        (await this.ApiContext.PlayerPresents.FirstAsync(x => x.PresentId == presentId))
+        (
+            await this.ApiContext.PlayerPresents.FirstAsync(
+                x => x.PresentId == presentId,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(
                 new DbPlayerPresent()
@@ -144,7 +164,8 @@ public class GraphQlTest : GraphQlTestFixture
                         }
                     }
                     """,
-                }
+                },
+                TestContext.Current.CancellationToken
             );
 
         response.Errors.Should().BeNullOrEmpty();
@@ -152,7 +173,10 @@ public class GraphQlTest : GraphQlTestFixture
         (
             await this
                 .ApiContext.PlayerUserData.AsNoTracking()
-                .FirstAsync(x => x.ViewerId == ViewerId)
+                .FirstAsync(
+                    x => x.ViewerId == ViewerId,
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
         )
             .TutorialStatus.Should()
             .Be(60999);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
@@ -26,7 +26,8 @@ public class ItemTest : TestFixture
     public async Task GetList_ReturnsItemList()
     {
         DragaliaResponse<ItemGetListResponse> resp = await Client.PostMsgpack<ItemGetListResponse>(
-            "item/get_list"
+            "item/get_list",
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         resp.Data.ItemList.Should()
@@ -42,7 +43,8 @@ public class ItemTest : TestFixture
                 "item/use_recovery_stamina",
                 new ItemUseRecoveryStaminaRequest(
                     new List<AtgenUseItemList> { new(UseItem.Honey, 1) }
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.RecoverData.RecoverStaminaType.Should().Be(UseItemEffect.RecoverStamina);
@@ -62,7 +64,7 @@ public class ItemTest : TestFixture
             .First(x => x.ViewerId == this.ViewerId);
         userData.StaminaSingle = 0;
         userData.LastStaminaSingleUpdateTime = DateTimeOffset.UtcNow - TimeSpan.FromHours(6);
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         int expectedPassiveRegen = (int)TimeSpan.FromHours(6).TotalSeconds / 360; // 6 minutes per stamina point
 
@@ -71,7 +73,8 @@ public class ItemTest : TestFixture
                 "item/use_recovery_stamina",
                 new ItemUseRecoveryStaminaRequest(
                     new List<AtgenUseItemList> { new(UseItem.Honey, 1) }
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.RecoverData.RecoverStaminaType.Should().Be(UseItemEffect.RecoverStamina);
@@ -87,7 +90,8 @@ public class ItemTest : TestFixture
                 "item/use_recovery_stamina",
                 new ItemUseRecoveryStaminaRequest(
                     new List<AtgenUseItemList> { new(UseItem.Honey, 5) }
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.Data.RecoverData.RecoverStaminaType.Should().Be(UseItemEffect.RecoverStamina);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Load/LoadIndexTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Load/LoadIndexTest.cs
@@ -9,7 +9,8 @@ public class LoadIndexTest : TestFixture
     public async Task LoadIndex_ReturnsPartyUnitsInSortedOrder()
     {
         DragaliaResponse<LoadIndexResponse> resp = await this.Client.PostMsgpack<LoadIndexResponse>(
-            "/load/index"
+            "/load/index",
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         resp.Data.PartyList.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -26,11 +26,18 @@ public class LoginTest : TestFixture
 
         await this
             .ApiContext.PlayerShopInfos.Where(x => x.ViewerId == ViewerId)
-            .ExecuteUpdateAsync(entity => entity.SetProperty(x => x.DailySummonCount, 5));
+            .ExecuteUpdateAsync(
+                entity => entity.SetProperty(x => x.DailySummonCount, 5),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         (await this.GetSummonCount()).Should().Be(5);
 
-        await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
+        await this.Client.PostMsgpack<LoginIndexResponse>(
+            "/login/index",
+            new LoginIndexRequest(),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         (await this.GetSummonCount()).Should().Be(0);
     }
@@ -42,25 +49,38 @@ public class LoginTest : TestFixture
 
         await this
             .ApiContext.PlayerDragonGifts.Where(x => x.ViewerId == ViewerId)
-            .ExecuteUpdateAsync(entity => entity.SetProperty(x => x.Quantity, 0));
+            .ExecuteUpdateAsync(
+                entity => entity.SetProperty(x => x.Quantity, 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         await this
             .ApiContext.PlayerDragonGifts.Where(x =>
                 x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.GoldenChalice
             )
-            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 1));
+            .ExecuteUpdateAsync(
+                e => e.SetProperty(p => p.Quantity, 1),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         await this
             .ApiContext.PlayerDragonGifts.Where(x =>
                 x.ViewerId == this.ViewerId && x.DragonGiftId == DragonGifts.FourLeafClover
             )
-            .ExecuteUpdateAsync(e => e.SetProperty(p => p.Quantity, 100));
+            .ExecuteUpdateAsync(
+                e => e.SetProperty(p => p.Quantity, 100),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         this.MockTimeProvider.SetUtcNow(
             new DateTimeOffset(2049, 03, 16, 02, 13, 59, TimeSpan.Zero)
         ); // Into Tuesday, but last reset was Monday
 
-        await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
+        await this.Client.PostMsgpack<LoginIndexResponse>(
+            "/login/index",
+            new LoginIndexRequest(),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         List<DbPlayerDragonGift> dbPlayerDragonGifts = await this.GetDragonGifts();
 
@@ -98,13 +118,17 @@ public class LoginTest : TestFixture
 
         await this
             .ApiContext.PlayerDragonGifts.Where(x => x.ViewerId == ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         this.MockTimeProvider.SetUtcNow(
             new DateTimeOffset(2049, 03, 15, 23, 13, 59, TimeSpan.Zero)
         ); // Monday
 
-        await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
+        await this.Client.PostMsgpack<LoginIndexResponse>(
+            "/login/index",
+            new LoginIndexRequest(),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         List<DbPlayerDragonGift> dbPlayerDragonGifts = await this.GetDragonGifts();
 
@@ -128,13 +152,17 @@ public class LoginTest : TestFixture
     {
         await this
             .ApiContext.PlayerDragonGifts.Where(x => x.ViewerId == ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         this.MockTimeProvider.SetUtcNow(
             new DateTimeOffset(2049, 03, 14, 23, 13, 59, TimeSpan.Zero)
         ); // Sunday
 
-        await this.Client.PostMsgpack<LoginIndexResponse>("/login/index", new LoginIndexRequest());
+        await this.Client.PostMsgpack<LoginIndexResponse>(
+            "/login/index",
+            new LoginIndexRequest(),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         List<DbPlayerDragonGift> dbPlayerDragonGifts = await this.GetDragonGifts();
 
@@ -172,7 +200,8 @@ public class LoginTest : TestFixture
         DragaliaResponse<LoginIndexResponse> response =
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "/login/index",
-                new LoginIndexRequest()
+                new LoginIndexRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -212,7 +241,8 @@ public class LoginTest : TestFixture
         DragaliaResponse<LoginIndexResponse> response =
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "/login/index",
-                new LoginIndexRequest()
+                new LoginIndexRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -250,7 +280,8 @@ public class LoginTest : TestFixture
         DragaliaResponse<LoginIndexResponse> response =
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "/login/index",
-                new LoginIndexRequest()
+                new LoginIndexRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -270,7 +301,10 @@ public class LoginTest : TestFixture
         (
             await this
                 .ApiContext.LoginBonuses.AsNoTracking()
-                .FirstAsync(x => x.ViewerId == ViewerId && x.Id == 2)
+                .FirstAsync(
+                    x => x.ViewerId == ViewerId && x.Id == 2,
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
         )
             .IsComplete.Should()
             .BeTrue();
@@ -278,7 +312,8 @@ public class LoginTest : TestFixture
         DragaliaResponse<LoginIndexResponse> secondResponse =
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "/login/index",
-                new LoginIndexRequest()
+                new LoginIndexRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         secondResponse.Data.LoginBonusList.Should().NotContain(x => x.LoginBonusId == 2);
@@ -302,12 +337,13 @@ public class LoginTest : TestFixture
             .ApiContext.PlayerDragonGifts.AsNoTracking()
             .Where(x => x.DragonGiftId == DragonGifts.FourLeafClover && x.ViewerId == ViewerId)
             .Select(x => x.Quantity)
-            .FirstAsync();
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         LoginIndexResponse response = (
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "login/index",
-                new LoginIndexRequest() { JwsResult = string.Empty }
+                new LoginIndexRequest() { JwsResult = string.Empty },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -356,7 +392,8 @@ public class LoginTest : TestFixture
 
         await this.Client.PostMsgpack(
             "login/index",
-            new LoginIndexRequest() { JwsResult = string.Empty }
+            new LoginIndexRequest() { JwsResult = string.Empty },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
@@ -427,7 +464,8 @@ public class LoginTest : TestFixture
 
         await this.Client.PostMsgpack(
             "login/index",
-            new LoginIndexRequest() { JwsResult = string.Empty }
+            new LoginIndexRequest() { JwsResult = string.Empty },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
@@ -461,7 +499,8 @@ public class LoginTest : TestFixture
         LoginIndexResponse response = (
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "login/index",
-                new LoginIndexRequest() { JwsResult = string.Empty }
+                new LoginIndexRequest() { JwsResult = string.Empty },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -481,7 +520,8 @@ public class LoginTest : TestFixture
         LoginIndexResponse response = (
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "login/index",
-                new LoginIndexRequest() { JwsResult = string.Empty }
+                new LoginIndexRequest() { JwsResult = string.Empty },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -511,7 +551,8 @@ public class LoginTest : TestFixture
         LoginIndexResponse response = (
             await this.Client.PostMsgpack<LoginIndexResponse>(
                 "login/index",
-                new LoginIndexRequest() { JwsResult = string.Empty }
+                new LoginIndexRequest() { JwsResult = string.Empty },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -542,7 +583,8 @@ public class LoginTest : TestFixture
 
         await this.Client.PostMsgpack<LoginIndexResponse>(
             "login/index",
-            new LoginIndexRequest() { JwsResult = string.Empty }
+            new LoginIndexRequest() { JwsResult = string.Empty },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerBannerData.AsNoTracking()
@@ -559,7 +601,8 @@ public class LoginTest : TestFixture
         ResultCodeResponse response = (
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "/login/verify_jws",
-                new LoginVerifyJwsRequest()
+                new LoginVerifyJwsRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Maintenance/MaintenanceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Maintenance/MaintenanceTest.cs
@@ -22,7 +22,8 @@ public class MaintenanceTest : TestFixture
         DragaliaResponse<ResultCodeResponse> response =
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "load/index",
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.CommonMaintenance);
@@ -36,7 +37,8 @@ public class MaintenanceTest : TestFixture
         DragaliaResponse<ToolGetServiceStatusResponse> response =
             await this.Client.PostMsgpack<ToolGetServiceStatusResponse>(
                 "tool/get_service_status",
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -59,7 +61,8 @@ public class MaintenanceTest : TestFixture
         DragaliaResponse<MaintenanceGetTextResponse> response =
             await this.Client.PostMsgpack<MaintenanceGetTextResponse>(
                 "maintenance/get_text",
-                new MaintenanceGetTextRequest()
+                new MaintenanceGetTextRequest(),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Missions/MissionTest.cs
@@ -22,7 +22,8 @@ public class MissionTest : TestFixture
         DragaliaResponse<MissionUnlockDrillMissionGroupResponse> resp =
             await this.Client.PostMsgpack<MissionUnlockDrillMissionGroupResponse>(
                 "mission/unlock_drill_mission_group",
-                new MissionUnlockDrillMissionGroupRequest(1)
+                new MissionUnlockDrillMissionGroupRequest(1),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -45,7 +46,8 @@ public class MissionTest : TestFixture
         DragaliaResponse<MissionUnlockMainStoryGroupResponse> resp =
             await this.Client.PostMsgpack<MissionUnlockMainStoryGroupResponse>(
                 "mission/unlock_main_story_group",
-                new MissionUnlockMainStoryGroupRequest(1)
+                new MissionUnlockMainStoryGroupRequest(1),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -58,13 +60,15 @@ public class MissionTest : TestFixture
     {
         await this.Client.PostMsgpack<MissionUnlockDrillMissionGroupResponse>(
             "mission/unlock_drill_mission_group",
-            new MissionUnlockDrillMissionGroupRequest(1)
+            new MissionUnlockDrillMissionGroupRequest(1),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<QuestReadStoryResponse> resp =
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = 1000106 }
+                new QuestReadStoryRequest() { QuestStoryId = 1000106 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -77,7 +81,8 @@ public class MissionTest : TestFixture
         DragaliaResponse<MissionReceiveDrillRewardResponse> rewardResp =
             await this.Client.PostMsgpack<MissionReceiveDrillRewardResponse>(
                 "/mission/receive_drill_reward",
-                new MissionReceiveDrillRewardRequest(new[] { 100200 }, Enumerable.Empty<int>())
+                new MissionReceiveDrillRewardRequest(new[] { 100200 }, Enumerable.Empty<int>()),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         rewardResp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -90,13 +95,15 @@ public class MissionTest : TestFixture
     {
         await this.Client.PostMsgpack<MissionUnlockDrillMissionGroupResponse>(
             "mission/unlock_drill_mission_group",
-            new MissionUnlockDrillMissionGroupRequest(3)
+            new MissionUnlockDrillMissionGroupRequest(3),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<TreasureTradeTradeResponse> resp =
             await this.Client.PostMsgpack<TreasureTradeTradeResponse>(
                 "/treasure_trade/trade",
-                new TreasureTradeTradeRequest() { TreasureTradeId = 10020101, TradeCount = 1 }
+                new TreasureTradeTradeRequest() { TreasureTradeId = 10020101, TradeCount = 1 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -121,7 +128,8 @@ public class MissionTest : TestFixture
 
         await this.Client.PostMsgpack<MissionUnlockDrillMissionGroupResponse>(
             "mission/unlock_drill_mission_group",
-            new MissionUnlockDrillMissionGroupRequest(3)
+            new MissionUnlockDrillMissionGroupRequest(3),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<AbilityCrestBuildupPieceResponse> resp =
@@ -137,7 +145,8 @@ public class MissionTest : TestFixture
                             BuildupPieceType = BuildupPieceTypes.Stats,
                             Step = x,
                         }),
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -168,7 +177,8 @@ public class MissionTest : TestFixture
                 new MissionReceiveMemoryEventRewardRequest()
                 {
                     MemoryEventMissionIdList = new[] { 10220101 }, // Participate in the Event (Toll of the Deep)
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -253,7 +263,8 @@ public class MissionTest : TestFixture
                         new() { DailyMissionId = missionId2, DayNo = today },
                         new() { DailyMissionId = missionId1, DayNo = yesterday },
                     ],
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -312,7 +323,8 @@ public class MissionTest : TestFixture
                 new MissionReceiveMemoryEventRewardRequest()
                 {
                     MemoryEventMissionIdList = [missionId],
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -355,7 +367,8 @@ public class MissionTest : TestFixture
 
         DragaliaResponse<MissionGetMissionListResponse> response =
             await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list"
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -413,7 +426,8 @@ public class MissionTest : TestFixture
             await this.Client.PostMsgpack<ShopItemSummonExecResponse>(
                 "shop/item_summon_exec",
                 new ShopItemSummonExecRequest() { PaymentType = PaymentTypes.Wyrmite },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -435,7 +449,8 @@ public class MissionTest : TestFixture
 
         MissionGetDrillMissionListResponse response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list"
+                "mission/get_drill_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -449,7 +464,8 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list"
+                "mission/get_drill_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -463,7 +479,8 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list"
+                "mission/get_drill_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -479,7 +496,8 @@ public class MissionTest : TestFixture
 
         response = (
             await this.Client.PostMsgpack<MissionGetDrillMissionListResponse>(
-                "mission/get_drill_mission_list"
+                "mission/get_drill_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -510,7 +528,10 @@ public class MissionTest : TestFixture
         );
 
         MissionGetMissionListResponse response = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -563,7 +584,10 @@ public class MissionTest : TestFixture
         );
 
         MissionGetMissionListResponse response = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -591,7 +615,8 @@ public class MissionTest : TestFixture
 
         DragaliaResponse<MissionGetMissionListResponse> response =
             await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list"
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -617,7 +642,8 @@ public class MissionTest : TestFixture
 
         DragaliaResponse<MissionGetMissionListResponse> response =
             await this.Client.PostMsgpack<MissionGetMissionListResponse>(
-                "mission/get_mission_list"
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -47,7 +47,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentGetPresentListResponse> response =
             await this.Client.PostMsgpack<PresentGetPresentListResponse>(
                 $"{Controller}/get_present_list",
-                new PresentGetPresentListRequest() { IsLimit = false, PresentId = 0 }
+                new PresentGetPresentListRequest() { IsLimit = false, PresentId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -113,7 +114,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentGetPresentListResponse> response =
             await this.Client.PostMsgpack<PresentGetPresentListResponse>(
                 $"{Controller}/get_present_list",
-                new PresentGetPresentListRequest() { IsLimit = true, PresentId = 0 }
+                new PresentGetPresentListRequest() { IsLimit = true, PresentId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -163,7 +165,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentGetPresentListResponse> firstResponse =
             await this.Client.PostMsgpack<PresentGetPresentListResponse>(
                 $"{Controller}/get_present_list",
-                new PresentGetPresentListRequest() { IsLimit = false, PresentId = 0 }
+                new PresentGetPresentListRequest() { IsLimit = false, PresentId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         firstResponse.Data.PresentList.Should().HaveCount(100);
@@ -175,7 +178,8 @@ public class PresentTest : TestFixture
                 {
                     IsLimit = false,
                     PresentId = firstResponse.Data.PresentList.Last().PresentId,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         secondResponse.Data.PresentList.Should().HaveCount(20);
@@ -291,7 +295,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ReceivePresentIdList.Should().BeEquivalentTo(presentIdList);
@@ -371,7 +376,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ReceivePresentIdList.Should().BeEquivalentTo(presentIdList);
@@ -421,7 +427,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ReceivePresentIdList.Should().BeEquivalentTo(presentIdList);
@@ -475,7 +482,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ReceivePresentIdList.Should().Contain((ulong)presents.First().PresentId);
@@ -520,7 +528,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ReceivePresentIdList.Should().BeEquivalentTo(presentIdList);
@@ -554,13 +563,16 @@ public class PresentTest : TestFixture
 
         await this.AddRangeToDatabase(presents);
 
-        await this.ApiContext.PlayerSummonTickets.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerSummonTickets.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         IEnumerable<ulong> presentIdList = presents.Select(x => (ulong)x.PresentId);
 
         await this.Client.PostMsgpack<PresentReceiveResponse>(
             $"{Controller}/receive",
-            new PresentReceiveRequest() { PresentIdList = presentIdList }
+            new PresentReceiveRequest() { PresentIdList = presentIdList },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerSummonTickets.AsNoTracking()
@@ -603,7 +615,9 @@ public class PresentTest : TestFixture
             },
         ];
 
-        await this.ApiContext.PlayerDragonGifts.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerDragonGifts.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         await this.AddRangeToDatabase(
             [
@@ -621,7 +635,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -672,7 +687,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -734,7 +750,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentReceiveResponse> response =
             await this.Client.PostMsgpack<PresentReceiveResponse>(
                 $"{Controller}/receive",
-                new PresentReceiveRequest() { PresentIdList = presentIdList }
+                new PresentReceiveRequest() { PresentIdList = presentIdList },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.UpdateDataList.DmodeInfo.DmodePoint1.Should().Be(200);
@@ -762,7 +779,8 @@ public class PresentTest : TestFixture
         DragaliaResponse<PresentGetHistoryListResponse> firstResponse =
             await this.Client.PostMsgpack<PresentGetHistoryListResponse>(
                 $"{Controller}/get_history_list",
-                new PresentGetHistoryListRequest() { PresentHistoryId = 0 }
+                new PresentGetHistoryListRequest() { PresentHistoryId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         firstResponse
@@ -776,7 +794,8 @@ public class PresentTest : TestFixture
                 new PresentGetHistoryListRequest()
                 {
                     PresentHistoryId = (ulong)presentHistories[99].Id,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         secondResponse.Data.PresentHistoryList.Should().HaveCount(20);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
@@ -25,7 +25,8 @@ public class QuestClearPartyTest : TestFixture
         DragaliaResponse<QuestGetQuestClearPartyResponse> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyResponse>(
                 "/quest/get_quest_clear_party",
-                new QuestGetQuestClearPartyRequest() { QuestId = 1 }
+                new QuestGetQuestClearPartyRequest() { QuestId = 1 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -44,7 +45,8 @@ public class QuestClearPartyTest : TestFixture
         DragaliaResponse<QuestGetQuestClearPartyMultiResponse> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyMultiResponse>(
                 "/quest/get_quest_clear_party_multi",
-                new QuestGetQuestClearPartyRequest() { QuestId = 2 }
+                new QuestGetQuestClearPartyRequest() { QuestId = 2 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -64,13 +66,15 @@ public class QuestClearPartyTest : TestFixture
             {
                 QuestId = questId,
                 RequestPartySettingList = this.MultiPartySettingLists,
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         DragaliaResponse<QuestGetQuestClearPartyResponse> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyResponse>(
                 "/quest/get_quest_clear_party",
-                new QuestGetQuestClearPartyRequest() { QuestId = questId }
+                new QuestGetQuestClearPartyRequest() { QuestId = questId },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.QuestClearPartySettingList.Should().BeEmpty();
@@ -88,7 +92,8 @@ public class QuestClearPartyTest : TestFixture
         DragaliaResponse<QuestGetQuestClearPartyResponse> response =
             await this.Client.PostMsgpack<QuestGetQuestClearPartyResponse>(
                 "/quest/get_quest_clear_party",
-                new QuestGetQuestClearPartyRequest() { QuestId = questId }
+                new QuestGetQuestClearPartyRequest() { QuestId = questId },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response
@@ -159,7 +164,8 @@ public class QuestClearPartyTest : TestFixture
                 {
                     QuestId = 3,
                     RequestPartySettingList = this.SoloPartySettingLists,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.Result.Should().Be(1);
@@ -168,7 +174,7 @@ public class QuestClearPartyTest : TestFixture
             .ApiContext.QuestClearPartyUnits.Where(x =>
                 x.QuestId == 3 && x.ViewerId == this.ViewerId && x.IsMulti == false
             )
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         storedList
             .Should()
@@ -188,7 +194,8 @@ public class QuestClearPartyTest : TestFixture
                 {
                     QuestId = 4,
                     RequestPartySettingList = this.MultiPartySettingLists,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.Result.Should().Be(1);
@@ -197,7 +204,7 @@ public class QuestClearPartyTest : TestFixture
             .ApiContext.QuestClearPartyUnits.Where(x =>
                 x.QuestId == 4 && x.ViewerId == this.ViewerId && x.IsMulti == true
             )
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         storedList
             .Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestOpenTreasureTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestOpenTreasureTest.cs
@@ -17,7 +17,8 @@ public class QuestOpenTreasureTest : TestFixture
         QuestOpenTreasureResponse response = (
             await this.Client.PostMsgpack<QuestOpenTreasureResponse>(
                 "/quest/open_treasure",
-                new QuestOpenTreasureRequest() { QuestTreasureId = 104101 }
+                new QuestOpenTreasureRequest() { QuestTreasureId = 104101 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -32,13 +33,14 @@ public class QuestOpenTreasureTest : TestFixture
         QuestOpenTreasureResponse response = (
             await this.Client.PostMsgpack<QuestOpenTreasureResponse>(
                 "/quest/open_treasure",
-                new QuestOpenTreasureRequest() { QuestTreasureId = 126201 }
+                new QuestOpenTreasureRequest() { QuestTreasureId = 126201 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
         List<DbQuestTreasureList> questTreasureList = await this
             .ApiContext.QuestTreasureList.Where(x => x.ViewerId == this.ViewerId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         questTreasureList.Should().Contain(x => x.QuestTreasureId == 126201);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
@@ -14,7 +14,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = 1000106 }
+                new QuestReadStoryRequest() { QuestStoryId = 1000106 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -44,7 +45,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = midgardStoryId }
+                new QuestReadStoryRequest() { QuestStoryId = midgardStoryId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -92,7 +94,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = midgardStoryId }
+                new QuestReadStoryRequest() { QuestStoryId = midgardStoryId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -126,7 +129,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = 1001410 }
+                new QuestReadStoryRequest() { QuestStoryId = 1001410 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -138,7 +142,7 @@ public class QuestReadStoryTest : TestFixture
 
         List<DbPlayerStoryState> storyStates = await this
             .ApiContext.PlayerStoryState.Where(x => x.ViewerId == this.ViewerId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         storyStates.Should().Contain(x => x.StoryId == 1001410 && x.State == StoryState.Read);
         this.ApiContext.PlayerCharaData.Any(x => x.CharaId == Charas.Zena).Should().BeTrue();
@@ -154,7 +158,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = theLonePaladynStoryId }
+                new QuestReadStoryRequest() { QuestStoryId = theLonePaladynStoryId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -176,14 +181,16 @@ public class QuestReadStoryTest : TestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(u =>
-                u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990)
+            .ExecuteUpdateAsync(
+                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         StoryReadResponse data = (
             await this.Client.PostMsgpack<StoryReadResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = 1001009 }
+                new QuestReadStoryRequest() { QuestStoryId = 1001009 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -214,7 +221,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = storyId }
+                new QuestReadStoryRequest() { QuestStoryId = storyId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -227,7 +235,8 @@ public class QuestReadStoryTest : TestFixture
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
                 "/quest/read_story",
-                new QuestReadStoryRequest() { QuestStoryId = 1001610 }
+                new QuestReadStoryRequest() { QuestStoryId = 1001610 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -53,7 +53,8 @@ public class QuestBonusTest : TestFixture
                     QuestEventId = questEventId,
                     IsReceive = true,
                     ReceiveBonusCount = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         bonusResponse.Data.ReceiveQuestBonus.TargetQuestId.Should().Be(questId);
@@ -202,7 +203,8 @@ public class QuestBonusTest : TestFixture
                     QuestEventId = questEventId,
                     IsReceive = true,
                     ReceiveBonusCount = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         bonusResponse.Data.ReceiveQuestBonus.TargetQuestId.Should().Be(questId);
@@ -247,7 +249,8 @@ public class QuestBonusTest : TestFixture
                     QuestEventId = questEventId,
                     IsReceive = false,
                     ReceiveBonusCount = 0,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         bonusResponse.Data.ReceiveQuestBonus.TargetQuestId.Should().Be(questId);
@@ -307,7 +310,8 @@ public class QuestBonusTest : TestFixture
                     QuestEventId = questEventId,
                     IsReceive = false,
                     ReceiveBonusCount = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         bonusResponse.Data.ReceiveQuestBonus.TargetQuestId.Should().Be(questId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Reward/RewardServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Reward/RewardServiceTest.cs
@@ -37,7 +37,8 @@ public class RewardServiceTest : TestFixture
 
         await this.Client.PostMsgpack(
             "/present/receive",
-            new PresentReceiveRequest() { PresentIdList = [(ulong)present.PresentId] }
+            new PresentReceiveRequest() { PresentIdList = [(ulong)present.PresentId] },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerSummonTickets.Should()
@@ -75,7 +76,8 @@ public class RewardServiceTest : TestFixture
 
         await this.Client.PostMsgpack(
             "/present/receive",
-            new PresentReceiveRequest() { PresentIdList = [(ulong)present.PresentId] }
+            new PresentReceiveRequest() { PresentIdList = [(ulong)present.PresentId] },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.PlayerSummonTickets.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V14UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V14UpdateTest.cs
@@ -14,8 +14,9 @@ public class V14UpdateTest : SavefileUpdateTestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(entity =>
-                entity.SetProperty(e => e.EmblemId, Emblems.HotBloodedInstructor)
+            .ExecuteUpdateAsync(
+                entity => entity.SetProperty(e => e.EmblemId, Emblems.HotBloodedInstructor),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         int cellieraCh5 = MasterAsset.CharaStories[(int)Charas.Celliera].StoryIds[^1];

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -23,7 +23,10 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.TheHalidom);
@@ -48,7 +51,10 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.Smithy);
@@ -73,7 +79,10 @@ public class V1UpdateTest : SavefileUpdateTestFixture
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.FlameDracolith);
@@ -87,12 +96,16 @@ public class V1UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V1Update_NoDojos_TutorialComplete_Adds()
     {
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(u =>
-            u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.BuildList.Should().Contain(x => x.PlantId == FortPlants.SwordDojo);
@@ -101,19 +114,27 @@ public class V1UpdateTest : SavefileUpdateTestFixture
 
         this.GetSavefileVersion().Should().Be(this.MaxVersion);
 
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(u =>
-            u.SetProperty(e => e.TutorialStatus, 0)
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.TutorialStatus, 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
     }
 
     [Fact]
     public async Task V1Update_StoryAndTutorialIncomplete_DoesNothing()
     {
-        await this.ApiContext.PlayerFortBuilds.ExecuteDeleteAsync();
-        await this.ApiContext.PlayerStoryState.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerFortBuilds.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerStoryState.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.BuildList.Should().BeEmpty();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V20UpdateTest.cs
@@ -66,7 +66,7 @@ public class V20UpdateTest : SavefileUpdateTestFixture
                 },
             ]
         );
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
         await this.LoadIndex();
 
         this.ApiContext.PlayerPresents.AsNoTracking()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V22UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V22UpdateTest.cs
@@ -18,13 +18,14 @@ public class V22UpdateTest : SavefileUpdateTestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(u =>
-                u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990)
+            .ExecuteUpdateAsync(
+                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         await this
             .ApiContext.PlayerPresents.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this.AddToDatabase(
             new DbPlayerStoryState()
@@ -38,8 +39,9 @@ public class V22UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         userData.Level.Should().Be(65);
@@ -47,7 +49,7 @@ public class V22UpdateTest : SavefileUpdateTestFixture
 
         List<DbPlayerPresent> presentData = await this
             .ApiContext.PlayerPresents.Where(x => x.ViewerId == this.ViewerId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         List<QuestStoryReward> rewards = MasterAsset
             .QuestStoryRewardInfo.Enumerable.Where(x => x.Id == Chapter10LastStoryId)
@@ -69,24 +71,26 @@ public class V22UpdateTest : SavefileUpdateTestFixture
     {
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(u =>
-                u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990)
+            .ExecuteUpdateAsync(
+                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         await this
             .ApiContext.PlayerStoryState.Where(x =>
                 x.ViewerId == this.ViewerId && x.StoryId == Chapter10LastStoryId
             )
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this
             .ApiContext.PlayerPresents.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this.LoadIndex();
 
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         userData.Level.Should().Be(30);
@@ -94,7 +98,7 @@ public class V22UpdateTest : SavefileUpdateTestFixture
 
         List<DbPlayerPresent> presentData = await this
             .ApiContext.PlayerPresents.Where(x => x.ViewerId == this.ViewerId)
-            .ToListAsync();
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         presentData.Count.Should().Be(0);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V2UpdateTest.cs
@@ -11,7 +11,10 @@ public class V2UpdateTest : SavefileUpdateTestFixture
     public async Task V2Update_AddsStampList()
     {
         LoadIndexResponse data = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("/load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "/load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         List<EquipStampList> expectedStampList =
@@ -62,7 +65,7 @@ public class V2UpdateTest : SavefileUpdateTestFixture
                         .WithMapping<DbEquippedStamp>(dto => dto.Slot, db => db.Slot)
                         .WithMapping<DbEquippedStamp>(dto => dto.StampId, db => db.StampId)
             );
-        (await this.ApiContext.Players.FindAsync(ViewerId))!
+        (await this.ApiContext.Players.FindAsync(ViewerId, TestContext.Current.CancellationToken))!
             .SavefileVersion.Should()
             .Be(MaxVersion);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Shop/ShopTest.cs
@@ -14,10 +14,13 @@ public class ShopTest : TestFixture
             this.ApiContext.PlayerPurchases.Where(x => x.ViewerId == ViewerId)
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         DragaliaResponse<ShopGetListResponse> resp =
-            await this.Client.PostMsgpack<ShopGetListResponse>("shop/get_list");
+            await this.Client.PostMsgpack<ShopGetListResponse>(
+                "shop/get_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
         resp.Data.MaterialShopPurchase.Should().BeEmpty();
@@ -35,7 +38,8 @@ public class ShopTest : TestFixture
                     MaterialShopType.Daily,
                     PaymentTypes.Coin,
                     1
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -57,7 +61,8 @@ public class ShopTest : TestFixture
                     (PaymentTypes)100,
                     1
                 ),
-                false
+                false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         resp.DataHeaders.ResultCode.Should().Be(ResultCode.ShopPaymentTypeInvalid);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Stamp/StampTest.cs
@@ -13,7 +13,10 @@ public class StampTest : TestFixture
     public async Task GetStamp_ReturnsStamps()
     {
         StampGetStampResponse data = (
-            await this.Client.PostMsgpack<StampGetStampResponse>($"{Controller}/get_stamp")
+            await this.Client.PostMsgpack<StampGetStampResponse>(
+                $"{Controller}/get_stamp",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         data.StampList.Should().HaveCount(123);
@@ -61,7 +64,8 @@ public class StampTest : TestFixture
 
         await this.Client.PostMsgpack<StampSetEquipStampResponse>(
             $"{Controller}/set_equip_stamp",
-            new StampSetEquipStampRequest() { StampList = requestList }
+            new StampSetEquipStampRequest() { StampList = requestList },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         this.ApiContext.ChangeTracker.Clear();
@@ -120,7 +124,8 @@ public class StampTest : TestFixture
         StampSetEquipStampResponse data = (
             await this.Client.PostMsgpack<StampSetEquipStampResponse>(
                 $"{Controller}/set_equip_stamp",
-                new StampSetEquipStampRequest() { StampList = requestList }
+                new StampSetEquipStampRequest() { StampList = requestList },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
@@ -18,7 +18,8 @@ public class StoryTest : TestFixture
         StoryReadResponse data = (
             await this.Client.PostMsgpack<StoryReadResponse>(
                 "/story/read",
-                new StoryReadRequest() { UnitStoryId = 100001141 }
+                new StoryReadRequest() { UnitStoryId = 100001141 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -64,12 +65,13 @@ public class StoryTest : TestFixture
                 StoryType = StoryTypes.Chara,
             }
         );
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         StoryReadResponse data = (
             await this.Client.PostMsgpack<StoryReadResponse>(
                 "/story/read",
-                new StoryReadRequest() { UnitStoryId = 100001122 }
+                new StoryReadRequest() { UnitStoryId = 100001122 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -86,12 +88,13 @@ public class StoryTest : TestFixture
             .ApiContext.PlayerUserData.AsNoTracking()
             .Where(x => x.ViewerId == this.ViewerId)
             .Select(x => x.Crystal)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         StoryReadResponse data = (
             await this.Client.PostMsgpack<StoryReadResponse>(
                 "/story/read",
-                new StoryReadRequest() { UnitStoryId = 100002011 }
+                new StoryReadRequest() { UnitStoryId = 100002011 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -99,7 +102,7 @@ public class StoryTest : TestFixture
             .ApiContext.PlayerUserData.AsNoTracking()
             .Where(x => x.ViewerId == this.ViewerId)
             .Select(x => x.Crystal)
-            .SingleAsync();
+            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         newCrystal.Should().Be(oldCrystal + 25);
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -26,16 +26,18 @@ public class StorySkipTest : TestFixture
 
         await this
             .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(u =>
-                u.SetProperty(e => e.Level, 5)
-                    .SetProperty(e => e.Exp, 1)
-                    .SetProperty(e => e.StaminaSingle, 10)
-                    .SetProperty(e => e.StaminaMulti, 10)
+            .ExecuteUpdateAsync(
+                u =>
+                    u.SetProperty(e => e.Level, 5)
+                        .SetProperty(e => e.Exp, 1)
+                        .SetProperty(e => e.StaminaSingle, 10)
+                        .SetProperty(e => e.StaminaMulti, 10),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         await this
             .ApiContext.PlayerQuests.Where(x => x.ViewerId == this.ViewerId && x.QuestId <= questId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this
             .ApiContext.PlayerStoryState.Where(x =>
@@ -43,33 +45,38 @@ public class StorySkipTest : TestFixture
                 && x.StoryType == StoryTypes.Quest
                 && x.StoryId <= storyId
             )
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this
             .ApiContext.PlayerCharaData.Where(x =>
                 x.ViewerId == this.ViewerId && x.CharaId != Charas.ThePrince
             )
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this
             .ApiContext.PlayerDragonData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this
             .ApiContext.PlayerFortBuilds.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteDeleteAsync();
+            .ExecuteDeleteAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         await this.Client.PostMsgpack(
             "mission/unlock_drill_mission_group",
-            new MissionUnlockDrillMissionGroupRequest(1)
+            new MissionUnlockDrillMissionGroupRequest(1),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         StorySkipSkipResponse data = (
-            await this.Client.PostMsgpack<StorySkipSkipResponse>("story_skip/skip")
+            await this.Client.PostMsgpack<StorySkipSkipResponse>(
+                "story_skip/skip",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         data.Should().BeEquivalentTo(new StorySkipSkipResponse() { ResultState = 1 });
@@ -96,7 +103,7 @@ public class StorySkipTest : TestFixture
                 .ApiContext.PlayerFortBuilds.Where(x =>
                     x.ViewerId == this.ViewerId && x.PlantId == fortPlant
                 )
-                .ToListAsync();
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
 
             forts.Count.Should().Be(fortConfig.BuildCount);
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/RedoableSummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/RedoableSummonTest.cs
@@ -14,7 +14,10 @@ public class RedoableSummonTest : TestFixture
     public async Task RedoableSummonGetData_ReturnsData()
     {
         RedoableSummonGetDataResponse response = (
-            await this.Client.PostMsgpack<RedoableSummonGetDataResponse>("redoable_summon/get_data")
+            await this.Client.PostMsgpack<RedoableSummonGetDataResponse>(
+                "redoable_summon/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.Should().NotBeNull();
@@ -26,7 +29,8 @@ public class RedoableSummonTest : TestFixture
         RedoableSummonPreExecResponse response = (
             await this.Client.PostMsgpack<RedoableSummonPreExecResponse>(
                 "redoable_summon/pre_exec",
-                new RedoableSummonPreExecRequest(0)
+                new RedoableSummonPreExecRequest(0),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -39,11 +43,15 @@ public class RedoableSummonTest : TestFixture
         // Set up cached summon result
         await this.Client.PostMsgpack<RedoableSummonPreExecResponse>(
             "redoable_summon/pre_exec",
-            new RedoableSummonPreExecRequest()
+            new RedoableSummonPreExecRequest(),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         RedoableSummonFixExecResponse response = (
-            await this.Client.PostMsgpack<RedoableSummonFixExecResponse>("redoable_summon/fix_exec")
+            await this.Client.PostMsgpack<RedoableSummonFixExecResponse>(
+                "redoable_summon/fix_exec",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         IEnumerable<int> newCharaIds = response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -26,7 +26,8 @@ public class SummonTest : TestFixture
         SummonExcludeGetListResponse response = (
             await this.Client.PostMsgpack<SummonExcludeGetListResponse>(
                 "summon_exclude/get_list",
-                new SummonExcludeGetListRequest(TestBannerId)
+                new SummonExcludeGetListRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -39,7 +40,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse response = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -160,7 +162,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse response = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(bannerId)
+                new SummonGetOddsDataRequest(bannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -210,7 +213,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse response = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -261,12 +265,16 @@ public class SummonTest : TestFixture
                 GetDewPointQuantity = 0,
             };
 
-        await this.ApiContext.PlayerSummonHistory.AddAsync(historyEntry);
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.PlayerSummonHistory.AddAsync(
+            historyEntry,
+            TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         SummonGetSummonHistoryResponse response = (
             await this.Client.PostMsgpack<SummonGetSummonHistoryResponse>(
-                "summon/get_summon_history"
+                "summon/get_summon_history",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -324,7 +332,10 @@ public class SummonTest : TestFixture
         );
 
         SummonGetSummonListResponse response = (
-            await this.Client.PostMsgpack<SummonGetSummonListResponse>("summon/get_summon_list")
+            await this.Client.PostMsgpack<SummonGetSummonListResponse>(
+                "summon/get_summon_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -407,7 +418,10 @@ public class SummonTest : TestFixture
         );
 
         SummonGetSummonListResponse response = (
-            await this.Client.PostMsgpack<SummonGetSummonListResponse>("summon/get_summon_list")
+            await this.Client.PostMsgpack<SummonGetSummonListResponse>(
+                "summon/get_summon_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -431,12 +445,16 @@ public class SummonTest : TestFixture
             .SummonPointList.Should()
             .HaveCountLessOrEqualTo(1, "special ticket banners don't participate in wyrmsigils");
 
-        await this.ApiContext.PlayerSummonTickets.ExecuteUpdateAsync(e =>
-            e.SetProperty(p => p.Quantity, 0)
+        await this.ApiContext.PlayerSummonTickets.ExecuteUpdateAsync(
+            e => e.SetProperty(p => p.Quantity, 0),
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response = (
-            await this.Client.PostMsgpack<SummonGetSummonListResponse>("summon/get_summon_list")
+            await this.Client.PostMsgpack<SummonGetSummonListResponse>(
+                "summon/get_summon_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.CharaSsrSummonList.Should().BeEmpty();
@@ -454,7 +472,8 @@ public class SummonTest : TestFixture
         SummonGetSummonPointTradeResponse response = (
             await this.Client.PostMsgpack<SummonGetSummonPointTradeResponse>(
                 "summon/get_summon_point_trade",
-                new SummonGetSummonPointTradeRequest(TestBannerId)
+                new SummonGetSummonPointTradeRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -502,7 +521,8 @@ public class SummonTest : TestFixture
         SummonGetSummonPointTradeResponse response = (
             await this.Client.PostMsgpack<SummonGetSummonPointTradeResponse>(
                 "summon/get_summon_point_trade",
-                new SummonGetSummonPointTradeRequest(TestBannerId)
+                new SummonGetSummonPointTradeRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -537,11 +557,12 @@ public class SummonTest : TestFixture
     [Fact]
     public async Task SummonRequest_SingleSummonWyrmite_ReturnsValidResult()
     {
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.Entry(userData).ReloadAsync();
+        await this.ApiContext.Entry(userData).ReloadAsync(TestContext.Current.CancellationToken);
 
         SummonRequestResponse response = (
             await this.Client.PostMsgpack<SummonRequestResponse>(
@@ -552,7 +573,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal, 120) // TODO: Change when banners are implemented otherwise this test breaks
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -564,8 +586,9 @@ public class SummonTest : TestFixture
     [Fact]
     public async Task SummonRequest_TenSummonWyrmite_ReturnsValidResult()
     {
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         SummonRequestResponse response = (
@@ -577,7 +600,8 @@ public class SummonTest : TestFixture
                     0,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal, 1200)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -617,7 +641,8 @@ public class SummonTest : TestFixture
                     PaymentTypes.Ticket,
                     new PaymentTarget(1, 1)
                 ),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -645,7 +670,8 @@ public class SummonTest : TestFixture
                     PaymentTypes.Ticket,
                     new PaymentTarget(5, 5)
                 ),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -673,7 +699,8 @@ public class SummonTest : TestFixture
                     PaymentTypes.Ticket,
                     new PaymentTarget(1, 1)
                 ),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -682,8 +709,9 @@ public class SummonTest : TestFixture
     [Fact]
     public async Task SummonRequest_IncrementsWyrmsigilPoints()
     {
-        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(x =>
-            x.ViewerId == this.ViewerId
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(
+            x => x.ViewerId == this.ViewerId,
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         SummonRequestResponse response = (
@@ -695,7 +723,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal, 1200)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -713,7 +742,8 @@ public class SummonTest : TestFixture
                     3,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal - 1200, 360)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -744,7 +774,8 @@ public class SummonTest : TestFixture
                     PaymentTypes.Ticket,
                     new PaymentTarget(0, 1)
                 ),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.CommonMaterialShort);
@@ -768,7 +799,8 @@ public class SummonTest : TestFixture
                     0,
                     PaymentTypes.Ticket,
                     new PaymentTarget(1, 1)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -790,7 +822,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse oddsResponse = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -806,7 +839,10 @@ public class SummonTest : TestFixture
 
         DbPlayerUserData userData = await this
             .ApiContext.PlayerUserData.AsNoTracking()
-            .SingleAsync(x => x.ViewerId == this.ViewerId);
+            .SingleAsync(
+                x => x.ViewerId == this.ViewerId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         DragaliaResponse<SummonRequestResponse> response =
             await this.Client.PostMsgpack<SummonRequestResponse>(
@@ -817,7 +853,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal, 120)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ResultUnitList.Should().Contain(x => x.Rarity == 5);
@@ -825,7 +862,8 @@ public class SummonTest : TestFixture
         oddsResponse = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -853,7 +891,10 @@ public class SummonTest : TestFixture
 
         DbPlayerUserData userData = await this
             .ApiContext.PlayerUserData.AsNoTracking()
-            .SingleAsync(x => x.ViewerId == this.ViewerId);
+            .SingleAsync(
+                x => x.ViewerId == this.ViewerId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         DragaliaResponse<SummonRequestResponse> response =
             await this.Client.PostMsgpack<SummonRequestResponse>(
@@ -864,7 +905,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Wyrmite,
                     new PaymentTarget(userData.Crystal, 120)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ResultUnitList.Should().Contain(x => x.Rarity == 5);
@@ -872,7 +914,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse oddsResponse = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -893,7 +936,8 @@ public class SummonTest : TestFixture
         SummonGetOddsDataResponse oddsResponse = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -913,7 +957,10 @@ public class SummonTest : TestFixture
         {
             DbPlayerUserData userData = await this
                 .ApiContext.PlayerUserData.AsNoTracking()
-                .SingleAsync(x => x.ViewerId == this.ViewerId);
+                .SingleAsync(
+                    x => x.ViewerId == this.ViewerId,
+                    cancellationToken: TestContext.Current.CancellationToken
+                );
 
             DragaliaResponse<SummonRequestResponse> response =
                 await this.Client.PostMsgpack<SummonRequestResponse>(
@@ -924,7 +971,8 @@ public class SummonTest : TestFixture
                         1,
                         PaymentTypes.Wyrmite,
                         new PaymentTarget(userData.Crystal, 1200)
-                    )
+                    ),
+                    cancellationToken: TestContext.Current.CancellationToken
                 );
 
             result = response.Data.ResultUnitList;
@@ -933,7 +981,8 @@ public class SummonTest : TestFixture
         oddsResponse = (
             await this.Client.PostMsgpack<SummonGetOddsDataResponse>(
                 "summon/get_odds_data",
-                new SummonGetOddsDataRequest(TestBannerId)
+                new SummonGetOddsDataRequest(TestBannerId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -963,7 +1012,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Diamantium,
                     new PaymentTarget(1210, 1200)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ResultSummonPoint.Should().Be(20);
@@ -988,7 +1038,8 @@ public class SummonTest : TestFixture
                     1,
                     PaymentTypes.Diamantium,
                     new PaymentTarget(30, 30)
-                )
+                ),
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.ResultSummonPoint.Should().Be(2);
@@ -999,7 +1050,10 @@ public class SummonTest : TestFixture
          whether the Daily Deal button is disabled. */
 
         DragaliaResponse<SummonGetSummonListResponse> summonListResponse =
-            await this.Client.PostMsgpack<SummonGetSummonListResponse>("/summon/get_summon_list");
+            await this.Client.PostMsgpack<SummonGetSummonListResponse>(
+                "/summon/get_summon_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         SummonList summonList = summonListResponse.Data.SummonList.First(x =>
             x.SummonId == TestGalaBannerId
@@ -1018,7 +1072,8 @@ public class SummonTest : TestFixture
                     PaymentTypes.Diamantium,
                     new PaymentTarget(30, 30)
                 ),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .DataHeaders.ResultCode.Should()
@@ -1037,7 +1092,8 @@ public class SummonTest : TestFixture
         SummonSummonPointTradeResponse response = (
             await this.Client.PostMsgpack<SummonSummonPointTradeResponse>(
                 "summon/summon_point_trade",
-                new SummonSummonPointTradeRequest(TestBannerId, monaTradeId)
+                new SummonSummonPointTradeRequest(TestBannerId, monaTradeId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -1070,7 +1126,8 @@ public class SummonTest : TestFixture
         SummonSummonPointTradeResponse response = (
             await this.Client.PostMsgpack<SummonSummonPointTradeResponse>(
                 "summon/summon_point_trade",
-                new SummonSummonPointTradeRequest(TestBannerId, arseneTradeId)
+                new SummonSummonPointTradeRequest(TestBannerId, arseneTradeId),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
@@ -16,7 +16,8 @@ public class TimeAttackRankingTest : TestFixture
     {
         (
             await this.Client.PostMsgpack<TimeAttackRankingGetDataResponse>(
-                "/time_attack_ranking/get_data"
+                "/time_attack_ranking/get_data",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .Data.RankingTierRewardList.Should()
@@ -28,7 +29,10 @@ public class TimeAttackRankingTest : TestFixture
     {
         DbPlayerUserData oldUserData = await this
             .ApiContext.PlayerUserData.AsNoTracking()
-            .FirstAsync(x => x.ViewerId == ViewerId);
+            .FirstAsync(
+                x => x.ViewerId == ViewerId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         int questId = 227010101; // First Volk TA quest
 
@@ -41,12 +45,13 @@ public class TimeAttackRankingTest : TestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         TimeAttackRankingReceiveTierRewardResponse rewardResponse = (
             await this.Client.PostMsgpack<TimeAttackRankingReceiveTierRewardResponse>(
                 "/time_attack_ranking/receive_tier_reward",
-                new TimeAttackRankingReceiveTierRewardRequest() { QuestId = questId }
+                new TimeAttackRankingReceiveTierRewardRequest() { QuestId = questId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -74,7 +79,8 @@ public class TimeAttackRankingTest : TestFixture
         TimeAttackRankingReceiveTierRewardResponse secondRewardResponse = (
             await this.Client.PostMsgpack<TimeAttackRankingReceiveTierRewardResponse>(
                 "/time_attack_ranking/receive_tier_reward",
-                new TimeAttackRankingReceiveTierRewardRequest() { QuestId = questId }
+                new TimeAttackRankingReceiveTierRewardRequest() { QuestId = questId },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -24,7 +24,10 @@ public class ToolTest : TestFixture
         this.Client.DefaultRequestHeaders.Clear();
 
         ToolGetServiceStatusResponse response = (
-            await this.Client.PostMsgpack<ToolGetServiceStatusResponse>("tool/get_service_status")
+            await this.Client.PostMsgpack<ToolGetServiceStatusResponse>(
+                "tool/get_service_status",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.ServiceStatus.Should().Be(1);
@@ -42,7 +45,10 @@ public class ToolTest : TestFixture
         this.Client.DefaultRequestHeaders.Add(Headers.IdToken, token);
 
         ToolAuthResponse response = (
-            await this.Client.PostMsgpack<ToolAuthResponse>(endpoint)
+            await this.Client.PostMsgpack<ToolAuthResponse>(
+                endpoint,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.ViewerId.Should().Be((ulong)this.ViewerId);
@@ -60,7 +66,10 @@ public class ToolTest : TestFixture
         this.Client.DefaultRequestHeaders.Add(Headers.IdToken, token);
 
         ToolAuthResponse response = (
-            await this.Client.PostMsgpack<ToolAuthResponse>(endpoint)
+            await this.Client.PostMsgpack<ToolAuthResponse>(
+                endpoint,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.ViewerId.Should().Be((ulong)this.ViewerId + 1);
@@ -82,7 +91,10 @@ public class ToolTest : TestFixture
 
         this.Client.DefaultRequestHeaders.Add(Headers.IdToken, token);
 
-        await this.Client.PostMsgpack<ToolAuthResponse>("tool/auth");
+        await this.Client.PostMsgpack<ToolAuthResponse>(
+            "tool/auth",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.PlayerUserData.AsNoTracking()
             .First(x => x.ViewerId == this.ViewerId)
@@ -141,7 +153,12 @@ public class ToolTest : TestFixture
 
         DragaliaResponse<ResultCodeResponse> responseBody = MessagePackSerializer.Deserialize<
             DragaliaResponse<ResultCodeResponse>
-        >(await secondResponse.Content.ReadAsByteArrayAsync());
+        >(
+            await secondResponse.Content.ReadAsByteArrayAsync(
+                TestContext.Current.CancellationToken
+            ),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         responseBody
             .Should()
@@ -166,7 +183,8 @@ public class ToolTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 endpoint,
                 new ToolAuthRequest() { },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/TransitionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/TransitionTest.cs
@@ -18,7 +18,8 @@ public class TransitionTest : TestFixture
 
         TransitionTransitionByNAccountResponse response = (
             await this.Client.PostMsgpack<TransitionTransitionByNAccountResponse>(
-                "/transition/transition_by_n_account"
+                "/transition/transition_by_n_account",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -37,7 +38,8 @@ public class TransitionTest : TestFixture
 
         TransitionTransitionByNAccountResponse response = (
             await this.Client.PostMsgpack<TransitionTransitionByNAccountResponse>(
-                "/transition/transition_by_n_account"
+                "/transition/transition_by_n_account",
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/AbilityCrestTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/AbilityCrestTradeTest.cs
@@ -29,7 +29,8 @@ public class AbilityCrestTradeTest : TestFixture
                 {
                     AbilityCrestTradeId = tradeId,
                     TradeCount = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/EventTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/EventTradeTest.cs
@@ -11,7 +11,8 @@ public class EventTradeTest : TestFixture
         DragaliaResponse<EventTradeGetListResponse> response =
             await this.Client.PostMsgpack<EventTradeGetListResponse>(
                 "event_trade/get_list",
-                new EventTradeGetListRequest() { TradeGroupId = 10803 }
+                new EventTradeGetListRequest() { TradeGroupId = 10803 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.Data.EventTradeList.Should().NotBeEmpty();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -14,10 +14,13 @@ public class TreasureTradeTest : TestFixture
     [Fact]
     public async Task GetListAll_NoTrades_ReturnsEmpty()
     {
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         TreasureTradeGetListAllResponse response = (
-            await Client.PostMsgpack<TreasureTradeGetListAllResponse>("treasure_trade/get_list_all")
+            await Client.PostMsgpack<TreasureTradeGetListAllResponse>(
+                "treasure_trade/get_list_all",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response.UserTreasureTradeList.Should().BeEmpty();
@@ -40,7 +43,10 @@ public class TreasureTradeTest : TestFixture
         );
 
         TreasureTradeGetListAllResponse response = (
-            await Client.PostMsgpack<TreasureTradeGetListAllResponse>("treasure_trade/get_list_all")
+            await Client.PostMsgpack<TreasureTradeGetListAllResponse>(
+                "treasure_trade/get_list_all",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         response
@@ -73,7 +79,8 @@ public class TreasureTradeTest : TestFixture
         TreasureTradeTradeResponse response = (
             await Client.PostMsgpack<TreasureTradeTradeResponse>(
                 "treasure_trade/trade",
-                new TreasureTradeTradeRequest(1001, 10010101, null, 1)
+                new TreasureTradeTradeRequest(1001, 10010101, null, 1),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -100,7 +107,8 @@ public class TreasureTradeTest : TestFixture
         TreasureTradeTradeResponse response = (
             await Client.PostMsgpack<TreasureTradeTradeResponse>(
                 "treasure_trade/trade",
-                new TreasureTradeTradeRequest(1012, 10124101, null, 1)
+                new TreasureTradeTradeRequest(1012, 10124101, null, 1),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -127,7 +135,8 @@ public class TreasureTradeTest : TestFixture
         TreasureTradeTradeResponse response = (
             await Client.PostMsgpack<TreasureTradeTradeResponse>(
                 "treasure_trade/trade",
-                new TreasureTradeTradeRequest(1003, highBrunhildaTrade, null, 4)
+                new TreasureTradeTradeRequest(1003, highBrunhildaTrade, null, 4),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
@@ -24,7 +24,8 @@ public class TutorialTest : TestFixture
         TutorialUpdateStepResponse response = (
             await this.Client.PostMsgpack<TutorialUpdateStepResponse>(
                 "/tutorial/update_step",
-                new TutorialUpdateStepRequest(step, false, 0, 0)
+                new TutorialUpdateStepRequest(step, false, 0, 0),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -40,7 +41,10 @@ public class TutorialTest : TestFixture
         int step = 20000;
 
         DbPlayerUserData dbUserData = (
-            await this.ApiContext.PlayerUserData.FindAsync(this.ViewerId)
+            await this.ApiContext.PlayerUserData.FindAsync(
+                this.ViewerId,
+                TestContext.Current.CancellationToken
+            )
         )!;
 
         UserData expUserData = this.Mapper.Map<UserData>(dbUserData);
@@ -50,7 +54,8 @@ public class TutorialTest : TestFixture
         TutorialUpdateStepResponse response = (
             await this.Client.PostMsgpack<TutorialUpdateStepResponse>(
                 "/tutorial/update_step",
-                new TutorialUpdateStepRequest(step, false, 0, 0)
+                new TutorialUpdateStepRequest(step, false, 0, 0),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -65,7 +70,8 @@ public class TutorialTest : TestFixture
         TutorialUpdateFlagsResponse response = (
             await this.Client.PostMsgpack<TutorialUpdateFlagsResponse>(
                 "/tutorial/update_flags",
-                new TutorialUpdateFlagsRequest() { FlagId = flag }
+                new TutorialUpdateFlagsRequest() { FlagId = flag },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Version/VersionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Version/VersionTest.cs
@@ -21,7 +21,8 @@ public class VersionTest : TestFixture
         VersionGetResourceVersionResponse response = (
             await this.Client.PostMsgpack<VersionGetResourceVersionResponse>(
                 "version/get_resource_version",
-                new VersionGetResourceVersionRequest(platform, "whatever")
+                new VersionGetResourceVersionRequest(platform, "whatever"),
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -37,7 +38,8 @@ public class VersionTest : TestFixture
         (
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "fort/get_data",
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .DataHeaders.ResultCode.Should()
@@ -53,7 +55,8 @@ public class VersionTest : TestFixture
         (
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "tool/get_service_status",
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         )
             .DataHeaders.ResultCode.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -68,7 +68,8 @@ public class WallRecordTest : TestFixture
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
                 "/wall_record/record",
-                new WallRecordRecordRequest() { WallId = wallId, DungeonKey = key }
+                new WallRecordRecordRequest() { WallId = wallId, DungeonKey = key },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -166,7 +167,8 @@ public class WallRecordTest : TestFixture
         WallRecordRecordResponse response = (
             await Client.PostMsgpack<WallRecordRecordResponse>(
                 "/wall_record/record",
-                new WallRecordRecordRequest() { WallId = wallId, DungeonKey = key }
+                new WallRecordRecordRequest() { WallId = wallId, DungeonKey = key },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -249,7 +251,8 @@ public class WallRecordTest : TestFixture
                 {
                     WallId = (int)QuestWallTypes.Flame,
                     DungeonKey = key,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -264,7 +267,10 @@ public class WallRecordTest : TestFixture
             .BeEquivalentTo([flameLv6MissionId, clearAllLv6MissionId]);
 
         MissionGetMissionListResponse missionList = (
-            await this.Client.PostMsgpack<MissionGetMissionListResponse>("mission/get_mission_list")
+            await this.Client.PostMsgpack<MissionGetMissionListResponse>(
+                "mission/get_mission_list",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         missionList.NormalMissionList.Should().Contain(x => x.NormalMissionId == flameLv7MissionId);
@@ -319,7 +325,8 @@ public class WallRecordTest : TestFixture
                 {
                     WallId = (int)QuestWallTypes.Flame,
                     DungeonKey = key,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
@@ -39,7 +39,8 @@ public class WallStartTest : TestFixture
                     WallId = wallId,
                     WallLevel = wallLevel,
                     PartyNo = 1,
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -79,7 +80,8 @@ public class WallStartTest : TestFixture
                     WallId = wallId,
                     WallLevel = wallLevel,
                     RequestPartySettingList = new List<PartySettingList>(),
-                }
+                },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
@@ -41,7 +41,8 @@ public class WallTest : TestFixture
         WallFailResponse response = (
             await Client.PostMsgpack<WallFailResponse>(
                 "/wall/fail",
-                new WallFailRequest() { DungeonKey = key, FailState = 0 }
+                new WallFailRequest() { DungeonKey = key, FailState = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -99,7 +100,8 @@ public class WallTest : TestFixture
         WallGetMonthlyRewardResponse response = (
             await this.Client.PostMsgpack<WallGetMonthlyRewardResponse>(
                 "wall/get_monthly_reward",
-                new WallGetMonthlyRewardResponse() { }
+                new WallGetMonthlyRewardResponse() { },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -176,7 +178,8 @@ public class WallTest : TestFixture
         WallReceiveMonthlyRewardResponse response = (
             await this.Client.PostMsgpack<WallReceiveMonthlyRewardResponse>(
                 "wall/receive_monthly_reward",
-                new WallGetMonthlyRewardRequest() { QuestGroupId = 21601 }
+                new WallGetMonthlyRewardRequest() { QuestGroupId = 21601 },
+                cancellationToken: TestContext.Current.CancellationToken
             )
         ).Data;
 
@@ -222,7 +225,8 @@ public class WallTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "wall/receive_monthly_reward",
                 new WallGetMonthlyRewardRequest() { QuestGroupId = 21601 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 
@@ -248,7 +252,8 @@ public class WallTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 "wall/receive_monthly_reward",
                 new WallGetMonthlyRewardRequest() { QuestGroupId = 21601 },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             )
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
@@ -27,12 +27,17 @@ public class NewsTests : WebTestFixture
     public async Task GetNewsItems_Returns200PagedResponse()
     {
         HttpResponseMessage page1Response = await this.Client.GetAsync(
-            "/api/news?offset=0&pageSize=5"
+            "/api/news?offset=0&pageSize=5",
+            TestContext.Current.CancellationToken
         );
 
         page1Response.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        (await page1Response.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>())
+        (
+            await page1Response.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(
                 new OffsetPagedResponse<NewsItem>()
@@ -51,12 +56,17 @@ public class NewsTests : WebTestFixture
             );
 
         HttpResponseMessage page2Response = await this.Client.GetAsync(
-            "/api/news?offset=5&pageSize=5"
+            "/api/news?offset=5&pageSize=5",
+            TestContext.Current.CancellationToken
         );
 
         page2Response.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        (await page2Response.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>())
+        (
+            await page2Response.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(
                 new OffsetPagedResponse<NewsItem>()
@@ -90,10 +100,15 @@ public class NewsTests : WebTestFixture
         this.ApiContext.SaveChanges();
 
         HttpResponseMessage allItems = await this.Client.GetAsync(
-            "/api/news?offset=0&pageSize=100"
+            "/api/news?offset=0&pageSize=100",
+            TestContext.Current.CancellationToken
         );
 
-        (await allItems.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>())!
+        (
+            await allItems.Content.ReadFromJsonAsync<OffsetPagedResponse<NewsItem>>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )!
             .Data.Should()
             .NotContain(x => x.Id == hiddenItem.Id);
     }
@@ -113,10 +128,15 @@ public class NewsTests : WebTestFixture
         this.ApiContext.SaveChanges();
 
         HttpResponseMessage specificItemResponse = await this.Client.GetAsync(
-            $"/api/news/{hiddenItem.Id}"
+            $"/api/news/{hiddenItem.Id}",
+            TestContext.Current.CancellationToken
         );
 
-        (await specificItemResponse.Content.ReadFromJsonAsync<NewsItem>())
+        (
+            await specificItemResponse.Content.ReadFromJsonAsync<NewsItem>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(
                 new NewsItem()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Savefile/SavefileEditTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Savefile/SavefileEditTests.cs
@@ -18,7 +18,12 @@ public class SavefileEditTests : WebTestFixture
 
     [Fact]
     public async Task PresentWidgetData_Unauthenticated_Returns401() =>
-        (await this.Client.GetAsync("/api/savefile/edit/widgets/present"))
+        (
+            await this.Client.GetAsync(
+                "/api/savefile/edit/widgets/present",
+                TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveStatusCode(HttpStatusCode.Unauthorized);
 
@@ -27,10 +32,15 @@ public class SavefileEditTests : WebTestFixture
     {
         this.AddTokenCookie();
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/savefile/edit/widgets/present");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/savefile/edit/widgets/present",
+            TestContext.Current.CancellationToken
+        );
         resp.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        PresentWidgetData? data = await resp.Content.ReadFromJsonAsync<PresentWidgetData>();
+        PresentWidgetData? data = await resp.Content.ReadFromJsonAsync<PresentWidgetData>(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         data.Should().NotBeNull();
         data!
@@ -51,7 +61,13 @@ public class SavefileEditTests : WebTestFixture
 
     [Fact]
     public async Task Edit_Unauthenticated_Returns401() =>
-        (await this.Client.PostAsync("/api/savefile/edit", null))
+        (
+            await this.Client.PostAsync(
+                "/api/savefile/edit",
+                null,
+                TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveStatusCode(HttpStatusCode.Unauthorized);
 
@@ -74,7 +90,13 @@ public class SavefileEditTests : WebTestFixture
                 ],
             };
 
-        (await this.Client.PostAsJsonAsync("/api/savefile/edit", invalidRequest))
+        (
+            await this.Client.PostAsJsonAsync(
+                "/api/savefile/edit",
+                invalidRequest,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveStatusCode(HttpStatusCode.BadRequest);
     }
@@ -98,14 +120,21 @@ public class SavefileEditTests : WebTestFixture
                 ],
             };
 
-        (await this.Client.PostAsJsonAsync("/api/savefile/edit", request))
+        (
+            await this.Client.PostAsJsonAsync(
+                "/api/savefile/edit",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveStatusCode(HttpStatusCode.OK);
 
         DragaliaResponse<PresentGetPresentListResponse> presentList =
             await this.Client.PostMsgpack<PresentGetPresentListResponse>(
                 "/present/get_present_list",
-                new PresentGetPresentListRequest { PresentId = 0 }
+                new PresentGetPresentListRequest { PresentId = 0 },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         presentList

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Savefile/SavefileExportTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Savefile/SavefileExportTests.cs
@@ -19,7 +19,7 @@ public class SavefileExportTests : WebTestFixture
 
     [Fact]
     public async Task Export_Unauthenticated_Returns401() =>
-        (await this.Client.GetAsync("/api/savefile/export"))
+        (await this.Client.GetAsync("/api/savefile/export", TestContext.Current.CancellationToken))
             .Should()
             .HaveStatusCode(HttpStatusCode.Unauthorized);
 
@@ -28,10 +28,15 @@ public class SavefileExportTests : WebTestFixture
     {
         this.AddTokenCookie();
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/savefile/export");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/savefile/export",
+            TestContext.Current.CancellationToken
+        );
         resp.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        string content = await resp.Content.ReadAsStringAsync();
+        string content = await resp.Content.ReadAsStringAsync(
+            TestContext.Current.CancellationToken
+        );
         content.Should().StartWith("{");
     }
 
@@ -53,11 +58,14 @@ public class SavefileExportTests : WebTestFixture
                     .SetProperty(x => x.EquipCrestSlotType1CrestId3, customCrest)
             );
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/savefile/export");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/savefile/export",
+            TestContext.Current.CancellationToken
+        );
 
         DragaliaResponse<LoadIndexResponse>? deserialized = await resp.Content.ReadFromJsonAsync<
             DragaliaResponse<LoadIndexResponse>
-        >(ApiJsonOptions.Instance);
+        >(ApiJsonOptions.Instance, cancellationToken: TestContext.Current.CancellationToken);
 
         deserialized.Should().NotBeNull();
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
@@ -15,7 +15,8 @@ public partial class TimeAttackTest : TestFixture
         await this.SeedTimeAttackData();
 
         List<TimeAttackQuest>? quests = await this.Client.GetFromJsonAsync<List<TimeAttackQuest>>(
-            "/api/time_attack/quests"
+            "/api/time_attack/quests",
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         quests
@@ -36,7 +37,10 @@ public partial class TimeAttackTest : TestFixture
 
         OffsetPagedResponse<TimeAttackRanking>? rankings = await this.Client.GetFromJsonAsync<
             OffsetPagedResponse<TimeAttackRanking>
-        >("/api/time_attack/rankings/227010105");
+        >(
+            "/api/time_attack/rankings/227010105",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         rankings?.Pagination.TotalCount.Should().Be(2);
 
@@ -83,7 +87,10 @@ public partial class TimeAttackTest : TestFixture
 
         OffsetPagedResponse<TimeAttackRanking>? rankings = await this.Client.GetFromJsonAsync<
             OffsetPagedResponse<TimeAttackRanking>
-        >("/api/time_attack/rankings/227010104");
+        >(
+            "/api/time_attack/rankings/227010104",
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         rankings
             ?.Data.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Users/UserTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Users/UserTests.cs
@@ -15,7 +15,10 @@ public class UserTests : WebTestFixture
     [Fact]
     public async Task UserMe_NotAuthenticated_Returns401()
     {
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/user/me");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/user/me",
+            TestContext.Current.CancellationToken
+        );
 
         resp.Should().HaveStatusCode(HttpStatusCode.Unauthorized);
     }
@@ -32,7 +35,10 @@ public class UserTests : WebTestFixture
 
         this.Client.DefaultRequestHeaders.Add("Cookie", $"idToken={token}");
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/user/me");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/user/me",
+            TestContext.Current.CancellationToken
+        );
 
         resp.Should().HaveStatusCode(HttpStatusCode.NotFound);
     }
@@ -47,11 +53,18 @@ public class UserTests : WebTestFixture
 
         this.Client.DefaultRequestHeaders.Add("Cookie", $"idToken={token}");
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/user/me");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/user/me",
+            TestContext.Current.CancellationToken
+        );
 
         resp.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        (await resp.Content.ReadFromJsonAsync<User>())
+        (
+            await resp.Content.ReadFromJsonAsync<User>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(new User() { Name = "Euden", ViewerId = this.ViewerId });
     }
@@ -59,7 +72,10 @@ public class UserTests : WebTestFixture
     [Fact]
     public async Task UserMeProfile_Unauthenticated_Returns401()
     {
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/user/me/profile");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/user/me/profile",
+            TestContext.Current.CancellationToken
+        );
 
         resp.Should().HaveStatusCode(HttpStatusCode.Unauthorized);
     }
@@ -74,11 +90,18 @@ public class UserTests : WebTestFixture
 
         this.Client.DefaultRequestHeaders.Add("Cookie", $"idToken={token}");
 
-        HttpResponseMessage resp = await this.Client.GetAsync("/api/user/me/profile");
+        HttpResponseMessage resp = await this.Client.GetAsync(
+            "/api/user/me/profile",
+            TestContext.Current.CancellationToken
+        );
 
         resp.Should().HaveStatusCode(HttpStatusCode.OK);
 
-        (await resp.Content.ReadFromJsonAsync<UserProfile>())
+        (
+            await resp.Content.ReadFromJsonAsync<UserProfile>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(
                 new UserProfile()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Zena/ZenaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Zena/ZenaTest.cs
@@ -22,13 +22,16 @@ public class ZenaTest : TestFixture
     public async Task GetTeamData_ValidId_ReturnsTeamData()
     {
         HttpResponseMessage zenaResponse = await this.Client.GetAsync(
-            $"zena/get_team_data?id={this.ViewerId}&teamnum=1"
+            $"zena/get_team_data?id={this.ViewerId}&teamnum=1",
+            TestContext.Current.CancellationToken
         );
 
         zenaResponse.Should().BeSuccessful();
 
         GetTeamDataResponse? deserialized =
-            await zenaResponse.Content.ReadFromJsonAsync<GetTeamDataResponse>();
+            await zenaResponse.Content.ReadFromJsonAsync<GetTeamDataResponse>(
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         deserialized
             .Should()
@@ -48,13 +51,16 @@ public class ZenaTest : TestFixture
     public async Task GetTeamData_ValidId_MultiTeam_ReturnsTeamData()
     {
         HttpResponseMessage zenaResponse = await this.Client.GetAsync(
-            $"zena/get_team_data?id={this.ViewerId}&teamnum=1&teamnum2=2"
+            $"zena/get_team_data?id={this.ViewerId}&teamnum=1&teamnum2=2",
+            TestContext.Current.CancellationToken
         );
 
         zenaResponse.Should().BeSuccessful();
 
         GetTeamDataResponse? deserialized =
-            await zenaResponse.Content.ReadFromJsonAsync<GetTeamDataResponse>();
+            await zenaResponse.Content.ReadFromJsonAsync<GetTeamDataResponse>(
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         deserialized
             .Should()
@@ -78,7 +84,8 @@ public class ZenaTest : TestFixture
     public async Task GetTeamData_InvalidId_Returns404()
     {
         HttpResponseMessage zenaResponse = await this.Client.GetAsync(
-            "zena/get_team_data?id=9999&teamnum=1&teamnum2=2"
+            "zena/get_team_data?id=9999&teamnum=1&teamnum2=2",
+            TestContext.Current.CancellationToken
         );
 
         zenaResponse.Should().HaveStatusCode(HttpStatusCode.NotFound);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -14,28 +14,32 @@ public static class HttpClientExtensions
     /// <param name="endpoint">Endpoint to POST to</param>
     /// <param name="request">Request object to send</param>
     /// <param name="ensureSuccessHeader">Whether to check for a success response and throw if not successful.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns></returns>
     public static async Task<DragaliaResponse<TResponse>> PostMsgpack<TResponse>(
         this HttpClient client,
         string endpoint,
         object request,
-        bool ensureSuccessHeader = true
+        bool ensureSuccessHeader = true,
+        CancellationToken cancellationToken = default
     )
         where TResponse : class
     {
         HttpContent content = CreateMsgpackContent(request);
 
-        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), content);
+        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), content, cancellationToken);
 
         response.EnsureSuccessStatusCode();
 
-        byte[] body = await response.Content.ReadAsByteArrayAsync();
+        byte[] body = await response.Content.ReadAsByteArrayAsync(cancellationToken);
         DragaliaResponse<TResponse> deserialized = MessagePackSerializer.Deserialize<
             DragaliaResponse<TResponse>
-        >(body, CustomResolver.Options);
+        >(body, CustomResolver.Options, cancellationToken);
 
         if (ensureSuccessHeader)
+        {
             deserialized.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+        }
 
         return deserialized;
     }
@@ -43,21 +47,24 @@ public static class HttpClientExtensions
     public static async Task<DragaliaResponse<TResponse>> PostMsgpack<TResponse>(
         this HttpClient client,
         string endpoint,
-        bool ensureSuccessHeader = true
+        bool ensureSuccessHeader = true,
+        CancellationToken cancellationToken = default
     )
         where TResponse : class
     {
-        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), null);
+        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), null, cancellationToken);
 
         response.EnsureSuccessStatusCode();
 
-        byte[] body = await response.Content.ReadAsByteArrayAsync();
+        byte[] body = await response.Content.ReadAsByteArrayAsync(cancellationToken);
         DragaliaResponse<TResponse> deserialized = MessagePackSerializer.Deserialize<
             DragaliaResponse<TResponse>
-        >(body, CustomResolver.Options);
+        >(body, CustomResolver.Options, cancellationToken);
 
         if (ensureSuccessHeader)
+        {
             deserialized.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+        }
 
         return deserialized;
     }
@@ -66,8 +73,9 @@ public static class HttpClientExtensions
         this HttpClient client,
         string endpoint,
         object request,
-        bool ensureSuccessHeader = true
-    ) => await client.PostMsgpack<object>(endpoint, request, ensureSuccessHeader);
+        bool ensureSuccessHeader = true,
+        CancellationToken cancellationToken = default
+    ) => await client.PostMsgpack<object>(endpoint, request, ensureSuccessHeader, cancellationToken);
 
     /// <summary>
     /// Post a msgpack request, but do not attempt to deserialize it.

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -27,7 +27,11 @@ public static class HttpClientExtensions
     {
         HttpContent content = CreateMsgpackContent(request);
 
-        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), content, cancellationToken);
+        HttpResponseMessage response = await client.PostAsync(
+            endpoint.TrimStart('/'),
+            content,
+            cancellationToken
+        );
 
         response.EnsureSuccessStatusCode();
 
@@ -52,7 +56,11 @@ public static class HttpClientExtensions
     )
         where TResponse : class
     {
-        HttpResponseMessage response = await client.PostAsync(endpoint.TrimStart('/'), null, cancellationToken);
+        HttpResponseMessage response = await client.PostAsync(
+            endpoint.TrimStart('/'),
+            null,
+            cancellationToken
+        );
 
         response.EnsureSuccessStatusCode();
 
@@ -75,7 +83,8 @@ public static class HttpClientExtensions
         object request,
         bool ensureSuccessHeader = true,
         CancellationToken cancellationToken = default
-    ) => await client.PostMsgpack<object>(endpoint, request, ensureSuccessHeader, cancellationToken);
+    ) =>
+        await client.PostMsgpack<object>(endpoint, request, ensureSuccessHeader, cancellationToken);
 
     /// <summary>
     /// Post a msgpack request, but do not attempt to deserialize it.

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
@@ -23,10 +23,15 @@ public class AuthorizationMiddlewareTest : TestFixture
         this.Client.DefaultRequestHeaders.Clear();
         this.Client.DefaultRequestHeaders.Add("SID", "session_id");
 
-        HttpResponseMessage response = await this.Client.GetAsync(Endpoint);
+        HttpResponseMessage response = await this.Client.GetAsync(
+            Endpoint,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
-        (await response.Content.ReadAsStringAsync()).Should().Be("OK");
+        (await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken))
+            .Should()
+            .Be("OK");
     }
 
     [Fact]
@@ -35,7 +40,10 @@ public class AuthorizationMiddlewareTest : TestFixture
         this.Client.DefaultRequestHeaders.Clear();
         this.Client.DefaultRequestHeaders.Add("SID", "invalid");
 
-        HttpResponseMessage response = await this.Client.GetAsync(Endpoint);
+        HttpResponseMessage response = await this.Client.GetAsync(
+            Endpoint,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(System.Net.HttpStatusCode.BadRequest);
         response.Headers.Should().ContainKey("Session-Expired");

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/DragalipatchTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/DragalipatchTest.cs
@@ -15,12 +15,17 @@ public class DragalipatchTest : TestFixture
     [Fact]
     public async Task Config_ReturnsExpectedJson()
     {
-        HttpResponseMessage response = await this.Client.GetAsync("dragalipatch/config");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            "dragalipatch/config",
+            TestContext.Current.CancellationToken
+        );
 
         response.IsSuccessStatusCode.Should().BeTrue();
 
         DragalipatchResponse? config =
-            await response.Content.ReadFromJsonAsync<DragalipatchResponse>();
+            await response.Content.ReadFromJsonAsync<DragalipatchResponse>(
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         config.Should().NotBeNull();
         config

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/ExceptionHandlerMiddlewareTest.cs
@@ -28,7 +28,8 @@ public class ExceptionHandlerMiddlewareTest : TestFixture
             await this.Client.PostMsgpack<ResultCodeResponse>(
                 $"{Controller}/dragalia",
                 new { },
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         data.Should()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -39,9 +39,13 @@ public class GlobalQueryFilterTest : TestFixture
         // We will already have an instance for our own Viewer ID thanks to TestFixture
         this.ApiContext.Players.Add(new() { ViewerId = this.ViewerId + 1, AccountId = "other" });
         this.ApiContext.PlayerUserData.Add(new() { ViewerId = this.ViewerId + 1 });
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.ApiContext.PlayerUserData.AsNoTracking().ToListAsync())
+        (
+            await this
+                .ApiContext.PlayerUserData.AsNoTracking()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
+        )
             .Should()
             .HaveCount(1)
             .And.AllSatisfy(x => x.ViewerId.Should().Be(this.ViewerId));
@@ -89,7 +93,7 @@ public class GlobalQueryFilterTest : TestFixture
                 },
             ]
         );
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.PlayerPresentHistory.Should()
             .ContainSingle()
@@ -107,7 +111,9 @@ public class GlobalQueryFilterTest : TestFixture
     [Fact]
     public async Task DbPlayerDmodeInfo_HasGlobalQueryFilter()
     {
-        await this.ApiContext.PlayerDmodeInfos.ExecuteDeleteAsync();
+        await this.ApiContext.PlayerDmodeInfos.ExecuteDeleteAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
         await TestGlobalQueryFilter<DbPlayerDmodeInfo>();
     }
 
@@ -116,9 +122,13 @@ public class GlobalQueryFilterTest : TestFixture
     {
         this.ApiContext.Players.Add(new() { ViewerId = this.ViewerId + 1, AccountId = "other" });
         this.ApiContext.PlayerDiamondData.Add(new() { ViewerId = this.ViewerId + 1 });
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
-        (await this.ApiContext.PlayerDiamondData.AsNoTracking().ToListAsync())
+        (
+            await this
+                .ApiContext.PlayerDiamondData.AsNoTracking()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
+        )
             .Should()
             .HaveCount(1)
             .And.AllSatisfy(x => x.ViewerId.Should().Be(this.ViewerId));

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/HeroParamTest.cs
@@ -14,13 +14,16 @@ public class HeroParamTest : TestFixture
     {
         await this.ImportSave();
 
-        HttpResponseMessage httpResponse = await this.Client.GetAsync($"heroparam/{ViewerId}/1");
+        HttpResponseMessage httpResponse = await this.Client.GetAsync(
+            $"heroparam/{ViewerId}/1",
+            TestContext.Current.CancellationToken
+        );
 
         httpResponse.StatusCode.Should().Be(HttpStatusCode.OK);
 
-        List<HeroParam>? heroParams = await httpResponse.Content.ReadFromJsonAsync<
-            List<HeroParam>
-        >();
+        List<HeroParam>? heroParams = await httpResponse.Content.ReadFromJsonAsync<List<HeroParam>>(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         Verify(heroParams);
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/OutputCachingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/OutputCachingTest.cs
@@ -33,7 +33,8 @@ public class OutputCachingTest : TestFixture
             await this.Client.PostMsgpack<FortBuildEndResponse>(
                 "/fort/levelup_end",
                 new FortBuildEndRequest(build.BuildId),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
@@ -42,7 +43,8 @@ public class OutputCachingTest : TestFixture
             await this.Client.PostMsgpack<FortBuildEndResponse>(
                 "/fort/levelup_end",
                 new FortBuildEndRequest(build.BuildId),
-                ensureSuccessHeader: false
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         // Ordinarily this request would fail because the building is no longer being upgraded.

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -28,7 +28,8 @@ public class SavefileImportTest : TestFixture
 
         HttpResponseMessage importResponse = await this.Client.PostAsync(
             $"savefile/import/1",
-            JsonContent.Create(new { })
+            JsonContent.Create(new { }),
+            TestContext.Current.CancellationToken
         );
 
         importResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -42,7 +43,8 @@ public class SavefileImportTest : TestFixture
 
         HttpResponseMessage importResponse = await this.Client.PostAsync(
             $"savefile/import/1",
-            JsonContent.Create(new { })
+            JsonContent.Create(new { }),
+            TestContext.Current.CancellationToken
         );
 
         importResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -65,7 +67,8 @@ public class SavefileImportTest : TestFixture
 
         HttpResponseMessage importResponse = await this.Client.PostAsync(
             $"savefile/import/{this.ViewerId}",
-            content
+            content,
+            TestContext.Current.CancellationToken
         );
         importResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
@@ -75,7 +78,10 @@ public class SavefileImportTest : TestFixture
             .BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(1));
 
         LoadIndexResponse storedSavefile = (
-            await this.Client.PostMsgpack<LoadIndexResponse>("load/index")
+            await this.Client.PostMsgpack<LoadIndexResponse>(
+                "load/index",
+                cancellationToken: TestContext.Current.CancellationToken
+            )
         ).Data;
 
         storedSavefile.UserData.Exp.Should().Be(savefile.UserData.Exp + 69990); // Exp rewarded from V22Update
@@ -159,7 +165,11 @@ public class SavefileImportTest : TestFixture
     public async Task Import_PropertiesMappedCorrectly()
     {
         HttpContent content = PrepareSavefileRequest("endgame_savefile.json");
-        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+        await this.Client.PostAsync(
+            $"savefile/import/{this.ViewerId}",
+            content,
+            TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.PlayerStoryState.Single(x =>
                 x.ViewerId == this.ViewerId && x.StoryId == 110313011
@@ -184,7 +194,11 @@ public class SavefileImportTest : TestFixture
         this.ApiContext.ChangeTracker.Clear();
 
         HttpContent content = PrepareSavefileRequest("endgame_savefile.json");
-        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+        await this.Client.PostAsync(
+            $"savefile/import/{this.ViewerId}",
+            content,
+            TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.Emblems.AsNoTracking()
             .Should()
@@ -202,7 +216,11 @@ public class SavefileImportTest : TestFixture
             );
 
         HttpContent content = PrepareSavefileRequest("endgame_savefile.json");
-        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+        await this.Client.PostAsync(
+            $"savefile/import/{this.ViewerId}",
+            content,
+            TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.PlayerDragonGifts.Should()
             .Contain(x =>
@@ -218,7 +236,11 @@ public class SavefileImportTest : TestFixture
         );
 
         HttpContent content = PrepareSavefileRequest("endgame_savefile.json");
-        await this.Client.PostAsync($"savefile/import/{this.ViewerId}", content);
+        await this.Client.PostAsync(
+            $"savefile/import/{this.ViewerId}",
+            content,
+            TestContext.Current.CancellationToken
+        );
 
         this.ApiContext.CompletedDailyMissions.Should()
             .NotContain(x => x.ViewerId == this.ViewerId);
@@ -231,13 +253,15 @@ public class SavefileImportTest : TestFixture
 
         HttpResponseMessage importResponse = await this.Client.PostAsync(
             $"savefile/import/{this.ViewerId}",
-            content
+            content,
+            TestContext.Current.CancellationToken
         );
         importResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 
         HttpResponseMessage importResponse2 = await this.Client.PostAsync(
             $"savefile/import/{this.ViewerId}",
-            content
+            content,
+            TestContext.Current.CancellationToken
         );
         importResponse2.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
@@ -250,7 +274,8 @@ public class SavefileImportTest : TestFixture
 
         HttpResponseMessage importResponse = await this.Client.PostAsync(
             $"savefile/import/{this.ViewerId}",
-            content
+            content,
+            TestContext.Current.CancellationToken
         );
         importResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
 

--- a/DragaliaAPI/DragaliaAPI.Shared.SourceGenerator/MasterAssetGenerator.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared.SourceGenerator/MasterAssetGenerator.cs
@@ -225,7 +225,7 @@ public class MasterAssetGenerator : IIncrementalGenerator
                     {loadMethodName}(
                         "{msgpackPath}",
                         ({declaration.ItemTypeName} x) => x.{declaration.KeyName}{(
-                    declaration.IsGroup ? "": ","
+                    declaration.IsGroup ? "" : ","
                 )}
                 """
             );

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/AbilityCrestControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/AbilityCrestControllerTest.cs
@@ -48,7 +48,7 @@ public class AbilityCrestControllerTest
         ResultCodeResponse response = (
             await this.abilityCrestController.SetFavorite(
                 new() { AbilityCrestId = AbilityCrestId.ManaFount, IsFavorite = true },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -60,7 +60,10 @@ public class AbilityCrestControllerTest
     public async Task BuildupPiece_AbilityCrestNotInMasterAssetReturnsError()
     {
         ResultCodeResponse response = (
-            await this.abilityCrestController.BuildupPiece(new() { AbilityCrestId = 0 }, default)
+            await this.abilityCrestController.BuildupPiece(
+                new() { AbilityCrestId = 0 },
+                TestContext.Current.CancellationToken
+            )
         ).GetData<ResultCodeResponse>()!;
 
         response.ResultCode.Should().Be(ResultCode.AbilityCrestIsNotPlayable);
@@ -91,7 +94,7 @@ public class AbilityCrestControllerTest
                         new(),
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -110,7 +113,9 @@ public class AbilityCrestControllerTest
             )
             .ReturnsAsync(ResultCode.Success);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestBuildupPieceResponse data = (
@@ -125,7 +130,7 @@ public class AbilityCrestControllerTest
                         new(),
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestBuildupPieceResponse>()!;
 
@@ -140,7 +145,7 @@ public class AbilityCrestControllerTest
         ResultCodeResponse response = (
             await this.abilityCrestController.BuildupPlusCount(
                 new() { AbilityCrestId = 0 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -166,7 +171,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestId = AbilityCrestId.ManaFount,
                     PlusCountParamsList = new List<AtgenPlusCountParamsList>() { new(), new() },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -186,7 +191,9 @@ public class AbilityCrestControllerTest
             .ReturnsAsync(ResultCode.Success)
             .ReturnsAsync(ResultCode.Success);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestBuildupPlusCountResponse data = (
@@ -196,7 +203,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestId = AbilityCrestId.ManaFount,
                     PlusCountParamsList = new List<AtgenPlusCountParamsList>() { new(), new() },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestBuildupPlusCountResponse>()!;
 
@@ -221,7 +228,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestId = AbilityCrestId.ManaFount,
                     PlusCountTypeList = new List<PlusCountType>() { PlusCountType.Hp, 0 },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -238,7 +245,9 @@ public class AbilityCrestControllerTest
             .ReturnsAsync(ResultCode.Success)
             .ReturnsAsync(ResultCode.Success);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestResetPlusCountResponse data = (
@@ -252,7 +261,7 @@ public class AbilityCrestControllerTest
                         PlusCountType.Atk,
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestResetPlusCountResponse>()!;
 
@@ -268,7 +277,9 @@ public class AbilityCrestControllerTest
             .Returns(new List<DbAbilityCrestSet>().AsQueryable().BuildMock());
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
-            await this.abilityCrestController.GetAbilityCrestSetList(default)
+            await this.abilityCrestController.GetAbilityCrestSetList(
+                TestContext.Current.CancellationToken
+            )
         ).GetData<AbilityCrestGetAbilityCrestSetListResponse>()!;
 
         int setNo = 1;
@@ -324,7 +335,9 @@ public class AbilityCrestControllerTest
             );
 
         AbilityCrestGetAbilityCrestSetListResponse data = (
-            await this.abilityCrestController.GetAbilityCrestSetList(default)
+            await this.abilityCrestController.GetAbilityCrestSetList(
+                TestContext.Current.CancellationToken
+            )
         ).GetData<AbilityCrestGetAbilityCrestSetListResponse>()!;
 
         int setNo = 1;
@@ -384,7 +397,7 @@ public class AbilityCrestControllerTest
         ResultCodeResponse response = (
             await this.abilityCrestController.SetAbilityCrestSet(
                 new() { AbilityCrestSetNo = setNo },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -401,7 +414,9 @@ public class AbilityCrestControllerTest
             )
             .Returns(Task.CompletedTask);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestSetAbilityCrestSetResponse data = (
@@ -412,7 +427,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestSetNo = setNo,
                     RequestAbilityCrestSetData = new() { },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestSetAbilityCrestSetResponse>()!;
 
@@ -438,7 +453,9 @@ public class AbilityCrestControllerTest
             )
             .Returns(Task.CompletedTask);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestUpdateAbilityCrestSetNameResponse data = (
@@ -448,7 +465,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestSetNo = setNo,
                     AbilityCrestSetName = newName,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestUpdateAbilityCrestSetNameResponse>()!;
 
@@ -472,7 +489,9 @@ public class AbilityCrestControllerTest
                 }
             );
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList() { });
 
         AbilityCrestUpdateAbilityCrestSetNameResponse data = (
@@ -482,7 +501,7 @@ public class AbilityCrestControllerTest
                     AbilityCrestSetNo = setNo,
                     AbilityCrestSetName = newName,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<AbilityCrestUpdateAbilityCrestSetNameResponse>()!;
 

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/PartyControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/PartyControllerTest.cs
@@ -62,13 +62,15 @@ public class PartyControllerTest : RepositoryTestFixture
                     new() { PartyName = "Z Team", PartyNo = 1 },
                 },
             };
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(updateDataList);
 
         PartyUpdatePartyNameResponse? response = (
             await this.partyController.UpdatePartyName(
                 new PartyUpdatePartyNameRequest() { PartyName = "Z Team", PartyNo = 1 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<PartyUpdatePartyNameResponse>();
 

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/QuestControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/QuestControllerTest.cs
@@ -68,13 +68,15 @@ public class QuestControllerTest
             );
         this.mockStoryService.Setup(x => x.GetEntityResult()).Returns(entityResult);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList());
 
         (
             await this.questController.ReadStory(
                 new QuestReadStoryRequest() { QuestStoryId = 1 },
-                default
+                TestContext.Current.CancellationToken
             )
         )
             .GetData<QuestReadStoryResponse>()

--- a/DragaliaAPI/DragaliaAPI.Test/Controllers/WeaponBodyControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Controllers/WeaponBodyControllerTest.cs
@@ -34,7 +34,9 @@ public class WeaponBodyControllerTest
         this.mockWeaponService.Setup(x => x.Craft(WeaponBodies.Areadbhar))
             .Returns(Task.CompletedTask);
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(
                 new UpdateDataList()
                 {
@@ -48,7 +50,7 @@ public class WeaponBodyControllerTest
         WeaponBodyCraftResponse data = (
             await this.weaponBodyController.Craft(
                 new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.Areadbhar },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<WeaponBodyCraftResponse>()!;
 
@@ -69,7 +71,7 @@ public class WeaponBodyControllerTest
         ResultCodeResponse response = (
             await this.weaponBodyController.Craft(
                 new WeaponBodyCraftRequest() { WeaponBodyId = WeaponBodies.Areadbhar },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -82,7 +84,7 @@ public class WeaponBodyControllerTest
         ResultCodeResponse response = (
             await this.weaponBodyController.BuildupPiece(
                 new WeaponBodyBuildupPieceRequest() { WeaponBodyId = (WeaponBodies)8 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -97,7 +99,7 @@ public class WeaponBodyControllerTest
         ResultCodeResponse response = (
             await this.weaponBodyController.BuildupPiece(
                 new WeaponBodyBuildupPieceRequest() { WeaponBodyId = WeaponBodies.Caduceus },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -131,7 +133,7 @@ public class WeaponBodyControllerTest
                         new(),
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<ResultCodeResponse>()!;
 
@@ -159,7 +161,10 @@ public class WeaponBodyControllerTest
                     new() { WeaponBodyId = WeaponBodies.Caduceus },
                 },
             };
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(udl);
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
+            .ReturnsAsync(udl);
 
         WeaponBodyBuildupPieceResponse data = (
             await this.weaponBodyController.BuildupPiece(
@@ -173,7 +178,7 @@ public class WeaponBodyControllerTest
                         new(),
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<WeaponBodyBuildupPieceResponse>()!;
 

--- a/DragaliaAPI/DragaliaAPI.Test/Features/AbilityCrests/AbilityCrestRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/AbilityCrests/AbilityCrestRepositoryTest.cs
@@ -33,7 +33,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
     public async Task Add_AddsToDatabase()
     {
         await this.abilityCrestRepository.Add(AbilityCrestId.ADogsDay);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerAbilityCrests.Single(x =>
                 x.AbilityCrestId == AbilityCrestId.ADogsDay
@@ -53,7 +53,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
     public async Task Add_AbilityCrestAlreadyExistsWarnsLogger()
     {
         await this.abilityCrestRepository.Add(AbilityCrestId.ADragonyuleforIlia);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.abilityCrestRepository.Add(AbilityCrestId.ADragonyuleforIlia);
         this.logger.Verify(
@@ -80,7 +80,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
     public async Task FindAsync_FindsAbilityCrestAsExpected()
     {
         await this.abilityCrestRepository.Add(AbilityCrestId.FlashofGenius);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (await this.abilityCrestRepository.FindAsync(AbilityCrestId.FlashofGenius))
             .Should()
@@ -103,7 +103,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
         await this.abilityCrestRepository.AddOrUpdateSet(
             new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 54)
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerAbilityCrestSets.Single(x =>
                 x.ViewerId == IdentityTestUtils.ViewerId && x.AbilityCrestSetNo == 54
@@ -119,7 +119,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
                 CrestSlotType1CrestId1 = AbilityCrestId.WorthyRivals,
             }
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerAbilityCrestSets.Single(x =>
                 x.ViewerId == IdentityTestUtils.ViewerId && x.AbilityCrestSetNo == 54
@@ -141,7 +141,7 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
         await this.abilityCrestRepository.AddOrUpdateSet(
             new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 1)
         );
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (await this.abilityCrestRepository.FindSetAsync(1))
             .Should()

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeControllerTest.cs
@@ -51,7 +51,9 @@ public class DmodeControllerTest
     public async Task GetData_ReturnsData()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         DmodeInfo info =
             new(50, 0, DateTimeOffset.UnixEpoch, 0, DateTimeOffset.UnixEpoch, 100, 50, true);
@@ -94,7 +96,7 @@ public class DmodeControllerTest
         mockDmodeService.Setup(x => x.GetServitorPassiveList()).ReturnsAsync(passiveList);
 
         DmodeGetDataResponse? resp = (
-            await dmodeController.GetData(default)
+            await dmodeController.GetData(TestContext.Current.CancellationToken)
         ).GetData<DmodeGetDataResponse>();
 
         resp.Should().NotBeNull();
@@ -116,7 +118,9 @@ public class DmodeControllerTest
     public async Task Entry_InitializesData()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         mockDmodeRepository.Setup(x => x.InitializeForPlayer());
 
@@ -161,7 +165,7 @@ public class DmodeControllerTest
         mockDmodeService.Setup(x => x.GetServitorPassiveList()).ReturnsAsync(passiveList);
 
         DmodeGetDataResponse? resp = (
-            await dmodeController.Entry(default)
+            await dmodeController.Entry(TestContext.Current.CancellationToken)
         ).GetData<DmodeGetDataResponse>();
 
         resp.Should().NotBeNull();
@@ -194,10 +198,15 @@ public class DmodeControllerTest
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(entityResult);
 
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         DmodeReadStoryResponse? resp = (
-            await dmodeController.ReadStory(new DmodeReadStoryRequest(1000), default)
+            await dmodeController.ReadStory(
+                new DmodeReadStoryRequest(1000),
+                TestContext.Current.CancellationToken
+            )
         ).GetData<DmodeReadStoryResponse>();
 
         resp.Should().NotBeNull();
@@ -215,7 +224,9 @@ public class DmodeControllerTest
     public async Task BuildupServitorPassive_BuildsupServitor()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         List<DmodeServitorPassiveList> passiveList =
             new() { new DmodeServitorPassiveList(DmodeServitorPassiveType.Exp, 5) };
@@ -227,7 +238,7 @@ public class DmodeControllerTest
         DmodeBuildupServitorPassiveResponse? resp = (
             await dmodeController.BuildupServitorPassive(
                 new DmodeBuildupServitorPassiveRequest(passiveList),
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<DmodeBuildupServitorPassiveResponse>();
 
@@ -243,7 +254,9 @@ public class DmodeControllerTest
     public async Task ExpeditionStart_StartsExpedition()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         List<Charas> charaIdList = new() { Charas.ThePrince, 0, 0, 0 };
 
@@ -256,7 +269,7 @@ public class DmodeControllerTest
         DmodeExpeditionStartResponse? resp = (
             await dmodeController.ExpeditionStart(
                 new DmodeExpeditionStartRequest(10, charaIdList),
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<DmodeExpeditionStartResponse>();
 
@@ -268,7 +281,9 @@ public class DmodeControllerTest
     public async Task ExpeditionFinish_FinishesExpedition()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         EntityResult entityResult = new();
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(entityResult);
@@ -283,7 +298,7 @@ public class DmodeControllerTest
             .ReturnsAsync((expedition, ingameResult));
 
         DmodeExpeditionFinishResponse? resp = (
-            await dmodeController.ExpeditionFinish(default)
+            await dmodeController.ExpeditionFinish(TestContext.Current.CancellationToken)
         ).GetData<DmodeExpeditionFinishResponse>();
 
         resp.Should().NotBeNull();
@@ -300,7 +315,9 @@ public class DmodeControllerTest
     public async Task ExpeditionForceFinish_FinishesExpeditionForced()
     {
         UpdateDataList updateDataList = new();
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         EntityResult entityResult = new();
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(entityResult);
@@ -315,7 +332,7 @@ public class DmodeControllerTest
             .ReturnsAsync((expedition, ingameResult));
 
         DmodeExpeditionForceFinishResponse? resp = (
-            await dmodeController.ExpeditionForceFinish(default)
+            await dmodeController.ExpeditionForceFinish(TestContext.Current.CancellationToken)
         ).GetData<DmodeExpeditionForceFinishResponse>();
 
         resp.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
@@ -29,7 +29,9 @@ public class DmodeDungeonControllerTest
             mockRewardService.Object
         );
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(updateDataList);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
@@ -52,7 +52,7 @@ public class DmodeDungeonControllerTest
             .ReturnsAsync((state, ingameData));
 
         DmodeDungeonStartResponse? resp = (
-            await dmodeDungeonController.Start(request, default)
+            await dmodeDungeonController.Start(request, TestContext.Current.CancellationToken)
         ).GetData<DmodeDungeonStartResponse>();
 
         resp.Should().NotBeNull();
@@ -72,7 +72,7 @@ public class DmodeDungeonControllerTest
         mockDmodeDungeonService.Setup(x => x.RestartDungeon()).ReturnsAsync((state, ingameData));
 
         DmodeDungeonRestartResponse? resp = (
-            await dmodeDungeonController.Restart(default)
+            await dmodeDungeonController.Restart(TestContext.Current.CancellationToken)
         ).GetData<DmodeDungeonRestartResponse>();
 
         resp.Should().NotBeNull();
@@ -105,7 +105,10 @@ public class DmodeDungeonControllerTest
             .ReturnsAsync((state, floorData));
 
         DmodeDungeonFloorResponse? resp = (
-            await dmodeDungeonController.Floor(new DmodeDungeonFloorRequest(playRecord), default)
+            await dmodeDungeonController.Floor(
+                new DmodeDungeonFloorRequest(playRecord),
+                TestContext.Current.CancellationToken
+            )
         ).GetData<DmodeDungeonFloorResponse>();
 
         resp.Should().NotBeNull();
@@ -133,7 +136,10 @@ public class DmodeDungeonControllerTest
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(entityResult);
 
         DmodeDungeonFinishResponse? resp = (
-            await dmodeDungeonController.Finish(new DmodeDungeonFinishRequest(isGameOver), default)
+            await dmodeDungeonController.Finish(
+                new DmodeDungeonFinishRequest(isGameOver),
+                TestContext.Current.CancellationToken
+            )
         ).GetData<DmodeDungeonFinishResponse>();
 
         resp.Should().NotBeNull();
@@ -155,7 +161,7 @@ public class DmodeDungeonControllerTest
         mockDmodeDungeonService.Setup(x => x.SkipFloor()).ReturnsAsync(state);
 
         DmodeDungeonFloorSkipResponse? resp = (
-            await dmodeDungeonController.FloorSkip(default)
+            await dmodeDungeonController.FloorSkip(TestContext.Current.CancellationToken)
         ).GetData<DmodeDungeonFloorSkipResponse>();
 
         resp.Should().NotBeNull();
@@ -174,7 +180,7 @@ public class DmodeDungeonControllerTest
         mockDmodeDungeonService.Setup(x => x.HaltDungeon(true)).ReturnsAsync(state);
 
         DmodeDungeonUserHaltResponse? resp = (
-            await dmodeDungeonController.UserHalt(default)
+            await dmodeDungeonController.UserHalt(TestContext.Current.CancellationToken)
         ).GetData<DmodeDungeonUserHaltResponse>();
 
         resp.Should().NotBeNull();
@@ -193,7 +199,7 @@ public class DmodeDungeonControllerTest
         mockDmodeDungeonService.Setup(x => x.HaltDungeon(false)).ReturnsAsync(state);
 
         DmodeDungeonSystemHaltResponse? resp = (
-            await dmodeDungeonController.SystemHalt(default)
+            await dmodeDungeonController.SystemHalt(TestContext.Current.CancellationToken)
         ).GetData<DmodeDungeonSystemHaltResponse>();
 
         resp.Should().NotBeNull();

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dmode/DmodeDungeonControllerTest.cs
@@ -29,7 +29,7 @@ public class DmodeDungeonControllerTest
             mockRewardService.Object
         );
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService.Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>())).ReturnsAsync(updateDataList);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
@@ -42,7 +42,9 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             partySlot
         );
 
-        DbDetailedPartyUnit result = await buildQuery.FirstAsync();
+        DbDetailedPartyUnit result = await buildQuery.FirstAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         result.Should().BeEquivalentTo(expectedResult);
     }
@@ -55,13 +57,15 @@ public class DungeonRepositoryTest : RepositoryTestFixture
         IEnumerable<PartySettingList> party = (
             await this
                 .ApiContext.PlayerPartyUnits.Where(x => x.ViewerId == ViewerId && x.PartyNo == 1)
-                .ToListAsync()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
         ).Select(this.Mapper.Map<PartySettingList>);
 
         IEnumerable<IQueryable<DbDetailedPartyUnit>> buildQuery =
             this.dungeonRepository.BuildDetailedPartyUnit(party);
 
-        DbDetailedPartyUnit result = await buildQuery.First().FirstAsync();
+        DbDetailedPartyUnit result = await buildQuery
+            .First()
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
         result.Should().BeEquivalentTo(expectedResult);
     }

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Fort/FortControllerTest.cs
@@ -60,7 +60,7 @@ public class FortControllerTest
             .ReturnsAsync(new AtgenProductionRp(0, 0));
 
         mockUpdateDataService
-            .Setup(x => x.SaveChangesAsync(default))
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
             .ReturnsAsync(new UpdateDataList());
 
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
@@ -71,7 +71,7 @@ public class FortControllerTest
         this.mockDragonService.Setup(x => x.GetFreeGiftCount()).ReturnsAsync(2);
 
         FortGetDataResponse data = (
-            await fortController.GetData(default)
+            await fortController.GetData(TestContext.Current.CancellationToken)
         ).GetData<FortGetDataResponse>()!;
 
         data.BuildList.Should().BeEquivalentTo(buildList);
@@ -94,12 +94,14 @@ public class FortControllerTest
             .ReturnsAsync(new FortDetail());
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortAddCarpenterResponse data = (
             await fortController.AddCarpenter(
                 new FortAddCarpenterRequest() { PaymentType = PaymentTypes.Diamantium },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortAddCarpenterResponse>()!;
 
@@ -137,7 +139,9 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortBuildAtOnceResponse data = (
             await fortController.BuildAtOnce(
@@ -146,7 +150,7 @@ public class FortControllerTest
                     PaymentType = PaymentTypes.HalidomHustleHammer,
                     BuildId = 8,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortBuildAtOnceResponse>()!;
 
@@ -172,10 +176,15 @@ public class FortControllerTest
             .ReturnsAsync(new DbFortBuild() { ViewerId = 1, BuildId = 1 });
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortBuildCancelResponse data = (
-            await fortController.BuildCancel(new FortBuildCancelRequest() { BuildId = 1 }, default)
+            await fortController.BuildCancel(
+                new FortBuildCancelRequest() { BuildId = 1 },
+                TestContext.Current.CancellationToken
+            )
         ).GetData<FortBuildCancelResponse>()!;
 
         data.Result.Should().Be(1);
@@ -211,10 +220,15 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortBuildEndResponse data = (
-            await fortController.BuildEnd(new FortBuildEndRequest() { BuildId = 8 }, default)
+            await fortController.BuildEnd(
+                new FortBuildEndRequest() { BuildId = 8 },
+                TestContext.Current.CancellationToken
+            )
         ).GetData<FortBuildEndResponse>()!;
 
         data.Result.Should().Be(1);
@@ -247,7 +261,9 @@ public class FortControllerTest
             .Setup(x => x.BuildStart(FortPlants.BroadleafTree, 2, 3))
             .ReturnsAsync(build);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortBuildStartResponse data = (
             await fortController.BuildStart(
@@ -257,7 +273,7 @@ public class FortControllerTest
                     PositionX = 2,
                     PositionZ = 3,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortBuildStartResponse>()!;
 
@@ -300,7 +316,9 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortLevelupAtOnceResponse data = (
             await fortController.LevelupAtOnce(
@@ -309,7 +327,7 @@ public class FortControllerTest
                     PaymentType = PaymentTypes.HalidomHustleHammer,
                     BuildId = 8,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortLevelupAtOnceResponse>()!;
 
@@ -337,12 +355,14 @@ public class FortControllerTest
             .ReturnsAsync(new DbFortBuild() { ViewerId = 1, BuildId = 1 });
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortLevelupCancelResponse data = (
             await fortController.LevelupCancel(
                 new FortLevelupCancelRequest() { BuildId = 1 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortLevelupCancelResponse>()!;
 
@@ -380,10 +400,15 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortLevelupEndResponse data = (
-            await fortController.LevelupEnd(new FortLevelupEndRequest() { BuildId = 8 }, default)
+            await fortController.LevelupEnd(
+                new FortLevelupEndRequest() { BuildId = 8 },
+                TestContext.Current.CancellationToken
+            )
         ).GetData<FortLevelupEndResponse>()!;
 
         data.Result.Should().Be(1);
@@ -418,12 +443,14 @@ public class FortControllerTest
         mockFortService.Setup(x => x.GetFortDetail()).ReturnsAsync(detail);
         mockFortService.Setup(x => x.LevelupStart(1)).ReturnsAsync(build);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortLevelupStartResponse data = (
             await fortController.LevelupStart(
                 new FortLevelupStartRequest() { BuildId = 1 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortLevelupStartResponse>()!;
 
@@ -463,7 +490,9 @@ public class FortControllerTest
 
         mockBonusService.Setup(x => x.GetBonusList()).ReturnsAsync(bonusList);
 
-        mockUpdateDataService.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(updateDataList);
+        mockUpdateDataService
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .ReturnsAsync(updateDataList);
 
         FortMoveResponse data = (
             await fortController.Move(
@@ -473,7 +502,7 @@ public class FortControllerTest
                     AfterPositionX = 2,
                     AfterPositionZ = 3,
                 },
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<FortMoveResponse>()!;
 

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Missions/MissionControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Missions/MissionControllerTest.cs
@@ -153,13 +153,15 @@ public class MissionControllerTest
                 }
             );
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList());
 
         DragaliaResult<MissionUnlockDrillMissionGroupResponse> resp =
             await this.missionController.UnlockDrillMissionGroup(
                 new MissionUnlockDrillMissionGroupRequest(100),
-                default
+                TestContext.Current.CancellationToken
             );
 
         MissionUnlockDrillMissionGroupResponse? response = resp.Value;
@@ -193,13 +195,15 @@ public class MissionControllerTest
         this.mockMissionService.Setup(x => x.UnlockMainMissionGroup(100))
             .ReturnsAsync((new[] { fakeReward }, new[] { fakeMission }));
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList());
 
         DragaliaResult<MissionUnlockMainStoryGroupResponse> resp =
             await this.missionController.UnlockMainStoryMissionGroup(
                 new MissionUnlockMainStoryGroupRequest(100),
-                default
+                TestContext.Current.CancellationToken
             );
 
         MissionUnlockMainStoryGroupResponse? response = resp.Value;
@@ -243,7 +247,9 @@ public class MissionControllerTest
         this.mockMissionService.Setup(x => x.GetCompletedDrillGroups())
             .ReturnsAsync(new List<DrillMissionGroupList>() { new(1) });
 
-        this.mockUpdateDataService.Setup(x => x.SaveChangesAsync(default))
+        this.mockUpdateDataService.Setup(x =>
+                x.SaveChangesAsync(TestContext.Current.CancellationToken)
+            )
             .ReturnsAsync(new UpdateDataList());
 
         this.mockMissionRepository.Setup(x => x.GetMissionsByType(MissionType.Drill))
@@ -254,7 +260,7 @@ public class MissionControllerTest
         DragaliaResult<MissionReceiveDrillRewardResponse> resp =
             await this.missionController.ReceiveDrillStoryReward(
                 new MissionReceiveDrillRewardRequest(fakeIdList, Enumerable.Empty<int>()),
-                default
+                TestContext.Current.CancellationToken
             );
 
         MissionReceiveDrillRewardResponse? response = resp.Value;

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Summon/UnitServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Summon/UnitServiceTest.cs
@@ -92,17 +92,21 @@ public class UnitServiceTest : IClassFixture<DbTestFixture>
         List<Charas> idList = new() { Charas.Addis, Charas.Aeleen };
 
         await this.unitService.AddCharas(idList);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (
             await this
                 .fixture.ApiContext.PlayerCharaData.Where(x => x.ViewerId == ViewerId)
                 .Select(x => x.CharaId)
-                .ToListAsync()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
         )
             .Should()
             .Contain(new List<Charas>() { Charas.Addis, Charas.Aeleen });
-        (await this.fixture.ApiContext.PlayerStoryState.Select(x => x.StoryId).ToListAsync())
+        (
+            await this
+                .fixture.ApiContext.PlayerStoryState.Select(x => x.StoryId)
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
+        )
             .Should()
             .Contain(
                 new List<int>()
@@ -148,7 +152,7 @@ public class UnitServiceTest : IClassFixture<DbTestFixture>
 
         await this.unitService.AddCharas(idList);
 
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerStoryState.Should()
             .ContainEquivalentOf(
@@ -210,7 +214,7 @@ public class UnitServiceTest : IClassFixture<DbTestFixture>
         List<Dragons> idList = [Dragons.AC011Garland, Dragons.Agni];
 
         await this.unitService.AddDragons(idList);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.fixture.ApiContext.PlayerDragonReliability.Should()
             .ContainEquivalentOf(
@@ -230,13 +234,13 @@ public class UnitServiceTest : IClassFixture<DbTestFixture>
         List<Dragons> idList = new() { Dragons.KonohanaSakuya, Dragons.Michael, Dragons.Michael };
 
         await this.unitService.AddDragons(idList);
-        await this.fixture.ApiContext.SaveChangesAsync();
+        await this.fixture.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (
             await this
                 .fixture.ApiContext.PlayerDragonData.Where(x => x.ViewerId == ViewerId)
                 .Select(x => x.DragonId)
-                .ToListAsync()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
         )
             .Should()
             .Contain(
@@ -253,7 +257,7 @@ public class UnitServiceTest : IClassFixture<DbTestFixture>
             await this
                 .fixture.ApiContext.PlayerDragonReliability.Where(x => x.ViewerId == ViewerId)
                 .Select(x => x.DragonId)
-                .ToListAsync()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
         )
             .Should()
             .Contain(new List<Dragons>() { Dragons.KonohanaSakuya, Dragons.Michael });

--- a/DragaliaAPI/DragaliaAPI.Test/Features/TimeAttack/TimeAttackRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/TimeAttack/TimeAttackRepositoryTest.cs
@@ -40,7 +40,7 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
             };
 
         await this.timeAttackRepository.CreateOrUpdateClear(clear);
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.TimeAttackClears.Should().ContainEquivalentOf(clear);
     }
@@ -67,7 +67,7 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await this.timeAttackRepository.CreateOrUpdateClear(
             new()
@@ -86,7 +86,7 @@ public class TimeAttackRepositoryTest : RepositoryTestFixture
             }
         );
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.TimeAttackClears.Should().Contain(x => x.GameId == gameId);
         this.ApiContext.TimeAttackClears.First(x => x.GameId == gameId)

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallControllerTest.cs
@@ -131,11 +131,11 @@ public class WallControllerTest
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(new EntityResult());
 
         mockUpdateDataService
-            .Setup(x => x.SaveChangesAsync(default))
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
             .ReturnsAsync(new UpdateDataList());
 
         WallReceiveMonthlyRewardResponse data = (
-            await wallController.ReceiveMonthlyReward(default)
+            await wallController.ReceiveMonthlyReward(TestContext.Current.CancellationToken)
         ).GetData<WallReceiveMonthlyRewardResponse>()!;
 
         data.UserWallRewardList.Should().ContainSingle().Which.Should().BeEquivalentTo(rewardList);

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
@@ -74,11 +74,11 @@ public class WallRecordControllerTest
                 WallLevel = wallLevel,
             };
 
-        this.mockDungeonService.Setup(x => x.GetSession(dungeonKey, CancellationToken.None))
+        this.mockDungeonService.Setup(x => x.GetSession(dungeonKey, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
         mockDungeonService
-            .Setup(x => x.RemoveSession(dungeonKey, CancellationToken.None))
+            .Setup(x => x.RemoveSession(dungeonKey, It.IsAny<CancellationToken>()))
             .Returns(Task.CompletedTask);
 
         mockWallService.Setup(x => x.GetQuestWall(wallId)).ReturnsAsync(playerQuestWall);
@@ -105,7 +105,7 @@ public class WallRecordControllerTest
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(new EntityResult());
 
         mockUpdateDataService
-            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
+            .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UpdateDataList());
 
         WallRecordRecordResponse data = (

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallRecordControllerTest.cs
@@ -105,13 +105,13 @@ public class WallRecordControllerTest
         mockRewardService.Setup(x => x.GetEntityResult()).Returns(new EntityResult());
 
         mockUpdateDataService
-            .Setup(x => x.SaveChangesAsync(default))
+            .Setup(x => x.SaveChangesAsync(TestContext.Current.CancellationToken))
             .ReturnsAsync(new UpdateDataList());
 
         WallRecordRecordResponse data = (
             await wallRecordController.Record(
                 new WallRecordRecordRequest(wallId, dungeonKey),
-                default
+                TestContext.Current.CancellationToken
             )
         ).GetData<WallRecordRecordResponse>()!;
 

--- a/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Services/DragonServiceTest.cs
@@ -168,7 +168,7 @@ public class DragonServiceTest : RepositoryTestFixture
                         DragonGifts.CompellingBook,
                     },
                 },
-                default
+                TestContext.Current.CancellationToken
             );
 
         responseData.Should().NotBeNull();
@@ -227,7 +227,7 @@ public class DragonServiceTest : RepositoryTestFixture
                     DragonId = Dragons.Garuda,
                     DragonGiftIdList = new List<DragonGifts>() { DragonGifts.FreshBread },
                 },
-                default
+                TestContext.Current.CancellationToken
             );
 
         responseData.Should().NotBeNull();
@@ -289,7 +289,7 @@ public class DragonServiceTest : RepositoryTestFixture
                 DragonGiftId = gift,
                 Quantity = usedQuantity,
             },
-            default
+            TestContext.Current.CancellationToken
         );
 
         responseData.Should().NotBeNull();
@@ -345,7 +345,7 @@ public class DragonServiceTest : RepositoryTestFixture
                     },
                 },
             },
-            default
+            TestContext.Current.CancellationToken
         );
 
         dragonData.AttackPlusCount.Should().Be(50);
@@ -409,7 +409,7 @@ public class DragonServiceTest : RepositoryTestFixture
                     },
                 },
             },
-            default
+            TestContext.Current.CancellationToken
         );
         dragonData.Exp.Should().Be(expectedXp);
         dragonData.Level.Should().Be(expectedLvl);
@@ -473,7 +473,7 @@ public class DragonServiceTest : RepositoryTestFixture
                 DragonKeyId = 1,
                 PlusCountType = PlusCountType.Atk,
             },
-            default
+            TestContext.Current.CancellationToken
         );
 
         mockRewardService.VerifyAll();
@@ -545,7 +545,7 @@ public class DragonServiceTest : RepositoryTestFixture
                     },
                 },
             },
-            default
+            TestContext.Current.CancellationToken
         );
 
         dragonData.LimitBreakCount.Should().Be(limitBreakNr);
@@ -581,7 +581,7 @@ public class DragonServiceTest : RepositoryTestFixture
 
         await dragonService.DoDragonSetLock(
             new DragonSetLockRequest() { DragonKeyId = 1, IsLock = true },
-            default
+            TestContext.Current.CancellationToken
         );
 
         dragonData.IsLock.Should().BeTrue();
@@ -619,7 +619,7 @@ public class DragonServiceTest : RepositoryTestFixture
 
         DragonSellResponse response = await dragonService.DoDragonSell(
             new DragonSellRequest() { DragonKeyIdList = new List<ulong>() { 1 } },
-            default
+            TestContext.Current.CancellationToken
         );
 
         dragonDataList.Count.Should().Be(0);

--- a/DragaliaAPI/DragaliaAPI.Test/Services/UpdateDataServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Services/UpdateDataServiceTest.cs
@@ -268,7 +268,7 @@ public class UpdateDataServiceTest : RepositoryTestFixture
         this.mockMissionProgressionService.Setup(x => x.ProcessMissionEvents(cts.Token))
             .Returns(Task.CompletedTask);
 
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (await this.updateDataService.SaveChangesAsync(cts.Token)).CharaList.Should().BeNull();
     }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/EntryConditionsTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/EntryConditionsTest.cs
@@ -22,7 +22,8 @@ public class EntryConditionsTest : TestFixture
 
         HttpResponseMessage response = await this.Client.PostAsync(
             Endpoint,
-            JsonContent.Create(new GameBase())
+            JsonContent.Create(new GameBase()),
+            TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -63,7 +64,8 @@ public class EntryConditionsTest : TestFixture
         HttpResponseMessage response =
             await this.Client.PostAsJsonAsync<GameModifyConditionsRequest>(
                 Endpoint,
-                new() { GameName = game.Name, NewEntryConditions = newConditions }
+                new() { GameName = game.Name, NewEntryConditions = newConditions },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCloseTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCloseTest.cs
@@ -19,7 +19,11 @@ public class GameCloseTest : TestFixture
     {
         this.Client.DefaultRequestHeaders.Clear();
 
-        HttpResponseMessage response = await this.Client.PostAsync(Endpoint, null);
+        HttpResponseMessage response = await this.Client.PostAsync(
+            Endpoint,
+            null,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -50,7 +54,8 @@ public class GameCloseTest : TestFixture
 
         HttpResponseMessage response = await this.Client.PostAsJsonAsync<GameModifyRequest>(
             Endpoint,
-            new() { GameName = game.Name }
+            new() { GameName = game.Name },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCreateTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameCreateTest.cs
@@ -22,7 +22,8 @@ public class GameCreateTest : TestFixture
 
         HttpResponseMessage response = await this.Client.PostAsync(
             Endpoint,
-            JsonContent.Create(new GameBase())
+            JsonContent.Create(new GameBase()),
+            TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
@@ -75,7 +76,8 @@ public class GameCreateTest : TestFixture
             {
                 Game = game,
                 Player = new() { ViewerId = 2, PartyNoList = [40] },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameJoinTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameJoinTest.cs
@@ -20,7 +20,11 @@ public class GameJoinTest : TestFixture
     {
         this.Client.DefaultRequestHeaders.Clear();
 
-        HttpResponseMessage response = await this.Client.PostAsync(Endpoint, null);
+        HttpResponseMessage response = await this.Client.PostAsync(
+            Endpoint,
+            null,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -55,7 +59,8 @@ public class GameJoinTest : TestFixture
             {
                 GameName = game.Name,
                 Player = new() { ViewerId = 22, PartyNoList = [1, 2] },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/GameLeaveTest.cs
@@ -20,7 +20,11 @@ public class GameLeaveTest : TestFixture
     {
         this.Client.DefaultRequestHeaders.Clear();
 
-        HttpResponseMessage response = await this.Client.PostAsync(Endpoint, null);
+        HttpResponseMessage response = await this.Client.PostAsync(
+            Endpoint,
+            null,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -59,7 +63,8 @@ public class GameLeaveTest : TestFixture
             {
                 GameName = game.Name,
                 Player = new() { ViewerId = 5 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         RedisGame? storedGame = await this.RedisConnectionProvider.GetGame(game.Name);
@@ -105,7 +110,8 @@ public class GameLeaveTest : TestFixture
             {
                 GameName = game.Name,
                 Player = new() { ViewerId = 5 },
-            }
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         RedisGame? storedGame = await this.RedisConnectionProvider.GetGame(game.Name);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/MatchingTypeTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/MatchingTypeTest.cs
@@ -19,7 +19,11 @@ public class MatchingTypeTest : TestFixture
     {
         this.Client.DefaultRequestHeaders.Clear();
 
-        HttpResponseMessage response = await this.Client.PostAsync(Endpoint, null);
+        HttpResponseMessage response = await this.Client.PostAsync(
+            Endpoint,
+            null,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
@@ -52,7 +56,8 @@ public class MatchingTypeTest : TestFixture
         HttpResponseMessage response =
             await this.Client.PostAsJsonAsync<GameModifyMatchingTypeRequest>(
                 Endpoint,
-                new() { GameName = game.Name, NewMatchingType = newMatchingType }
+                new() { GameName = game.Name, NewMatchingType = newMatchingType },
+                cancellationToken: TestContext.Current.CancellationToken
             );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/RoomIdTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/RoomIdTest.cs
@@ -40,7 +40,8 @@ public class RoomIdTest : TestFixture
 
         HttpResponseMessage response = await this.Client.PostAsJsonAsync<GameModifyRoomIdRequest>(
             Endpoint,
-            new() { GameName = game.Name, NewRoomId = 56789 }
+            new() { GameName = game.Name, NewRoomId = 56789 },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/VisibleTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Event/VisibleTest.cs
@@ -42,7 +42,8 @@ public class VisibleTest : TestFixture
 
         HttpResponseMessage response = await this.Client.PostAsJsonAsync<GameModifyVisibleRequest>(
             Endpoint,
-            new() { GameName = game.Name, NewVisibility = visibility }
+            new() { GameName = game.Name, NewVisibility = visibility },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByIdTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByIdTest.cs
@@ -37,10 +37,17 @@ public class ByIdTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/12345");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/12345",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<ApiGame>())
+        (
+            await response.Content.ReadFromJsonAsync<ApiGame>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(game.ToApiGame());
     }
@@ -48,7 +55,10 @@ public class ByIdTest : TestFixture
     [Fact]
     public async Task ById_NotFound_Returns404()
     {
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/56789");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/56789",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByViewerIdTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/ByViewerIdTest.cs
@@ -37,10 +37,17 @@ public class ByViewerIdTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/2");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/2",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<ApiGame>())
+        (
+            await response.Content.ReadFromJsonAsync<ApiGame>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .BeEquivalentTo(game.ToApiGame());
     }
@@ -69,7 +76,10 @@ public class ByViewerIdTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/88888");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/88888",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/GameListTest.cs
@@ -79,10 +79,17 @@ public class GameListTest : TestFixture
 
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(games);
 
-        HttpResponseMessage response = await this.Client.GetAsync(Endpoint);
+        HttpResponseMessage response = await this.Client.GetAsync(
+            Endpoint,
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>())
+        (
+            await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveCount(1)
             .And.BeEquivalentTo([games[0].ToApiGame()]);
@@ -132,11 +139,16 @@ public class GameListTest : TestFixture
         await this.RedisConnectionProvider.RedisCollection<RedisGame>().InsertAsync(games);
 
         HttpResponseMessage response = await this.Client.GetAsync(
-            $"{Endpoint}?questId={219010102}"
+            $"{Endpoint}?questId={219010102}",
+            TestContext.Current.CancellationToken
         );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>())
+        (
+            await response.Content.ReadFromJsonAsync<IEnumerable<ApiGame>>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
             .Should()
             .HaveCount(1)
             .And.BeEquivalentTo(new List<ApiGame>() { games[1].ToApiGame() });

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/IsHostTest.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager.Test/Get/IsHostTest.cs
@@ -40,10 +40,19 @@ public class IsHostTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/2");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/2",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(true);
+        (
+            await response.Content.ReadFromJsonAsync<bool>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .Be(true);
     }
 
     [Fact]
@@ -74,10 +83,19 @@ public class IsHostTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/3");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/3",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(false);
+        (
+            await response.Content.ReadFromJsonAsync<bool>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .Be(false);
     }
 
     [Fact]
@@ -106,9 +124,18 @@ public class IsHostTest : TestFixture
 
         this.RedisConnectionProvider.RedisCollection<RedisGame>().Insert(game);
 
-        HttpResponseMessage response = await this.Client.GetAsync($"{Endpoint}/8888");
+        HttpResponseMessage response = await this.Client.GetAsync(
+            $"{Endpoint}/8888",
+            TestContext.Current.CancellationToken
+        );
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
-        (await response.Content.ReadFromJsonAsync<bool>()).Should().Be(false);
+        (
+            await response.Content.ReadFromJsonAsync<bool>(
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .Be(false);
     }
 }


### PR DESCRIPTION
Pass CancellationToken in tests
    
Resolves new XUnit warning globally. Accomplished via `dotnet format DragaliaAPI.sln -v diag --diagnostics xUnit1051`
