### PR TITLE
Parallelize integration tests

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/FortRepositoryTest.cs
@@ -33,9 +33,6 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
             this.fakeTimeProvider,
             LoggerTestUtils.Create<FortRepository>()
         );
-
-        CommonAssertionOptions.ApplyTimeOptions();
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]
@@ -80,7 +77,9 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
         };
         await this.fixture.AddToDatabase(detail);
 
-        (await this.fortRepository.GetFortDetail()).Should().BeEquivalentTo(detail);
+        (await this.fortRepository.GetFortDetail())
+            .Should()
+            .BeEquivalentTo(detail, opts => opts.WithDateTimeTolerance());
 
         this.mockPlayerIdentityService.VerifyAll();
     }
@@ -138,7 +137,12 @@ public class FortRepositoryTest : IClassFixture<DbTestFixture>
 
         await this.fixture.AddToDatabase(build);
 
-        (await this.fortRepository.GetBuilding(8)).Should().BeEquivalentTo(build);
+        (await this.fortRepository.GetBuilding(8))
+            .Should()
+            .BeEquivalentTo(
+                build,
+                opts => opts.WithDateTimeTolerance().WithTimeSpanTolerance(TimeSpan.FromSeconds(1))
+            );
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/QuestRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/QuestRepositoryTest.cs
@@ -19,8 +19,6 @@ public class QuestRepositoryTest : IClassFixture<DbTestFixture>
             fixture.ApiContext,
             IdentityTestUtils.MockPlayerDetailsService.Object
         );
-
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Database.Test/Repositories/WeaponRepositoryTest.cs
@@ -22,9 +22,6 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
             IdentityTestUtils.MockPlayerDetailsService.Object,
             LoggerTestUtils.Create<WeaponRepository>()
         );
-
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]
@@ -78,7 +75,8 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
                 {
                     ViewerId = IdentityTestUtils.ViewerId,
                     WeaponBodyId = WeaponBodies.Arondight,
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
     }
 
@@ -203,7 +201,8 @@ public class WeaponRepositoryTest : IClassFixture<DbTestFixture>
                     WeaponSkinId = 4,
                     IsNew = false,
                     GetTime = DateTimeOffset.UtcNow,
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -208,5 +208,7 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbPlayerDmodeInfo>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+        
+        modelBuilder.Entity<DbPlayerMaterial>().HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -208,7 +208,9 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
         modelBuilder
             .Entity<DbPlayerDmodeInfo>()
             .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
-        
-        modelBuilder.Entity<DbPlayerMaterial>().HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
+
+        modelBuilder
+            .Entity<DbPlayerMaterial>()
+            .HasQueryFilter(x => x.ViewerId == this.playerIdentityService.ViewerId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -24,9 +24,7 @@ public class InventoryRepository : IInventoryRepository
     }
 
     public IQueryable<DbPlayerMaterial> Materials =>
-        this.apiContext.PlayerMaterials.Where(storage =>
-            storage.ViewerId == this.playerIdentityService.ViewerId
-        );
+        this.apiContext.PlayerMaterials;
 
     public DbPlayerMaterial AddMaterial(Materials type)
     {

--- a/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Repositories/InventoryRepository.cs
@@ -23,8 +23,7 @@ public class InventoryRepository : IInventoryRepository
         this.logger = logger;
     }
 
-    public IQueryable<DbPlayerMaterial> Materials =>
-        this.apiContext.PlayerMaterials;
+    public IQueryable<DbPlayerMaterial> Materials => this.apiContext.PlayerMaterials;
 
     public DbPlayerMaterial AddMaterial(Materials type)
     {

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/AssemblyAttributes.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/AssemblyAttributes.cs
@@ -1,3 +1,7 @@
 // Capture console output and report it to XUnit. Temporary replacement for MartinCostello.Logging.Xunit
 // https://github.com/martincostello/xunit-logging/issues/717
+
+using DragaliaAPI.Integration.Test;
+
 [assembly: CaptureConsole]
+[assembly: AssemblyFixture(typeof(CustomWebApplicationFactory))]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/CustomWebApplicationFactory.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/CustomWebApplicationFactory.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Npgsql;
 using StackExchange.Redis;
+using Xunit.Sdk;
 
 namespace DragaliaAPI.Integration.Test;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
@@ -8,7 +8,6 @@ public class CastleStoryTest : TestFixture
     public CastleStoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/CastleStoryTest.cs
@@ -6,9 +6,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 public class CastleStoryTest : TestFixture
 {
     public CastleStoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task ReadStory_StoryNotRead_ResponseHasRewards()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -412,6 +412,7 @@ public class DragonTest : TestFixture
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.Id == missionId)
             .Progress.Should()
             .Be(9);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -161,9 +161,9 @@ public class DragonTest : TestFixture
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.ChangeTracker.Clear();
-        DbPlayerUserData userData = await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         long startCoin = userData.Coin;
 
@@ -231,9 +231,9 @@ public class DragonTest : TestFixture
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.ChangeTracker.Clear();
-        DbPlayerUserData userData = await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.FirstAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         long startCoin = userData.Coin;
 
@@ -735,9 +735,9 @@ public class DragonTest : TestFixture
         DragonData dragonDataStribog = MasterAsset.DragonData.Get(Dragons.Stribog);
 
         this.ApiContext.ChangeTracker.Clear();
-        DbPlayerUserData uData = await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+        DbPlayerUserData uData = await this.ApiContext.PlayerUserData.FirstAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         long startCoin = uData.Coin;
         long startDew = uData.DewPoint;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/DragonTest.cs
@@ -429,6 +429,7 @@ public class DragonTest : TestFixture
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.Id == missionId)
             .Progress.Should()
             .Be(9, "the progress is based on the highest level reached");
@@ -451,6 +452,7 @@ public class DragonTest : TestFixture
             .Contain(missionId);
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.Id == missionId)
             .Should()
             .BeEquivalentTo(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
@@ -8,9 +8,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 public class FriendTest : TestFixture
 {
     public FriendTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task GetSupportCharaDetail_GetsCorrectCharacter()
@@ -177,8 +175,10 @@ public class FriendTest : TestFixture
 
         response
             .SupportUserDataDetail.UserSupportData.Should()
-            .BeEquivalentTo(HelperService.StubData.SupportListData.SupportUserList.First(),
-                opts => opts.WithDateTimeTolerance());
+            .BeEquivalentTo(
+                HelperService.StubData.SupportListData.SupportUserList.First(),
+                opts => opts.WithDateTimeTolerance()
+            );
 
         response.SupportUserDataDetail.IsFriend.Should().BeFalse();
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/FriendTest.cs
@@ -10,7 +10,6 @@ public class FriendTest : TestFixture
     public FriendTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]
@@ -178,7 +177,8 @@ public class FriendTest : TestFixture
 
         response
             .SupportUserDataDetail.UserSupportData.Should()
-            .BeEquivalentTo(HelperService.StubData.SupportListData.SupportUserList.First());
+            .BeEquivalentTo(HelperService.StubData.SupportListData.SupportUserList.First(),
+                opts => opts.WithDateTimeTolerance());
 
         response.SupportUserDataDetail.IsFriend.Should().BeFalse();
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/PartyTest.cs
@@ -203,9 +203,9 @@ public class PartyTest : TestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        DbPlayerUserData userData = await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == ViewerId)
-            .SingleAsync(cancellationToken: TestContext.Current.CancellationToken);
+        DbPlayerUserData userData = await this.ApiContext.PlayerUserData.SingleAsync(
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         userData.MainPartyNo.Should().Be(2);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -5,9 +5,7 @@ namespace DragaliaAPI.Integration.Test.Dragalia;
 public class UserTest : TestFixture
 {
     public UserTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task LinkedNAccount_ReturnsExpectedResponse()
@@ -30,7 +28,8 @@ public class UserTest : TestFixture
                 {
                     UpdateDataList = new() { UserData = expectedUserData },
                 },
-                opts => opts.Excluding(x => x.UpdateDataList.UserData.Crystal).WithDateTimeTolerance()
+                opts =>
+                    opts.Excluding(x => x.UpdateDataList.UserData.Crystal).WithDateTimeTolerance()
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/UserTest.cs
@@ -7,7 +7,6 @@ public class UserTest : TestFixture
     public UserTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]
@@ -31,7 +30,7 @@ public class UserTest : TestFixture
                 {
                     UpdateDataList = new() { UserData = expectedUserData },
                 },
-                opts => opts.Excluding(x => x.UpdateDataList.UserData.Crystal)
+                opts => opts.Excluding(x => x.UpdateDataList.UserData.Crystal).WithDateTimeTolerance()
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -13,8 +13,6 @@ public class WeaponBodyTest : TestFixture
     public WeaponBodyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 5);
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]
@@ -56,7 +54,8 @@ public class WeaponBodyTest : TestFixture
                         IsNew = false,
                         GetTime = DateTimeOffset.UtcNow,
                     },
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
 
         list.UserData.Should().NotBeNull();
@@ -154,11 +153,12 @@ public class WeaponBodyTest : TestFixture
 
         weaponBody
             .Should()
-            .BeEquivalentTo(testCase.ExpFinalState, opts => opts.Excluding(x => x.ViewerId));
+            .BeEquivalentTo(testCase.ExpFinalState, opts => opts.Excluding(x => x.ViewerId).WithDateTimeTolerance());
         response
             .UpdateDataList.WeaponBodyList.Should()
             .BeEquivalentTo(
-                new List<WeaponBodyList>() { testCase.ExpFinalState.ToWeaponBodyList() }
+                new List<WeaponBodyList>() { testCase.ExpFinalState.ToWeaponBodyList() },
+                opts => opts.WithDateTimeTolerance()
             );
 
         // Check materials

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Dragalia/WeaponBodyTest.cs
@@ -11,9 +11,7 @@ public class WeaponBodyTest : TestFixture
     private const string EndpointGroup = "/weapon_body";
 
     public WeaponBodyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task Craft_Success_ReturnsExpectedResponse()
@@ -153,7 +151,10 @@ public class WeaponBodyTest : TestFixture
 
         weaponBody
             .Should()
-            .BeEquivalentTo(testCase.ExpFinalState, opts => opts.Excluding(x => x.ViewerId).WithDateTimeTolerance());
+            .BeEquivalentTo(
+                testCase.ExpFinalState,
+                opts => opts.Excluding(x => x.ViewerId).WithDateTimeTolerance()
+            );
         response
             .UpdateDataList.WeaponBodyList.Should()
             .BeEquivalentTo(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -181,7 +181,8 @@ public class DmodeTest : TestFixture
                     TargetFloorNum = 30,
                     State = ExpeditionState.Playing,
                     StartTime = DateTimeOffset.UtcNow,
-                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DmodeExpeditionForceFinishResponse> finishResp =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -8,7 +8,6 @@ public class DmodeTest : TestFixture
     public DmodeTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
 
@@ -182,7 +181,7 @@ public class DmodeTest : TestFixture
                     TargetFloorNum = 30,
                     State = ExpeditionState.Playing,
                     StartTime = DateTimeOffset.UtcNow,
-                }
+                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DmodeExpeditionForceFinishResponse> finishResp =
@@ -248,7 +247,8 @@ public class DmodeTest : TestFixture
                     TargetFloorNum = 30,
                     State = ExpeditionState.Playing,
                     StartTime = startTime,
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
 
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow.AddDays(1));
@@ -271,7 +271,8 @@ public class DmodeTest : TestFixture
                     TargetFloorNum = 30,
                     State = ExpeditionState.Waiting,
                     StartTime = startTime,
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
 
         finishResp.Data.DmodeIngameResult.TakeDmodePoint1.Should().BeGreaterThan(0);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dmode/DmodeTest.cs
@@ -182,7 +182,7 @@ public class DmodeTest : TestFixture
                     State = ExpeditionState.Playing,
                     StartTime = DateTimeOffset.UtcNow,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance()
             );
 
         DragaliaResponse<DmodeExpeditionForceFinishResponse> finishResp =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -16,7 +16,6 @@ public class DungeonRecordTest : TestFixture
     public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-
         this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaSingle, e => 100)
         );
@@ -587,7 +586,10 @@ public class DungeonRecordTest : TestFixture
             .And.Contain(10221301); // Earn the "Light of the Deep" Epithet
 
         // Clear Three Challenge Battles
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).First(x => x.Id == 10220801).Progress.Should().Be(1);
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .First(x => x.Id == 10220801)
+            .Progress.Should()
+            .Be(1);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -16,10 +16,10 @@ public class DungeonRecordTest : TestFixture
     public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaSingle, e => 100)
         );
-        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaMulti, e => 100)
         );
 
@@ -892,7 +892,7 @@ public class DungeonRecordTest : TestFixture
         await this.ImportSave();
         this.SetupPhotonAuthentication();
 
-        int questId = 219020101; // Kai Yan's Wrath Standard (not a TA quest but who cares)
+        int questId = 227080106; // Asura's Blinding Light (Ranked)
         string roomName = Guid.NewGuid().ToString();
         string roomId = "1234";
         string gameId = $"{roomName}_{roomId}";
@@ -900,21 +900,12 @@ public class DungeonRecordTest : TestFixture
         this.Client.DefaultRequestHeaders.Add("RoomName", roomName);
         this.Client.DefaultRequestHeaders.Add("RoomId", roomId);
 
-        await this.AddToDatabase(
-            new DbQuest()
-            {
-                QuestId = questId,
-                State = 0,
-                ViewerId = ViewerId,
-            }
-        );
-
         DungeonStartStartMultiResponse startResponse = (
             await this.Client.PostMsgpack<DungeonStartStartMultiResponse>(
                 "/dungeon_start/start_multi",
                 new DungeonStartStartMultiRequest()
                 {
-                    PartyNoList = new[] { 4 }, // Flame team
+                    PartyNoList = [2], // Shadow team
                     QuestId = questId,
                 },
                 cancellationToken: TestContext.Current.CancellationToken
@@ -976,7 +967,7 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaSingle, e => 0)
         );
 
@@ -1032,7 +1023,7 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaSingle, e => 0)
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -16,12 +16,10 @@ public class DungeonRecordTest : TestFixture
     public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
-            p.SetProperty(e => e.StaminaSingle, e => 100)
-        );
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
-            p.SetProperty(e => e.StaminaMulti, e => 100)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 100));
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaMulti, e => 100));
 
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
@@ -967,9 +965,8 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
-            p.SetProperty(e => e.StaminaSingle, e => 0)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 0));
 
         DungeonSession mockSession =
             new()
@@ -1023,9 +1020,8 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
-            p.SetProperty(e => e.StaminaSingle, e => 0)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 0));
 
         DungeonSession mockSession =
             new()
@@ -1301,8 +1297,7 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials
-            .Where(x => x.ViewerId == this.ViewerId)
+            .ApiContext.PlayerMaterials.Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
@@ -1357,8 +1352,7 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials
-            .Where(x => x.ViewerId == this.ViewerId)
+            .ApiContext.PlayerMaterials.Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
@@ -1439,8 +1433,7 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials
-            .Where(x => x.ViewerId == this.ViewerId)
+            .ApiContext.PlayerMaterials.Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -10,12 +10,12 @@ using Microsoft.EntityFrameworkCore;
 namespace DragaliaAPI.Integration.Test.Features.Dungeon;
 
 [SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
+[Collection("TimeAttack")]
 public class DungeonRecordTest : TestFixture
 {
     public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(2);
 
         this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
             p.SetProperty(e => e.StaminaSingle, e => 100)
@@ -180,7 +180,8 @@ public class DungeonRecordTest : TestFixture
                     BestClearTime = 10,
                     LastDailyResetTime = DateTimeOffset.UtcNow,
                     LastWeeklyResetTime = DateTimeOffset.UtcNow,
-                }
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         response.RepeatData.Should().BeNull();
@@ -586,7 +587,7 @@ public class DungeonRecordTest : TestFixture
             .And.Contain(10221301); // Earn the "Light of the Deep" Epithet
 
         // Clear Three Challenge Battles
-        this.ApiContext.PlayerMissions.First(x => x.Id == 10220801).Progress.Should().Be(1);
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).First(x => x.Id == 10220801).Progress.Should().Be(1);
     }
 
     [Fact]
@@ -889,7 +890,7 @@ public class DungeonRecordTest : TestFixture
         await this.ImportSave();
         this.SetupPhotonAuthentication();
 
-        int questId = 227010104; // Volk's Wrath TA Solo
+        int questId = 219020101; // Kai Yan's Wrath Standard (not a TA quest but who cares)
         string roomName = Guid.NewGuid().ToString();
         string roomId = "1234";
         string gameId = $"{roomName}_{roomId}";

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -180,7 +180,7 @@ public class DungeonRecordTest : TestFixture
                     LastDailyResetTime = DateTimeOffset.UtcNow,
                     LastWeeklyResetTime = DateTimeOffset.UtcNow,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance()
             );
 
         response.RepeatData.Should().BeNull();
@@ -1301,7 +1301,9 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .ApiContext.PlayerMaterials
+            .Where(x => x.ViewerId == this.ViewerId)
+            .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
         await this.AddToDatabase(new DbQuest() { QuestId = questId, DailyPlayCount = 0 });
@@ -1355,7 +1357,9 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .ApiContext.PlayerMaterials
+            .Where(x => x.ViewerId == this.ViewerId)
+            .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
         await this.AddToDatabase(
@@ -1435,7 +1439,9 @@ public class DungeonRecordTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .ApiContext.PlayerMaterials
+            .Where(x => x.ViewerId == this.ViewerId)
+            .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
         await this.AddToDatabase(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -10,16 +10,17 @@ using Microsoft.EntityFrameworkCore;
 namespace DragaliaAPI.Integration.Test.Features.Dungeon;
 
 [SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments")]
-[Collection("TimeAttack")]
 public class DungeonRecordTest : TestFixture
 {
     public DungeonRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 100));
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaMulti, e => 100));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+            p.SetProperty(e => e.StaminaSingle, e => 100)
+        );
+        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+            p.SetProperty(e => e.StaminaMulti, e => 100)
+        );
 
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
@@ -965,8 +966,9 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 0));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+            p.SetProperty(e => e.StaminaSingle, e => 0)
+        );
 
         DungeonSession mockSession =
             new()
@@ -1020,8 +1022,9 @@ public class DungeonRecordTest : TestFixture
             }
         );
 
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(p => p.SetProperty(e => e.StaminaSingle, e => 0));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+            p.SetProperty(e => e.StaminaSingle, e => 0)
+        );
 
         DungeonSession mockSession =
             new()
@@ -1154,16 +1157,14 @@ public class DungeonRecordTest : TestFixture
     [Fact]
     public async Task Record_IsCoopTutorial_AdvancesTutorialStatus()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                e =>
-                    e.SetProperty(
-                        p => p.TutorialStatus,
-                        TutorialService.TutorialStatusIds.CoopTutorial
-                    ),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            e =>
+                e.SetProperty(
+                    p => p.TutorialStatus,
+                    TutorialService.TutorialStatusIds.CoopTutorial
+                ),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         int questId = TutorialService.TutorialQuestIds.AvenueToPowerBeginner;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -281,8 +281,7 @@ public class DungeonSkipTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials
-            .Where(x => x.ViewerId == this.ViewerId)
+            .ApiContext.PlayerMaterials.Where(x => x.ViewerId == this.ViewerId)
             .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -281,7 +281,9 @@ public class DungeonSkipTest : TestFixture
         // Ch. 5 / 4-3 Dark Terminus (Hard)
         int questId = 100050209;
         int existingEssenceQuantity = this
-            .ApiContext.PlayerMaterials.First(x => x.MaterialId == Materials.ChthoniussEssence)
+            .ApiContext.PlayerMaterials
+            .Where(x => x.ViewerId == this.ViewerId)
+            .First(x => x.MaterialId == Materials.ChthoniussEssence)
             .Quantity;
 
         await this.AddToDatabase(new DbQuest() { QuestId = questId, DailyPlayCount = 0 });

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonSkipTest.cs
@@ -12,7 +12,6 @@ public class DungeonSkipTest : TestFixture
     public DungeonSkipTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
 
@@ -271,7 +270,8 @@ public class DungeonSkipTest : TestFixture
                     QuestBonusReserveTime = response.Data.IngameResultData.EndTime,
                     QuestBonusStackCount = 0,
                     QuestBonusStackTime = DateTimeOffset.UnixEpoch,
-                }
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -164,30 +164,22 @@ public class DungeonStartTest : TestFixture
     [InlineData("start_assign_unit")]
     public async Task Start_InsufficientStamina_ReturnsError(string endpoint)
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.StaminaSingle, e => 0),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.StaminaMulti, e => 0),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaSingle, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaMulti, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         (
             await Client.PostMsgpack<DungeonStartStartResponse>(
@@ -208,30 +200,22 @@ public class DungeonStartTest : TestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.StaminaSingle, e => 0),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.StaminaMulti, e => 0),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaSingle, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.StaminaMulti, e => 0),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         (
             await Client.PostMsgpack<DungeonStartStartResponse>(
@@ -285,16 +269,14 @@ public class DungeonStartTest : TestFixture
     [Fact]
     public async Task Start_CoopTutorial_SetsIsBotTutorialTrue()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                e =>
-                    e.SetProperty(
-                        p => p.TutorialStatus,
-                        TutorialService.TutorialStatusIds.CoopTutorial
-                    ),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            e =>
+                e.SetProperty(
+                    p => p.TutorialStatus,
+                    TutorialService.TutorialStatusIds.CoopTutorial
+                ),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         DragaliaResponse<DungeonStartStartResponse> response =
             await this.Client.PostMsgpack<DungeonStartStartResponse>(
@@ -313,16 +295,14 @@ public class DungeonStartTest : TestFixture
     [Fact]
     public async Task Start_AtpBeginner_NotCoopTutorial_SetsIsBotTutorialFalse()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                e =>
-                    e.SetProperty(
-                        p => p.TutorialStatus,
-                        TutorialService.TutorialStatusIds.CoopTutorial + 1
-                    ),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            e =>
+                e.SetProperty(
+                    p => p.TutorialStatus,
+                    TutorialService.TutorialStatusIds.CoopTutorial + 1
+                ),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         DragaliaResponse<DungeonStartStartResponse> response =
             await this.Client.PostMsgpack<DungeonStartStartResponse>(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -164,19 +164,19 @@ public class DungeonStartTest : TestFixture
     [InlineData("start_assign_unit")]
     public async Task Start_InsufficientStamina_ReturnsError(string endpoint)
     {
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.StaminaSingle, e => 0),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.StaminaMulti, e => 0),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
             cancellationToken: TestContext.Current.CancellationToken
         );
@@ -200,19 +200,19 @@ public class DungeonStartTest : TestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.StaminaSingle, e => 0),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.StaminaMulti, e => 0),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
             cancellationToken: TestContext.Current.CancellationToken
         );
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
             cancellationToken: TestContext.Current.CancellationToken
         );

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonStartTest.cs
@@ -164,22 +164,30 @@ public class DungeonStartTest : TestFixture
     [InlineData("start_assign_unit")]
     public async Task Start_InsufficientStamina_ReturnsError(string endpoint)
     {
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.StaminaSingle, e => 0),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.StaminaMulti, e => 0),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.StaminaSingle, e => 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.StaminaMulti, e => 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         (
             await Client.PostMsgpack<DungeonStartStartResponse>(
@@ -200,22 +208,30 @@ public class DungeonStartTest : TestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.StaminaSingle, e => 0),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.StaminaMulti, e => 0),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.StaminaSingle, e => 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.StaminaMulti, e => 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.LastStaminaSingleUpdateTime, e => DateTimeOffset.UtcNow),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                p => p.SetProperty(e => e.LastStaminaMultiUpdateTime, e => DateTimeOffset.UtcNow),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         (
             await Client.PostMsgpack<DungeonStartStartResponse>(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
@@ -39,7 +39,8 @@ public class BuildEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId)
+            .AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/BuildEventTest.cs
@@ -39,7 +39,7 @@ public class BuildEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
@@ -39,7 +39,8 @@ public class Clb01EventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.AsTracking().Where(x => x.ViewerId == this.ViewerId)
+            .PlayerEventItems.AsTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/Clb01EventTest.cs
@@ -39,7 +39,7 @@ public class Clb01EventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.AsTracking()
+            .PlayerEventItems.AsTracking().Where(x => x.ViewerId == this.ViewerId)
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
@@ -41,7 +41,7 @@ public class CombatEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)CombatEventItemType.EventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
@@ -74,6 +74,7 @@ public class CombatEventTest : TestFixture
     {
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)Clb01EventItemType.Clb01EventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/CombatEventTest.cs
@@ -41,7 +41,8 @@ public class CombatEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId)
+            .AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)CombatEventItemType.EventPoint,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
@@ -54,15 +54,18 @@ public class EarnEventTest : TestFixture
                 opts => opts.Excluding(x => x.Owner)
             );
 
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .HaveCount(8 + 25, because: "the event has 8 daily missions and 25 limited missions");
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .ToList()
             .Should()
             .AllSatisfy(x =>
             {
                 x.GroupId.Should().Be(EventId);
             });
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .Contain(
                 x => x.Id == 11650101 && x.State == MissionState.Completed,
                 "this is the event participation mission"
@@ -128,7 +131,10 @@ public class EarnEventTest : TestFixture
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
             .SingleAsync(
-                x => x.ViewerId == this.ViewerId && x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
+                x =>
+                    x.ViewerId == this.ViewerId
+                    && x.EventId == EventId
+                    && x.Type == (int)BuildEventItemType.BuildEventPoint,
                 cancellationToken: TestContext.Current.CancellationToken
             );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EarnEventTest.cs
@@ -54,15 +54,15 @@ public class EarnEventTest : TestFixture
                 opts => opts.Excluding(x => x.Owner)
             );
 
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .HaveCount(8 + 25, because: "the event has 8 daily missions and 25 limited missions");
-        this.ApiContext.PlayerMissions.ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
             .Should()
             .AllSatisfy(x =>
             {
                 x.GroupId.Should().Be(EventId);
             });
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .Contain(
                 x => x.Id == 11650101 && x.State == MissionState.Completed,
                 "this is the event participation mission"
@@ -128,7 +128,7 @@ public class EarnEventTest : TestFixture
         DbPlayerEventItem pointItem = await ApiContext
             .PlayerEventItems.AsTracking()
             .SingleAsync(
-                x => x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
+                x => x.ViewerId == this.ViewerId && x.EventId == EventId && x.Type == (int)BuildEventItemType.BuildEventPoint,
                 cancellationToken: TestContext.Current.CancellationToken
             );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -41,7 +41,7 @@ public class RaidEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)RaidEventItemType.RaidPoint1,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -41,7 +41,8 @@ public class RaidEventTest : TestFixture
     public async Task ReceiveEventRewards_ReturnsEventRewards()
     {
         DbPlayerEventItem pointItem = await ApiContext
-            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).AsTracking()
+            .PlayerEventItems.Where(x => x.ViewerId == this.ViewerId)
+            .AsTracking()
             .SingleAsync(
                 x => x.EventId == EventId && x.Type == (int)RaidEventItemType.RaidPoint1,
                 cancellationToken: TestContext.Current.CancellationToken

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Fort/FortTest.cs
@@ -10,7 +10,6 @@ public class FortTest : TestFixture
     public FortTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Item/ItemTest.cs
@@ -18,8 +18,7 @@ public class ItemTest : TestFixture
             )
             .Wait();
 
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(e => e.SetProperty(p => p.StaminaSingle, 5));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(e => e.SetProperty(p => p.StaminaSingle, 5));
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/LoginTest.cs
@@ -401,6 +401,7 @@ public class LoginTest : TestFixture
             .NotContain(x => x.Id == oldMissionId);
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .Where(x => x.GroupId == 0)
             .Should()
             .BeEquivalentTo(
@@ -417,6 +418,7 @@ public class LoginTest : TestFixture
             );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .Where(x => x.GroupId == starryDragonyuleEventId)
             .Should()
             .BeEquivalentTo(
@@ -435,6 +437,7 @@ public class LoginTest : TestFixture
             );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .ToList()
             .Should()
             .AllSatisfy(x =>
@@ -469,10 +472,12 @@ public class LoginTest : TestFixture
         );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .Should()
             .NotContain(x => x.Id == oldMissionId);
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .Where(x => x.GroupId == 0)
             .Should()
             .BeEquivalentTo(
@@ -489,6 +494,7 @@ public class LoginTest : TestFixture
             );
 
         this.ApiContext.PlayerMissions.AsNoTracking()
+            .Where(x => x.ViewerId == this.ViewerId)
             .Should()
             .NotContain(x => x.GroupId == starryDragonyuleEventId);
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -73,9 +73,7 @@ public class PresentTest : TestFixture
                     },
                 },
                 opts =>
-                    opts.WithDateTimeTolerance()
-                        .For(x => x.PresentList)
-                        .Exclude(x => x.PresentId)
+                    opts.WithDateTimeTolerance().For(x => x.PresentList).Exclude(x => x.PresentId)
             );
 
         response.Data.PresentList.Should().BeInDescendingOrder(x => x.PresentId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -73,7 +73,7 @@ public class PresentTest : TestFixture
                     },
                 },
                 opts =>
-                    opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3))
+                    opts.WithDateTimeTolerance()
                         .For(x => x.PresentList)
                         .Exclude(x => x.PresentId)
             );
@@ -136,7 +136,7 @@ public class PresentTest : TestFixture
                     },
                 },
                 opts =>
-                    opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3))
+                    opts.WithDateTimeTolerance()
                         .For(x => x.PresentLimitList)
                         .Exclude(x => x.PresentId)
             );

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -13,12 +13,6 @@ public class PresentTest : TestFixture
     public PresentTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 3);
-
-        // Ignore auto-generated PK
-        AssertionOptions.AssertEquivalencyUsing(opts =>
-            opts.Excluding(member => member.Name == nameof(PresentDetailList.PresentId))
-        );
     }
 
     [Fact]
@@ -79,7 +73,9 @@ public class PresentTest : TestFixture
                     {
                         PresentNotice = new() { PresentCount = 2, PresentLimitCount = 0 },
                     },
-                }
+                    
+                },     opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3)).For(x => x.PresentList).Exclude(x => x.PresentId)
+
             );
 
         response.Data.PresentList.Should().BeInDescendingOrder(x => x.PresentId);
@@ -138,7 +134,8 @@ public class PresentTest : TestFixture
                     {
                         PresentNotice = new() { PresentCount = 1, PresentLimitCount = 1 },
                     },
-                }
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3)).For(x => x.PresentLimitList).Exclude(x => x.PresentId)
             );
 
         response.Data.PresentLimitList.Should().BeInDescendingOrder(x => x.PresentId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Present/PresentTest.cs
@@ -11,9 +11,7 @@ public class PresentTest : TestFixture
     private const string Controller = "/present";
 
     public PresentTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task GetPresentList_ReturnsPresentList()
@@ -73,9 +71,11 @@ public class PresentTest : TestFixture
                     {
                         PresentNotice = new() { PresentCount = 2, PresentLimitCount = 0 },
                     },
-                    
-                },     opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3)).For(x => x.PresentList).Exclude(x => x.PresentId)
-
+                },
+                opts =>
+                    opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3))
+                        .For(x => x.PresentList)
+                        .Exclude(x => x.PresentId)
             );
 
         response.Data.PresentList.Should().BeInDescendingOrder(x => x.PresentId);
@@ -135,7 +135,10 @@ public class PresentTest : TestFixture
                         PresentNotice = new() { PresentCount = 1, PresentLimitCount = 1 },
                     },
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3)).For(x => x.PresentLimitList).Exclude(x => x.PresentId)
+                opts =>
+                    opts.WithDateTimeTolerance(TimeSpan.FromSeconds(3))
+                        .For(x => x.PresentLimitList)
+                        .Exclude(x => x.PresentId)
             );
 
         response.Data.PresentLimitList.Should().BeInDescendingOrder(x => x.PresentId);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
@@ -10,9 +10,7 @@ namespace DragaliaAPI.Integration.Test.Features.Quest;
 public class QuestClearPartyTest : TestFixture
 {
     public QuestClearPartyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task GetQuestClearParty_ReturnsSetClearParty()
@@ -30,7 +28,10 @@ public class QuestClearPartyTest : TestFixture
 
         response
             .Data.QuestClearPartySettingList.Should()
-            .BeEquivalentTo(this.SoloPartySettingLists, opts => opts.Excluding(x => x.EquipTalismanKeyId));
+            .BeEquivalentTo(
+                this.SoloPartySettingLists,
+                opts => opts.Excluding(x => x.EquipTalismanKeyId)
+            );
         response.Data.LostUnitList.Should().BeEmpty();
     }
 
@@ -50,7 +51,10 @@ public class QuestClearPartyTest : TestFixture
 
         response
             .Data.QuestMultiClearPartySettingList.Should()
-            .BeEquivalentTo(this.MultiPartySettingLists,opts => opts.Excluding(x => x.EquipTalismanKeyId));
+            .BeEquivalentTo(
+                this.MultiPartySettingLists,
+                opts => opts.Excluding(x => x.EquipTalismanKeyId)
+            );
         response.Data.LostUnitList.Should().BeEmpty();
     }
 
@@ -177,7 +181,10 @@ public class QuestClearPartyTest : TestFixture
 
         storedList
             .Should()
-            .BeEquivalentTo(this.SoloDbEntities, opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId));
+            .BeEquivalentTo(
+                this.SoloDbEntities,
+                opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId)
+            );
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(3));
     }
 
@@ -207,7 +214,10 @@ public class QuestClearPartyTest : TestFixture
 
         storedList
             .Should()
-            .BeEquivalentTo(this.MultiDbEntities, opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId));
+            .BeEquivalentTo(
+                this.MultiDbEntities,
+                opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId)
+            );
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(4));
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestClearPartyTest.cs
@@ -12,7 +12,6 @@ public class QuestClearPartyTest : TestFixture
     public QuestClearPartyTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]
@@ -31,7 +30,7 @@ public class QuestClearPartyTest : TestFixture
 
         response
             .Data.QuestClearPartySettingList.Should()
-            .BeEquivalentTo(this.SoloPartySettingLists);
+            .BeEquivalentTo(this.SoloPartySettingLists, opts => opts.Excluding(x => x.EquipTalismanKeyId));
         response.Data.LostUnitList.Should().BeEmpty();
     }
 
@@ -51,7 +50,7 @@ public class QuestClearPartyTest : TestFixture
 
         response
             .Data.QuestMultiClearPartySettingList.Should()
-            .BeEquivalentTo(this.MultiPartySettingLists);
+            .BeEquivalentTo(this.MultiPartySettingLists,opts => opts.Excluding(x => x.EquipTalismanKeyId));
         response.Data.LostUnitList.Should().BeEmpty();
     }
 
@@ -178,7 +177,7 @@ public class QuestClearPartyTest : TestFixture
 
         storedList
             .Should()
-            .BeEquivalentTo(this.SoloDbEntities, opts => opts.Excluding(x => x.QuestId));
+            .BeEquivalentTo(this.SoloDbEntities, opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId));
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(3));
     }
 
@@ -208,7 +207,7 @@ public class QuestClearPartyTest : TestFixture
 
         storedList
             .Should()
-            .BeEquivalentTo(this.MultiDbEntities, opts => opts.Excluding(x => x.QuestId));
+            .BeEquivalentTo(this.MultiDbEntities, opts => opts.Excluding(x => x.QuestId).Excluding(x => x.EquipTalismanKeyId));
         storedList.Should().AllSatisfy(x => x.QuestId.Should().Be(4));
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
@@ -38,9 +38,8 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_GrantsReward_InventoryFull_SendsToGiftBox()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(x =>
-            x.SetProperty(e => e.MaxDragonQuantity, 0)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(x => x.SetProperty(e => e.MaxDragonQuantity, 0));
 
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
@@ -83,9 +82,8 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_Midgardsormr_DoesNotAddReliabilityIfOwned()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(x =>
-            x.SetProperty(e => e.MaxDragonQuantity, 0)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(x => x.SetProperty(e => e.MaxDragonQuantity, 0));
 
         await this.AddToDatabase(
             new DbPlayerDragonReliability() { DragonId = Dragons.Midgardsormr }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
@@ -38,7 +38,7 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_GrantsReward_InventoryFull_SendsToGiftBox()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.ExecuteUpdate(x =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(x =>
             x.SetProperty(e => e.MaxDragonQuantity, 0)
         );
 
@@ -83,7 +83,7 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_Midgardsormr_DoesNotAddReliabilityIfOwned()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.ExecuteUpdate(x =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(x =>
             x.SetProperty(e => e.MaxDragonQuantity, 0)
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Quest/QuestReadStoryTest.cs
@@ -38,8 +38,9 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_GrantsReward_InventoryFull_SendsToGiftBox()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(x => x.SetProperty(e => e.MaxDragonQuantity, 0));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(x =>
+            x.SetProperty(e => e.MaxDragonQuantity, 0)
+        );
 
         QuestReadStoryResponse response = (
             await this.Client.PostMsgpack<QuestReadStoryResponse>(
@@ -82,8 +83,9 @@ public class QuestReadStoryTest : TestFixture
     public async Task ReadStory_Midgardsormr_DoesNotAddReliabilityIfOwned()
     {
         int midgardStoryId = 1000109;
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(x => x.SetProperty(e => e.MaxDragonQuantity, 0));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(x =>
+            x.SetProperty(e => e.MaxDragonQuantity, 0)
+        );
 
         await this.AddToDatabase(
             new DbPlayerDragonReliability() { DragonId = Dragons.Midgardsormr }
@@ -177,12 +179,10 @@ public class QuestReadStoryTest : TestFixture
     [Fact]
     public async Task ReadStory_Chapter10Completion_GrantsRewards()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         StoryReadResponse data = (
             await this.Client.PostMsgpack<StoryReadResponse>(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -41,7 +41,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -110,7 +111,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                },  opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
     }
 
@@ -152,7 +154,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = resetTime,
                     DailyPlayCount = 11,
                     WeeklyPlayCount = 21,
-                }, opts => opts.WithDateTimeTolerance()
+                },
+                opts => opts.WithDateTimeTolerance()
             );
     }
 
@@ -191,7 +194,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -298,7 +302,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }, opts => opts.WithDateTimeTolerance()
+                },
+                opts => opts.WithDateTimeTolerance()
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -332,7 +337,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -42,7 +42,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -112,7 +112,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
     }
 
@@ -155,7 +155,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 11,
                     WeeklyPlayCount = 21,
                 },
-                opts => opts.WithDateTimeTolerance()
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
     }
 
@@ -195,7 +195,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -241,7 +241,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                }, opts =>opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -303,7 +303,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance()
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -338,7 +338,7 @@ public class QuestBonusTest : TestFixture
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -241,7 +241,8 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }, opts =>opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
+                },
+                opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(10))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/QuestBonusTest.cs
@@ -15,7 +15,6 @@ public class QuestBonusTest : TestFixture
     public QuestBonusTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
         this.MockTimeProvider.SetUtcNow(DateTimeOffset.UtcNow);
     }
 
@@ -42,7 +41,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -111,7 +110,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                },  opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
     }
 
@@ -153,7 +152,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = resetTime,
                     DailyPlayCount = 11,
                     WeeklyPlayCount = 21,
-                }
+                }, opts => opts.WithDateTimeTolerance()
             );
     }
 
@@ -192,7 +191,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -299,7 +298,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                }, opts => opts.WithDateTimeTolerance()
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -333,7 +332,7 @@ public class QuestBonusTest : TestFixture
                     LastWeeklyResetTime = response.Data.IngameResultData.EndTime,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
-                }
+                }, opts => opts.WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -21,7 +21,7 @@ public abstract class SavefileUpdateTestFixture : TestFixture
             .MaxBy(x => x.SavefileVersion)!
             .SavefileVersion;
 
-        this.ApiContext.Players.ExecuteUpdate(u =>
+        this.ApiContext.Players.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(u =>
             u.SetProperty(e => e.SavefileVersion, StartingVersion)
         );
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -21,9 +21,8 @@ public abstract class SavefileUpdateTestFixture : TestFixture
             .MaxBy(x => x.SavefileVersion)!
             .SavefileVersion;
 
-        this.ApiContext.Players.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(u =>
-            u.SetProperty(e => e.SavefileVersion, StartingVersion)
-        );
+        this.ApiContext.Players.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(u => u.SetProperty(e => e.SavefileVersion, StartingVersion));
     }
 
     protected int GetSavefileVersion()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -28,7 +28,10 @@ public abstract class SavefileUpdateTestFixture : TestFixture
 
     protected int GetSavefileVersion()
     {
-        return this.ApiContext.Players.AsNoTracking().First( x=> x.ViewerId == this.ViewerId).SavefileVersion;
+        return this
+            .ApiContext.Players.AsNoTracking()
+            .First(x => x.ViewerId == this.ViewerId)
+            .SavefileVersion;
     }
 
     protected async Task LoadIndex()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/SavefileUpdateTestFixture.cs
@@ -28,7 +28,7 @@ public abstract class SavefileUpdateTestFixture : TestFixture
 
     protected int GetSavefileVersion()
     {
-        return this.ApiContext.Players.Find(ViewerId)!.SavefileVersion;
+        return this.ApiContext.Players.AsNoTracking().First( x=> x.ViewerId == this.ViewerId).SavefileVersion;
     }
 
     protected async Task LoadIndex()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V14UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V14UpdateTest.cs
@@ -12,12 +12,10 @@ public class V14UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V14Update_DoesNotConflictWithV10Update()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                entity => entity.SetProperty(e => e.EmblemId, Emblems.HotBloodedInstructor),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            entity => entity.SetProperty(e => e.EmblemId, Emblems.HotBloodedInstructor),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         int cellieraCh5 = MasterAsset.CharaStories[(int)Charas.Celliera].StoryIds[^1];
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
@@ -35,7 +35,8 @@ public class V16UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerEventItems.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .BeEquivalentTo(
                 [
                     new DbPlayerEventItem()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V16UpdateTest.cs
@@ -35,7 +35,7 @@ public class V16UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerEventItems.Should()
+        this.ApiContext.PlayerEventItems.Where(x => x.ViewerId == this.ViewerId).Should()
             .BeEquivalentTo(
                 [
                     new DbPlayerEventItem()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
@@ -35,7 +35,7 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .ContainEquivalentOf(
                 new DbPlayerMission()
                 {
@@ -200,7 +200,7 @@ public class V18UpdateTest : SavefileUpdateTestFixture
                 );
         }
 
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .NotContain(
                 x =>
                     x.Id > 10010200
@@ -236,7 +236,7 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
             .Should()
             .AllSatisfy(x => x.State.Should().Be(MissionState.Completed));
     }
@@ -266,7 +266,7 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
             .Should()
             .BeEquivalentTo<DbPlayerMission>(
                 [

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V18UpdateTest.cs
@@ -35,7 +35,8 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .ContainEquivalentOf(
                 new DbPlayerMission()
                 {
@@ -200,7 +201,8 @@ public class V18UpdateTest : SavefileUpdateTestFixture
                 );
         }
 
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .NotContain(
                 x =>
                     x.Id > 10010200
@@ -236,7 +238,8 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .ToList()
             .Should()
             .AllSatisfy(x => x.State.Should().Be(MissionState.Completed));
     }
@@ -266,7 +269,8 @@ public class V18UpdateTest : SavefileUpdateTestFixture
 
         await this.LoadIndex();
 
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).ToList()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .ToList()
             .Should()
             .BeEquivalentTo<DbPlayerMission>(
                 [

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -96,10 +96,12 @@ public class V1UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V1Update_NoDojos_TutorialComplete_Adds()
     {
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
 
         LoadIndexResponse data = (
             await this.Client.PostMsgpack<LoadIndexResponse>(
@@ -114,10 +116,12 @@ public class V1UpdateTest : SavefileUpdateTestFixture
 
         this.GetSavefileVersion().Should().Be(this.MaxVersion);
 
-        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
-            u => u.SetProperty(e => e.TutorialStatus, 0),
-            cancellationToken: TestContext.Current.CancellationToken
-        );
+        await this
+            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdateAsync(
+                u => u.SetProperty(e => e.TutorialStatus, 0),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -96,7 +96,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V1Update_NoDojos_TutorialComplete_Adds()
     {
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
             cancellationToken: TestContext.Current.CancellationToken
         );
@@ -114,7 +114,7 @@ public class V1UpdateTest : SavefileUpdateTestFixture
 
         this.GetSavefileVersion().Should().Be(this.MaxVersion);
 
-        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+        await this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdateAsync(
             u => u.SetProperty(e => e.TutorialStatus, 0),
             cancellationToken: TestContext.Current.CancellationToken
         );

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V1UpdateTest.cs
@@ -96,12 +96,10 @@ public class V1UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V1Update_NoDojos_TutorialComplete_Adds()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.TutorialStatus, TutorialService.TutorialStatusIds.Dojos),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         LoadIndexResponse data = (
             await this.Client.PostMsgpack<LoadIndexResponse>(
@@ -116,12 +114,10 @@ public class V1UpdateTest : SavefileUpdateTestFixture
 
         this.GetSavefileVersion().Should().Be(this.MaxVersion);
 
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u => u.SetProperty(e => e.TutorialStatus, 0),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.TutorialStatus, 0),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V22UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V22UpdateTest.cs
@@ -16,12 +16,10 @@ public class V22UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V22Update_Chapter10Completed_GrantsRewards()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         await this
             .ApiContext.PlayerPresents.Where(x => x.ViewerId == this.ViewerId)
@@ -69,12 +67,10 @@ public class V22UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V22Update_Chapter10NotCompleted_DoesNotGrantRewards()
     {
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u => u.SetProperty(e => e.Level, 30).SetProperty(e => e.Exp, 18990),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         await this
             .ApiContext.PlayerStoryState.Where(x =>

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
@@ -6,9 +6,7 @@ namespace DragaliaAPI.Integration.Test.Features.Story;
 public class StoryTest : TestFixture
 {
     public StoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task ReadStory_StoryNotRead_ResponseHasRewards()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StoryTest.cs
@@ -8,8 +8,6 @@ public class StoryTest : TestFixture
     public StoryTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -114,7 +114,7 @@ public class StorySkipTest : TestFixture
         }
 
         int clearCh1Quest23Mission = 100200;
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .Contain(x => x.Id == clearCh1Quest23Mission)
             .Which.State.Should()
             .Be(MissionState.Completed);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -24,16 +24,14 @@ public class StorySkipTest : TestFixture
         FrozenDictionary<FortPlants, FortConfig> fortConfigs = StorySkipRewards.FortConfigs;
         List<FortPlants> uniqueFortPlants = new(fortConfigs.Keys);
 
-        await this
-            .ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdateAsync(
-                u =>
-                    u.SetProperty(e => e.Level, 5)
-                        .SetProperty(e => e.Exp, 1)
-                        .SetProperty(e => e.StaminaSingle, 10)
-                        .SetProperty(e => e.StaminaMulti, 10),
-                cancellationToken: TestContext.Current.CancellationToken
-            );
+        await this.ApiContext.PlayerUserData.ExecuteUpdateAsync(
+            u =>
+                u.SetProperty(e => e.Level, 5)
+                    .SetProperty(e => e.Exp, 1)
+                    .SetProperty(e => e.StaminaSingle, 10)
+                    .SetProperty(e => e.StaminaMulti, 10),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
 
         await this
             .ApiContext.PlayerQuests.Where(x => x.ViewerId == this.ViewerId && x.QuestId <= questId)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -121,7 +121,7 @@ public class StorySkipTest : TestFixture
             .Be(MissionState.Completed);
 
         int upgradeHalidomToLv3Mission = 105500;
-        this.ApiContext.PlayerMissions.Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
             .Contain(x => x.Id == upgradeHalidomToLv3Mission)
             .Which.State.Should()
             .Be(MissionState.Completed);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -121,7 +121,8 @@ public class StorySkipTest : TestFixture
             .Be(MissionState.Completed);
 
         int upgradeHalidomToLv3Mission = 105500;
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .Contain(x => x.Id == upgradeHalidomToLv3Mission)
             .Which.State.Should()
             .Be(MissionState.Completed);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/StorySkip/StorySkipTest.cs
@@ -114,7 +114,8 @@ public class StorySkipTest : TestFixture
         }
 
         int clearCh1Quest23Mission = 100200;
-        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId).Should()
+        this.ApiContext.PlayerMissions.Where(x => x.ViewerId == this.ViewerId)
+            .Should()
             .Contain(x => x.Id == clearCh1Quest23Mission)
             .Which.State.Should()
             .Be(MissionState.Completed);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -15,9 +15,7 @@ public class SummonTest : TestFixture
     private const int TestGalaBannerId = 1020183;
 
     public SummonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task SummonExcludeGetList_ReturnsAnyData()
@@ -615,16 +613,8 @@ public class SummonTest : TestFixture
     public async Task SummonRequest_SingleSummonTicket_ReturnsValidResult()
     {
         await this.AddToDatabase(
-            new DbSummonTicket()
-            {
-                SummonTicketId = SummonTickets.SingleSummon,
-                Quantity = 1,
-            },
-            new DbSummonTicket()
-            {
-                SummonTicketId = SummonTickets.SingleSummon,
-                Quantity = 1,
-            }
+            new DbSummonTicket() { SummonTicketId = SummonTickets.SingleSummon, Quantity = 1 },
+            new DbSummonTicket() { SummonTicketId = SummonTickets.SingleSummon, Quantity = 1 }
         );
 
         DragaliaResponse<SummonRequestResponse> response =
@@ -648,11 +638,7 @@ public class SummonTest : TestFixture
     public async Task SummonRequest_MultiSingleSummonTicket_ReturnsValidResult()
     {
         await this.AddToDatabase(
-            new DbSummonTicket()
-            {
-                SummonTicketId = SummonTickets.SingleSummon,
-                Quantity = 5,
-            }
+            new DbSummonTicket() { SummonTicketId = SummonTickets.SingleSummon, Quantity = 5 }
         );
 
         DragaliaResponse<SummonRequestResponse> response =
@@ -676,11 +662,7 @@ public class SummonTest : TestFixture
     public async Task SummonRequest_TenfoldSummonTicket_ReturnsValidResult()
     {
         await this.AddToDatabase(
-            new DbSummonTicket()
-            {
-                SummonTicketId = SummonTickets.TenfoldSummon,
-                Quantity = 1,
-            }
+            new DbSummonTicket() { SummonTicketId = SummonTickets.TenfoldSummon, Quantity = 1 }
         );
 
         DragaliaResponse<SummonRequestResponse> response =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -299,7 +299,7 @@ public class SummonTest : TestFixture
                     SummonPoint = 10,
                     GetDewPointQuantity = 0,
                 },
-                o => o.Excluding(x => x.KeyId).WithDateTimeTolerance()
+                o => o.Excluding(x => x.KeyId).WithDateTimeTolerance(TimeSpan.FromSeconds(2))
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -299,7 +299,7 @@ public class SummonTest : TestFixture
                     SummonPoint = 10,
                     GetDewPointQuantity = 0,
                 },
-                o => o.Excluding(x => x.KeyId).WithDateTimeTolerance(TimeSpan.FromSeconds(2))
+                o => o.Excluding(x => x.KeyId).WithDateTimeTolerance()
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Summoning/SummonTest.cs
@@ -17,7 +17,6 @@ public class SummonTest : TestFixture
     public SummonTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
     }
 
     [Fact]
@@ -302,7 +301,7 @@ public class SummonTest : TestFixture
                     SummonPoint = 10,
                     GetDewPointQuantity = 0,
                 },
-                o => o.Excluding(x => x.KeyId)
+                o => o.Excluding(x => x.KeyId).WithDateTimeTolerance()
             );
     }
 
@@ -325,7 +324,6 @@ public class SummonTest : TestFixture
             new DbSummonTicket()
             {
                 SummonTicketId = SummonTickets.SingleSummon,
-                KeyId = 2,
                 Quantity = 1,
                 UseLimitTime = DateTimeOffset.UnixEpoch,
             }
@@ -381,10 +379,10 @@ public class SummonTest : TestFixture
                 new SummonTicketList()
                 {
                     SummonTicketId = SummonTickets.SingleSummon,
-                    KeyId = 2,
                     Quantity = 1,
                     UseLimitTime = DateTimeOffset.UnixEpoch,
-                }
+                },
+                opts => opts.Excluding(x => x.KeyId)
             );
     }
 
@@ -620,13 +618,11 @@ public class SummonTest : TestFixture
             new DbSummonTicket()
             {
                 SummonTicketId = SummonTickets.SingleSummon,
-                KeyId = 1,
                 Quantity = 1,
             },
             new DbSummonTicket()
             {
                 SummonTicketId = SummonTickets.SingleSummon,
-                KeyId = 2,
                 Quantity = 1,
             }
         );
@@ -655,7 +651,6 @@ public class SummonTest : TestFixture
             new DbSummonTicket()
             {
                 SummonTicketId = SummonTickets.SingleSummon,
-                KeyId = 1,
                 Quantity = 5,
             }
         );
@@ -684,7 +679,6 @@ public class SummonTest : TestFixture
             new DbSummonTicket()
             {
                 SummonTicketId = SummonTickets.TenfoldSummon,
-                KeyId = 1,
                 Quantity = 1,
             }
         );
@@ -761,7 +755,7 @@ public class SummonTest : TestFixture
     )
     {
         await this.AddToDatabase(
-            new DbSummonTicket() { SummonTicketId = SummonTickets.TenfoldSummon, KeyId = 1 }
+            new DbSummonTicket() { SummonTicketId = SummonTickets.TenfoldSummon }
         );
 
         DragaliaResponse<SummonRequestResponse> response =

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/TimeAttack/TimeAttackRankingTest.cs
@@ -34,7 +34,7 @@ public class TimeAttackRankingTest : TestFixture
                 cancellationToken: TestContext.Current.CancellationToken
             );
 
-        int questId = 227010101; // First Volk TA quest
+        int questId = 227080101; // Battle in the Dornith Mountains: Beginner
 
         this.ApiContext.PlayerQuests.Add(
             new DbQuest()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -72,7 +72,7 @@ public class ToolTest : TestFixture
             )
         ).Data;
 
-        response.ViewerId.Should().Be((ulong)this.ViewerId + 1);
+        response.ViewerId.Should().BeGreaterThan((ulong)this.ViewerId);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -117,7 +117,7 @@ public class ToolTest : TestFixture
 
         this.Client.DefaultRequestHeaders.Clear();
         this.Client.DefaultRequestHeaders.Add(Headers.IdToken, token);
-        this.Client.DefaultRequestHeaders.Add("DeviceId", "id");
+        this.Client.DefaultRequestHeaders.Add("DeviceId", "expired_device_id");
 
         HttpResponseMessage response = await this.Client.PostMsgpackBasic(
             "/tool/auth",

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -78,9 +78,8 @@ public class ToolTest : TestFixture
     [Fact]
     public async Task Auth_PendingImport_ImportsSave()
     {
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
-            p.SetProperty(e => e.LastSaveImportTime, DateTimeOffset.UnixEpoch)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(p => p.SetProperty(e => e.LastSaveImportTime, DateTimeOffset.UnixEpoch));
 
         string token = TokenHelper.GetToken(
             DeviceAccountId,

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -78,8 +78,9 @@ public class ToolTest : TestFixture
     [Fact]
     public async Task Auth_PendingImport_ImportsSave()
     {
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(p => p.SetProperty(e => e.LastSaveImportTime, DateTimeOffset.UnixEpoch));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+            p.SetProperty(e => e.LastSaveImportTime, DateTimeOffset.UnixEpoch)
+        );
 
         string token = TokenHelper.GetToken(
             DeviceAccountId,

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/ToolTest.cs
@@ -78,7 +78,7 @@ public class ToolTest : TestFixture
     [Fact]
     public async Task Auth_PendingImport_ImportsSave()
     {
-        this.ApiContext.PlayerUserData.ExecuteUpdate(p =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(p =>
             p.SetProperty(e => e.LastSaveImportTime, DateTimeOffset.UnixEpoch)
         );
 
@@ -115,6 +115,7 @@ public class ToolTest : TestFixture
             DateTime.UtcNow - TimeSpan.FromHours(5)
         );
 
+        this.Client.DefaultRequestHeaders.Clear();
         this.Client.DefaultRequestHeaders.Add(Headers.IdToken, token);
         this.Client.DefaultRequestHeaders.Add("DeviceId", "id");
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/TransitionTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tool/TransitionTest.cs
@@ -43,7 +43,7 @@ public class TransitionTest : TestFixture
             )
         ).Data;
 
-        response.TransitionResultData.LinkedViewerId.Should().Be((ulong)this.ViewerId + 1);
+        response.TransitionResultData.LinkedViewerId.Should().BeGreaterThan((ulong)this.ViewerId);
         response.TransitionResultData.AbolishedViewerId.Should().Be(0);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -126,9 +126,8 @@ public class TreasureTradeTest : TestFixture
     public async Task Trade_MultiDragon_AlmostFull_Trades()
     {
         this.ApiContext.PlayerDragonData.ExecuteDelete();
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(e =>
-            e.SetProperty(x => x.MaxDragonQuantity, 2)
-        );
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
+            .ExecuteUpdate(e => e.SetProperty(x => x.MaxDragonQuantity, 2));
 
         int highBrunhildaTrade = 10030302;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -126,7 +126,7 @@ public class TreasureTradeTest : TestFixture
     public async Task Trade_MultiDragon_AlmostFull_Trades()
     {
         this.ApiContext.PlayerDragonData.ExecuteDelete();
-        this.ApiContext.PlayerUserData.ExecuteUpdate(e =>
+        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId).ExecuteUpdate(e =>
             e.SetProperty(x => x.MaxDragonQuantity, 2)
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Trade/TreasureTradeTest.cs
@@ -126,8 +126,9 @@ public class TreasureTradeTest : TestFixture
     public async Task Trade_MultiDragon_AlmostFull_Trades()
     {
         this.ApiContext.PlayerDragonData.ExecuteDelete();
-        this.ApiContext.PlayerUserData.Where(x => x.ViewerId == this.ViewerId)
-            .ExecuteUpdate(e => e.SetProperty(x => x.MaxDragonQuantity, 2));
+        this.ApiContext.PlayerUserData.ExecuteUpdate(e =>
+            e.SetProperty(x => x.MaxDragonQuantity, 2)
+        );
 
         int highBrunhildaTrade = 10030302;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
@@ -11,9 +11,7 @@ namespace DragaliaAPI.Integration.Test.Features.Tutorial;
 public class TutorialTest : TestFixture
 {
     public TutorialTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task TutorialUpdateStep_UpdatesDB()
@@ -58,7 +56,9 @@ public class TutorialTest : TestFixture
             )
         ).Data;
 
-        response.UpdateDataList.Should().BeEquivalentTo(expUpdateData, opts => opts.WithDateTimeTolerance());
+        response
+            .UpdateDataList.Should()
+            .BeEquivalentTo(expUpdateData, opts => opts.WithDateTimeTolerance());
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Tutorial/TutorialTest.cs
@@ -13,7 +13,6 @@ public class TutorialTest : TestFixture
     public TutorialTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]
@@ -59,7 +58,7 @@ public class TutorialTest : TestFixture
             )
         ).Data;
 
-        response.UpdateDataList.Should().BeEquivalentTo(expUpdateData);
+        response.UpdateDataList.Should().BeEquivalentTo(expUpdateData, opts => opts.WithDateTimeTolerance());
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -11,7 +11,6 @@ public class WallRecordTest : TestFixture
     public WallRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallRecordTest.cs
@@ -9,9 +9,7 @@ namespace DragaliaAPI.Integration.Test.Features.Wall;
 public class WallRecordTest : TestFixture
 {
     public WallRecordTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task Record_ReceivesRewards()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
@@ -5,9 +5,7 @@ namespace DragaliaAPI.Integration.Test.Features.Wall;
 public class WallStartTest : TestFixture
 {
     public WallStartTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task Start_ReturnsExpectedResponse()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallStartTest.cs
@@ -7,7 +7,6 @@ public class WallStartTest : TestFixture
     public WallStartTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
@@ -7,9 +7,7 @@ namespace DragaliaAPI.Integration.Test.Features.Wall;
 public class WallTest : TestFixture
 {
     public WallTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
-        : base(factory, outputHelper)
-    {
-    }
+        : base(factory, outputHelper) { }
 
     [Fact]
     public async Task Fail_ReturnsExpectedResponse()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Wall/WallTest.cs
@@ -9,7 +9,6 @@ public class WallTest : TestFixture
     public WallTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper)
     {
-        CommonAssertionOptions.ApplyTimeOptions(toleranceSec: 2);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
@@ -13,7 +13,7 @@ public class NewsTests : WebTestFixture
         : base(factory, testOutputHelper)
     {
         this.ApiContext.NewsItems.ExecuteDelete();
-        
+
         this.ApiContext.NewsItems.AddRange(
             Enumerable
                 .Range(1, 6)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/News/NewsTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Features.Web;
 using DragaliaAPI.Features.Web.News;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Integration.Test.Features.Web.News;
 
@@ -11,6 +12,8 @@ public class NewsTests : WebTestFixture
     public NewsTests(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
         : base(factory, testOutputHelper)
     {
+        this.ApiContext.NewsItems.ExecuteDelete();
+        
         this.ApiContext.NewsItems.AddRange(
             Enumerable
                 .Range(1, 6)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.Data.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.Data.cs
@@ -1,4 +1,5 @@
 using DragaliaAPI.Database.Entities;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Integration.Test.Features.Web.TimeAttack;
 
@@ -6,8 +7,52 @@ public partial class TimeAttackTest
 {
     private async Task SeedTimeAttackData()
     {
+        await this.ApiContext.TimeAttackClears.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
+        
         string teamJson = File.ReadAllText("Data/time_attack_party_info.json");
 
+        DbPlayer player1 = new() { AccountId = Guid.NewGuid().ToString(), UserData = new() { Name = "Qwerby" }, };
+
+        DbPlayer player2 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "Leom" },
+        };
+
+        DbPlayer player3 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "Shiny" },
+        };
+
+        DbPlayer player4 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "poopnut" },
+        };
+        DbPlayer player5 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "Alicia" },
+        };
+
+        DbPlayer player6 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "eze" },
+        };
+
+        DbPlayer player7 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "OzpinXD" },
+        };
+        DbPlayer player8 = new()
+        {
+            AccountId = Guid.NewGuid().ToString(),
+            UserData = new() { Name = "Euden" },
+        };
+        
         DbTimeAttackClear[] clears =
         [
             new()
@@ -21,48 +66,28 @@ public partial class TimeAttackTest
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 1530,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "Qwerby" },
-                        },
+                        Player = player1,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 3108,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "Leom" },
-                        },
+                        Player = player2,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 2104,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "Shiny" },
-                        },
+                        Player = player3,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 1718,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "poopnut" },
-                        },
+                        Player = player4,
                         PartyInfo = teamJson,
                     },
                 ],
@@ -78,25 +103,29 @@ public partial class TimeAttackTest
                     new()
                     {
                         GameId = null!,
-                        ViewerId = 1530,
+                        ViewerId = default,
+                        Player = player1,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
-                        ViewerId = 3108,
+                        ViewerId = default,
+                        Player = player2,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
-                        ViewerId = 2104,
+                        ViewerId = default,
+                        Player = player3,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
-                        ViewerId = 1718,
+                        ViewerId = default,
+                        Player = player4,
                         PartyInfo = teamJson,
                     },
                 ],
@@ -113,48 +142,28 @@ public partial class TimeAttackTest
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 55,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "Alicia" },
-                        },
+                        Player = player5,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 2119,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "eze" },
-                        },
+                        Player = player6,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 2348,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "OzpinXD" },
-                        },
+                        Player = player7,
                         PartyInfo = teamJson,
                     },
                     new()
                     {
                         GameId = null!,
                         ViewerId = default,
-                        Player = new()
-                        {
-                            ViewerId = 609,
-                            AccountId = Guid.NewGuid().ToString(),
-                            UserData = new() { Name = "Euden" },
-                        },
+                        Player = player8,
                         PartyInfo = teamJson,
                     },
                 ],
@@ -170,7 +179,8 @@ public partial class TimeAttackTest
                     new()
                     {
                         GameId = null!,
-                        ViewerId = 1530,
+                        ViewerId = default,
+                        Player = player1,
                         PartyInfo = teamJson,
                     },
                 ],

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.Data.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.Data.cs
@@ -7,52 +7,66 @@ public partial class TimeAttackTest
 {
     private async Task SeedTimeAttackData()
     {
-        await this.ApiContext.TimeAttackClears.ExecuteDeleteAsync(TestContext.Current.CancellationToken);
-        
+        await this.ApiContext.TimeAttackClears.ExecuteDeleteAsync(
+            TestContext.Current.CancellationToken
+        );
+
         string teamJson = File.ReadAllText("Data/time_attack_party_info.json");
 
-        DbPlayer player1 = new() { AccountId = Guid.NewGuid().ToString(), UserData = new() { Name = "Qwerby" }, };
+        DbPlayer player1 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "Qwerby" },
+            };
 
-        DbPlayer player2 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "Leom" },
-        };
+        DbPlayer player2 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "Leom" },
+            };
 
-        DbPlayer player3 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "Shiny" },
-        };
+        DbPlayer player3 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "Shiny" },
+            };
 
-        DbPlayer player4 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "poopnut" },
-        };
-        DbPlayer player5 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "Alicia" },
-        };
+        DbPlayer player4 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "poopnut" },
+            };
+        DbPlayer player5 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "Alicia" },
+            };
 
-        DbPlayer player6 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "eze" },
-        };
+        DbPlayer player6 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "eze" },
+            };
 
-        DbPlayer player7 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "OzpinXD" },
-        };
-        DbPlayer player8 = new()
-        {
-            AccountId = Guid.NewGuid().ToString(),
-            UserData = new() { Name = "Euden" },
-        };
-        
+        DbPlayer player7 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "OzpinXD" },
+            };
+        DbPlayer player8 =
+            new()
+            {
+                AccountId = Guid.NewGuid().ToString(),
+                UserData = new() { Name = "Euden" },
+            };
+
         DbTimeAttackClear[] clears =
         [
             new()

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
@@ -4,7 +4,6 @@ using DragaliaAPI.Features.Web.TimeAttack.Models;
 
 namespace DragaliaAPI.Integration.Test.Features.Web.TimeAttack;
 
-[Collection("TimeAttack")]
 public partial class TimeAttackTest : TestFixture
 {
     public TimeAttackTest(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/TimeAttack/TimeAttackTest.cs
@@ -4,6 +4,7 @@ using DragaliaAPI.Features.Web.TimeAttack.Models;
 
 namespace DragaliaAPI.Integration.Test.Features.Web.TimeAttack;
 
+[Collection("TimeAttack")]
 public partial class TimeAttackTest : TestFixture
 {
     public TimeAttackTest(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
@@ -82,8 +83,6 @@ public partial class TimeAttackTest : TestFixture
     public async Task GetRankings_ParsesTeamDataFromJson()
     {
         await this.SeedTimeAttackData();
-
-        AssertionOptions.FormattingOptions.MaxLines = 10000;
 
         OffsetPagedResponse<TimeAttackRanking>? rankings = await this.Client.GetFromJsonAsync<
             OffsetPagedResponse<TimeAttackRanking>

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Users/UserTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/Users/UserTests.cs
@@ -47,7 +47,7 @@ public class UserTests : WebTestFixture
     public async Task UserMe_Authenticated_Returns200()
     {
         string token = TokenHelper.GetToken(
-            DeviceAccountId,
+            this.WebAccountId,
             DateTime.UtcNow + TimeSpan.FromMinutes(5)
         );
 
@@ -84,7 +84,7 @@ public class UserTests : WebTestFixture
     public async Task UserMeProfile_Authenticated_Returns()
     {
         string token = TokenHelper.GetToken(
-            DeviceAccountId,
+            this.WebAccountId,
             DateTime.UtcNow + TimeSpan.FromMinutes(5)
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/WebTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/WebTestFixture.cs
@@ -1,7 +1,16 @@
+using System.Text;
+using Microsoft.IdentityModel.JsonWebTokens;
+using Microsoft.IdentityModel.Tokens;
+
 namespace DragaliaAPI.Integration.Test.Features.Web;
 
 public class WebTestFixture : TestFixture
 {
+    /// <summary>
+    /// The web account ID.
+    /// </summary>
+    protected string WebAccountId { get; } = $"web_account_id_{Guid.NewGuid()}";
+    
     protected WebTestFixture(
         CustomWebApplicationFactory factory,
         ITestOutputHelper testOutputHelper
@@ -10,16 +19,24 @@ public class WebTestFixture : TestFixture
 
     protected void SetupMockBaas()
     {
-        this.MockBaasApi.Setup(x => x.GetUserId(It.IsAny<string>())).ReturnsAsync(DeviceAccountId);
+        this.MockBaasApi.Setup(x => x.GetUserId(It.Is<string>(token => GetSubject(token) == WebAccountId))).ReturnsAsync(DeviceAccountId);
     }
 
     protected void AddTokenCookie()
     {
         string token = TokenHelper.GetToken(
-            DeviceAccountId,
+            WebAccountId,
             DateTime.UtcNow + TimeSpan.FromMinutes(5)
         );
 
         this.Client.DefaultRequestHeaders.Add("Cookie", $"idToken={token}");
+    }
+
+    private static string GetSubject(string token)
+    {
+        string[] segments = token.Split('.');
+        string dataJson = Base64UrlEncoder.Decode(segments[1]);
+        JsonDocument document = JsonDocument.Parse(dataJson);
+        return document.RootElement.GetProperty("sub").GetString() ?? throw new InvalidOperationException("Failed to parse token");
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/WebTestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Web/WebTestFixture.cs
@@ -10,7 +10,7 @@ public class WebTestFixture : TestFixture
     /// The web account ID.
     /// </summary>
     protected string WebAccountId { get; } = $"web_account_id_{Guid.NewGuid()}";
-    
+
     protected WebTestFixture(
         CustomWebApplicationFactory factory,
         ITestOutputHelper testOutputHelper
@@ -19,7 +19,10 @@ public class WebTestFixture : TestFixture
 
     protected void SetupMockBaas()
     {
-        this.MockBaasApi.Setup(x => x.GetUserId(It.Is<string>(token => GetSubject(token) == WebAccountId))).ReturnsAsync(DeviceAccountId);
+        this.MockBaasApi.Setup(x =>
+                x.GetUserId(It.Is<string>(token => GetSubject(token) == WebAccountId))
+            )
+            .ReturnsAsync(DeviceAccountId);
     }
 
     protected void AddTokenCookie()
@@ -37,6 +40,7 @@ public class WebTestFixture : TestFixture
         string[] segments = token.Split('.');
         string dataJson = Base64UrlEncoder.Decode(segments[1]);
         JsonDocument document = JsonDocument.Parse(dataJson);
-        return document.RootElement.GetProperty("sub").GetString() ?? throw new InvalidOperationException("Failed to parse token");
+        return document.RootElement.GetProperty("sub").GetString()
+            ?? throw new InvalidOperationException("Failed to parse token");
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/AuthorizationMiddlewareTest.cs
@@ -21,7 +21,7 @@ public class AuthorizationMiddlewareTest : TestFixture
     public async Task ValidSidHeader_ReturnsExpectedResponse()
     {
         this.Client.DefaultRequestHeaders.Clear();
-        this.Client.DefaultRequestHeaders.Add("SID", "session_id");
+        this.Client.DefaultRequestHeaders.Add("SID", this.SessionId);
 
         HttpResponseMessage response = await this.Client.GetAsync(
             Endpoint,

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -37,10 +37,10 @@ public class GlobalQueryFilterTest : TestFixture
     public async Task DbPlayerUserData_HasGlobalQueryFilter()
     {
         // We will already have an instance for our own Viewer ID thanks to TestFixture
-        DbPlayer otherPlayer = new() {  AccountId = "other_userdata" };
+        DbPlayer otherPlayer = new() { AccountId = "other_userdata" };
         this.ApiContext.Players.Add(otherPlayer);
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        
+
         this.ApiContext.PlayerUserData.Add(new() { ViewerId = otherPlayer.ViewerId });
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -126,7 +126,7 @@ public class GlobalQueryFilterTest : TestFixture
         DbPlayer otherPlayer = new() { AccountId = "other_diamantium" };
         this.ApiContext.Players.Add(otherPlayer);
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        
+
         this.ApiContext.PlayerDiamondData.Add(new() { ViewerId = otherPlayer.ViewerId });
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
@@ -147,13 +147,13 @@ public class GlobalQueryFilterTest : TestFixture
 
         this.ApiContext.Players.Add(otherPlayer);
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        
+
         TEntity visible = CreateEntityInstance<TEntity>();
         visible.ViewerId = this.ViewerId;
 
         TEntity invisible = CreateEntityInstance<TEntity>();
         invisible.ViewerId = otherPlayer.ViewerId;
-        
+
         this.ApiContext.Set<TEntity>().Add(visible);
         this.ApiContext.Set<TEntity>().Add(invisible);
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -37,8 +37,11 @@ public class GlobalQueryFilterTest : TestFixture
     public async Task DbPlayerUserData_HasGlobalQueryFilter()
     {
         // We will already have an instance for our own Viewer ID thanks to TestFixture
-        this.ApiContext.Players.Add(new() { ViewerId = this.ViewerId + 1, AccountId = "other" });
-        this.ApiContext.PlayerUserData.Add(new() { ViewerId = this.ViewerId + 1 });
+        DbPlayer otherPlayer = new() {  AccountId = "other_userdata" };
+        this.ApiContext.Players.Add(otherPlayer);
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        
+        this.ApiContext.PlayerUserData.Add(new() { ViewerId = otherPlayer.ViewerId });
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (
@@ -89,7 +92,7 @@ public class GlobalQueryFilterTest : TestFixture
                 new()
                 {
                     Id = 2,
-                    Owner = new() { ViewerId = this.ViewerId + 1, AccountId = "otherhist" },
+                    Owner = new() { AccountId = "otherhist" },
                 },
             ]
         );
@@ -120,8 +123,11 @@ public class GlobalQueryFilterTest : TestFixture
     [Fact]
     public async Task DbPlayerDiamondData_HasGlobalQueryFilter()
     {
-        this.ApiContext.Players.Add(new() { ViewerId = this.ViewerId + 1, AccountId = "other" });
-        this.ApiContext.PlayerDiamondData.Add(new() { ViewerId = this.ViewerId + 1 });
+        DbPlayer otherPlayer = new() { AccountId = "other_diamantium" };
+        this.ApiContext.Players.Add(otherPlayer);
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        
+        this.ApiContext.PlayerDiamondData.Add(new() { ViewerId = otherPlayer.ViewerId });
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (
@@ -137,18 +143,20 @@ public class GlobalQueryFilterTest : TestFixture
     private async Task TestGlobalQueryFilter<TEntity>()
         where TEntity : class, IDbPlayerData
     {
-        DbPlayer otherPlayer = new DbPlayer() { ViewerId = this.ViewerId + 1, AccountId = "other" };
+        DbPlayer otherPlayer = new DbPlayer() { AccountId = "other" };
 
+        this.ApiContext.Players.Add(otherPlayer);
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        
         TEntity visible = CreateEntityInstance<TEntity>();
         visible.ViewerId = this.ViewerId;
 
         TEntity invisible = CreateEntityInstance<TEntity>();
-        invisible.ViewerId = this.ViewerId + 1;
-
-        this.ApiContext.Players.Add(otherPlayer);
+        invisible.ViewerId = otherPlayer.ViewerId;
+        
         this.ApiContext.Set<TEntity>().Add(visible);
         this.ApiContext.Set<TEntity>().Add(invisible);
-        await this.ApiContext.SaveChangesAsync();
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         this.ApiContext.ChangeTracker.Clear();
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -85,14 +85,20 @@ public class GlobalQueryFilterTest : TestFixture
     [Fact]
     public async Task DbPlayerPresentHistory_HasGlobalQueryFilter()
     {
-        // This entity uses a non-auto-incrementing integer primary key :/
+        // Acquire valid ID values from the Presents table
+        DbPlayerPresent present = new() { ViewerId = this.ViewerId };
+        DbPlayerPresent otherPresent = new() { Owner = new() { AccountId = "otherhist" } };
+        this.ApiContext.PlayerPresents.Add(present);
+        this.ApiContext.PlayerPresents.Add(otherPresent);
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+        
         this.ApiContext.PlayerPresentHistory.AddRange(
             [
-                new() { Id = 1, ViewerId = this.ViewerId },
+                new() { Id = present.PresentId, ViewerId = this.ViewerId },
                 new()
                 {
-                    Id = 2,
-                    Owner = new() { AccountId = "otherhist" },
+                    Id = otherPresent.PresentId,
+                    ViewerId = otherPresent.ViewerId,
                 },
             ]
         );

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -127,6 +127,22 @@ public class GlobalQueryFilterTest : TestFixture
     }
 
     [Fact]
+    public async Task DbPlayerMaterial_hasGlobalQueryFilter()
+    {
+        // All materials are added by the test fixture, so can't use generic method due to conflicts
+        this.ApiContext.PlayerMaterials.Add(new() { MaterialId = Materials.Squishums, Owner = new() { AccountId = "other_material"}});
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        (
+                await this
+                    .ApiContext.PlayerMaterials.AsNoTracking()
+                    .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
+            )
+            .Should()
+            .AllSatisfy(x => x.ViewerId.Should().Be(this.ViewerId));
+    }
+
+    [Fact]
     public async Task DbPlayerDiamondData_HasGlobalQueryFilter()
     {
         DbPlayer otherPlayer = new() { AccountId = "other_diamantium" };

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/GlobalQueryFilterTest.cs
@@ -91,15 +91,11 @@ public class GlobalQueryFilterTest : TestFixture
         this.ApiContext.PlayerPresents.Add(present);
         this.ApiContext.PlayerPresents.Add(otherPresent);
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
-        
+
         this.ApiContext.PlayerPresentHistory.AddRange(
             [
                 new() { Id = present.PresentId, ViewerId = this.ViewerId },
-                new()
-                {
-                    Id = otherPresent.PresentId,
-                    ViewerId = otherPresent.ViewerId,
-                },
+                new() { Id = otherPresent.PresentId, ViewerId = otherPresent.ViewerId },
             ]
         );
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
@@ -130,14 +126,20 @@ public class GlobalQueryFilterTest : TestFixture
     public async Task DbPlayerMaterial_hasGlobalQueryFilter()
     {
         // All materials are added by the test fixture, so can't use generic method due to conflicts
-        this.ApiContext.PlayerMaterials.Add(new() { MaterialId = Materials.Squishums, Owner = new() { AccountId = "other_material"}});
+        this.ApiContext.PlayerMaterials.Add(
+            new()
+            {
+                MaterialId = Materials.Squishums,
+                Owner = new() { AccountId = "other_material" },
+            }
+        );
         await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         (
-                await this
-                    .ApiContext.PlayerMaterials.AsNoTracking()
-                    .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
-            )
+            await this
+                .ApiContext.PlayerMaterials.AsNoTracking()
+                .ToListAsync(cancellationToken: TestContext.Current.CancellationToken)
+        )
             .Should()
             .AllSatisfy(x => x.ViewerId.Should().Be(this.ViewerId));
     }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -17,7 +17,6 @@ public class SavefileImportTest : TestFixture
     {
         Environment.SetEnvironmentVariable("DEVELOPER_TOKEN", "supersecrettoken");
         this.Client.DefaultRequestHeaders.Add("Authorization", $"Bearer supersecrettoken");
-
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/SavefileImportTest.cs
@@ -18,7 +18,6 @@ public class SavefileImportTest : TestFixture
         Environment.SetEnvironmentVariable("DEVELOPER_TOKEN", "supersecrettoken");
         this.Client.DefaultRequestHeaders.Add("Authorization", $"Bearer supersecrettoken");
 
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestCollection.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestCollection.cs
@@ -1,7 +1,0 @@
-namespace DragaliaAPI.Integration.Test;
-
-[CollectionDefinition(Name)]
-public class TestCollection : ICollectionFixture<CustomWebApplicationFactory>
-{
-    public const string Name = "DragaliaIntegration";
-}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestContainersHelper.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestContainersHelper.cs
@@ -104,8 +104,7 @@ public class TestContainersHelper
         if (!this.ContainersAvailable)
             return;
 
-        await Task.WhenAll(postgresContainer.StartAsync(),
-            redisContainer.StartAsync());
+        await Task.WhenAll(postgresContainer.StartAsync(), redisContainer.StartAsync());
 
         this.postgresPort = this.postgresPort = this.postgresContainer.GetMappedPublicPort(
             PostgresContainerPort

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestContainersHelper.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestContainersHelper.cs
@@ -104,8 +104,8 @@ public class TestContainersHelper
         if (!this.ContainersAvailable)
             return;
 
-        await postgresContainer.StartAsync();
-        await redisContainer.StartAsync();
+        await Task.WhenAll(postgresContainer.StartAsync(),
+            redisContainer.StartAsync());
 
         this.postgresPort = this.postgresPort = this.postgresContainer.GetMappedPublicPort(
             PostgresContainerPort

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -313,7 +313,13 @@ public class TestFixture
         IDistributedCache cache = this.Services.GetRequiredService<IDistributedCache>();
 
         Session session =
-            new(this.SessionId, "id_token", this.DeviceAccountId, this.ViewerId, DateTimeOffset.MaxValue);
+            new(
+                this.SessionId,
+                "id_token",
+                this.DeviceAccountId,
+                this.ViewerId,
+                DateTimeOffset.MaxValue
+            );
         await cache.SetStringAsync(
             $":session:session_id:{this.SessionId}",
             JsonSerializer.Serialize(session)

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -212,7 +212,7 @@ public class TestFixture
     protected long GetTalismanKeyId(Talismans talisman)
     {
         return this
-            .ApiContext.PlayerTalismans.Where(x => x.TalismanId == talisman)
+            .ApiContext.PlayerTalismans.Where(x => x.ViewerId == this.ViewerId && x.TalismanId == talisman)
             .Select(x => x.TalismanKeyId)
             .DefaultIfEmpty()
             .First();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -54,7 +54,9 @@ public class TestFixture
         this.SeedDatabase().Wait();
         this.SeedCache().Wait();
 
-        IPlayerIdentityService stubPlayerIdentityService = new StubPlayerIdentityService(this.ViewerId);
+        IPlayerIdentityService stubPlayerIdentityService = new StubPlayerIdentityService(
+            this.ViewerId
+        );
 
         DbContextOptions<ApiContext> options = this.Services.GetRequiredService<
             DbContextOptions<ApiContext>
@@ -212,7 +214,9 @@ public class TestFixture
     protected long GetTalismanKeyId(Talismans talisman)
     {
         return this
-            .ApiContext.PlayerTalismans.Where(x => x.ViewerId == this.ViewerId && x.TalismanId == talisman)
+            .ApiContext.PlayerTalismans.Where(x =>
+                x.ViewerId == this.ViewerId && x.TalismanId == talisman
+            )
             .Select(x => x.TalismanKeyId)
             .DefaultIfEmpty()
             .First();
@@ -318,6 +322,9 @@ public class TestFixture
             $":session:session_id:{this.sessionId}",
             JsonSerializer.Serialize(session)
         );
-        await cache.SetStringAsync($":session_id:device_account_id:{this.DeviceAccountId}", sessionId);
+        await cache.SetStringAsync(
+            $":session_id:device_account_id:{this.DeviceAccountId}",
+            sessionId
+        );
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -87,10 +87,6 @@ public class TestFixture
     /// <summary>
     /// The viewer ID associated with the logged in user.
     /// </summary>
-    /// <remarks>
-    /// This is not a constant -- although the database is cleared in <see cref="SeedDatabase"/> between each test,
-    /// the seeding of the identity column is not reset, so each test increments the viewer ID by 1.
-    /// </remarks>
     protected long ViewerId { get; private set; }
 
     protected HttpClient Client { get; set; }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -34,7 +34,7 @@ public class TestFixture
     /// <summary>
     /// The session ID which is associated with the logged in test user.
     /// </summary>
-    private readonly string sessionId = $"session_id_{Guid.NewGuid()}";
+    protected string SessionId { get; } = $"session_id_{Guid.NewGuid()}";
 
     private readonly CustomWebApplicationFactory factory;
 
@@ -204,7 +204,7 @@ public class TestFixture
                 }
             );
 
-        client.DefaultRequestHeaders.Add(Headers.SessionId, sessionId);
+        client.DefaultRequestHeaders.Add(Headers.SessionId, this.SessionId);
         client.DefaultRequestHeaders.Add("Platform", "2");
         client.DefaultRequestHeaders.Add("Res-Ver", "y2XM6giU6zz56wCm");
 
@@ -317,14 +317,14 @@ public class TestFixture
         IDistributedCache cache = this.Services.GetRequiredService<IDistributedCache>();
 
         Session session =
-            new(sessionId, "id_token", DeviceAccountId, this.ViewerId, DateTimeOffset.MaxValue);
+            new(this.SessionId, "id_token", this.DeviceAccountId, this.ViewerId, DateTimeOffset.MaxValue);
         await cache.SetStringAsync(
-            $":session:session_id:{this.sessionId}",
+            $":session:session_id:{this.SessionId}",
             JsonSerializer.Serialize(session)
         );
         await cache.SetStringAsync(
             $":session_id:device_account_id:{this.DeviceAccountId}",
-            sessionId
+            this.SessionId
         );
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -20,26 +20,23 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Time.Testing;
-using Npgsql;
 using static DragaliaAPI.Infrastructure.DragaliaHttpConstants;
 
 namespace DragaliaAPI.Integration.Test;
 
-[Collection(TestCollection.Name)]
 public class TestFixture
 {
     /// <summary>
     /// The device account ID which links to the seeded savefiles <see cref="SeedDatabase"/>
     /// </summary>
-    protected const string DeviceAccountId = "logged_in_id";
+    protected string DeviceAccountId { get; } = $"logged_in_id_{Guid.NewGuid()}";
 
     /// <summary>
     /// The session ID which is associated with the logged in test user.
     /// </summary>
-    protected const string SessionId = "session_id";
+    private readonly string sessionId = $"session_id_{Guid.NewGuid()}";
 
     private readonly CustomWebApplicationFactory factory;
-    private readonly IPlayerIdentityService stubPlayerIdentityService;
 
     protected TestFixture(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
     {
@@ -57,18 +54,18 @@ public class TestFixture
         this.SeedDatabase().Wait();
         this.SeedCache().Wait();
 
-        this.stubPlayerIdentityService = new StubPlayerIdentityService(this.ViewerId);
+        IPlayerIdentityService stubPlayerIdentityService = new StubPlayerIdentityService(this.ViewerId);
 
         DbContextOptions<ApiContext> options = this.Services.GetRequiredService<
             DbContextOptions<ApiContext>
         >();
-        this.ApiContext = new ApiContext(options, this.stubPlayerIdentityService);
+        this.ApiContext = new ApiContext(options, stubPlayerIdentityService);
         this.ApiContext.ChangeTracker.QueryTrackingBehavior = QueryTrackingBehavior.NoTracking;
 
         this.DungeonService = new DungeonService(
             this.Services.GetRequiredService<IDistributedCache>(),
             this.Services.GetRequiredService<IOptionsMonitor<RedisCachingOptions>>(),
-            this.stubPlayerIdentityService,
+            stubPlayerIdentityService,
             NullLogger<DungeonService>.Instance
         );
     }
@@ -205,7 +202,7 @@ public class TestFixture
                 }
             );
 
-        client.DefaultRequestHeaders.Add(Headers.SessionId, SessionId);
+        client.DefaultRequestHeaders.Add(Headers.SessionId, sessionId);
         client.DefaultRequestHeaders.Add("Platform", "2");
         client.DefaultRequestHeaders.Add("Res-Ver", "y2XM6giU6zz56wCm");
 
@@ -231,12 +228,6 @@ public class TestFixture
 
     private async Task SeedDatabase()
     {
-        await using NpgsqlConnection connection = new(this.factory.PostgresConnectionString);
-        await connection.OpenAsync();
-
-        ArgumentNullException.ThrowIfNull(this.factory.Respawner);
-        await this.factory.Respawner.ResetAsync(connection);
-
         ISavefileService savefileService = this.Services.GetRequiredService<ISavefileService>();
         IPlayerIdentityService playerIdentityService =
             this.Services.GetRequiredService<IPlayerIdentityService>();
@@ -319,16 +310,14 @@ public class TestFixture
 
     private async Task SeedCache()
     {
-        this.factory.ResetCache();
-
         IDistributedCache cache = this.Services.GetRequiredService<IDistributedCache>();
 
         Session session =
-            new(SessionId, "id_token", DeviceAccountId, this.ViewerId, DateTimeOffset.MaxValue);
+            new(sessionId, "id_token", DeviceAccountId, this.ViewerId, DateTimeOffset.MaxValue);
         await cache.SetStringAsync(
-            ":session:session_id:session_id",
+            $":session:session_id:{this.sessionId}",
             JsonSerializer.Serialize(session)
         );
-        await cache.SetStringAsync(":session_id:device_account_id:logged_in_id", SessionId);
+        await cache.SetStringAsync($":session_id:device_account_id:{this.DeviceAccountId}", sessionId);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
@@ -6,20 +6,22 @@ namespace DragaliaAPI.Test.Utils;
 
 public static class CommonAssertionOptions
 {
-    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(this EquivalencyAssertionOptions<T> options) => WithDateTimeTolerance(options, TimeSpan.FromSeconds(1));
-    
-    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(this EquivalencyAssertionOptions<T> options, TimeSpan tolerance)
-    {
+    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(
+        this EquivalencyAssertionOptions<T> options
+    ) => WithDateTimeTolerance(options, TimeSpan.FromSeconds(1));
 
+    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(
+        this EquivalencyAssertionOptions<T> options,
+        TimeSpan tolerance
+    )
+    {
         options
             .Using<DateTimeOffset>(ctx =>
-                ctx.Subject.Should()
-                    .BeCloseTo(ctx.Expectation, tolerance)
+                ctx.Subject.Should().BeCloseTo(ctx.Expectation, tolerance)
             )
             .WhenTypeIs<DateTimeOffset>();
 
         return options;
-
 
         // AssertionOptions.AssertEquivalencyUsing(options =>
         //     options
@@ -30,6 +32,4 @@ public static class CommonAssertionOptions
         //         .WhenTypeIs<TimeSpan>()
         // );
     }
-
-
 }

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
@@ -6,10 +6,26 @@ namespace DragaliaAPI.Test.Utils;
 
 public static class CommonAssertionOptions
 {
+    /// <summary>
+    /// Applies a tolerance when comparing <see cref="DateTimeOffset"/> properties in FluentAssertions equivalency.
+    /// </summary>
+    /// <remarks>
+    /// The default applied tolerance is +- three seconds.
+    /// </remarks>
+    /// <param name="options">Instance of <see cref="EquivalencyAssertionOptions{TExpectation}"/>.</param>
+    /// <typeparam name="T">The root type of object being compared.</typeparam>
+    /// <returns>The same instance given by <paramref name="options"/>, for chaining calls.</returns>
     public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(
         this EquivalencyAssertionOptions<T> options
-    ) => WithDateTimeTolerance(options, TimeSpan.FromSeconds(1));
+    ) => WithDateTimeTolerance(options, TimeSpan.FromSeconds(3));
 
+    /// <summary>
+    /// Applies a tolerance when comparing <see cref="DateTimeOffset"/> properties in FluentAssertions equivalency.
+    /// </summary>
+    /// <param name="options">Instance of <see cref="EquivalencyAssertionOptions{TExpectation}"/>.</param>
+    /// <param name="tolerance">The tolerance to apply.</param>
+    /// <typeparam name="T">The root type of object being compared.</typeparam>
+    /// <returns>The same instance given by <paramref name="options"/>, for chaining calls.</returns>
     public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(
         this EquivalencyAssertionOptions<T> options,
         TimeSpan tolerance
@@ -22,14 +38,5 @@ public static class CommonAssertionOptions
             .WhenTypeIs<DateTimeOffset>();
 
         return options;
-
-        // AssertionOptions.AssertEquivalencyUsing(options =>
-        //     options
-        //         .Using<TimeSpan>(ctx =>
-        //             ctx.Subject.Should()
-        //                 .BeCloseTo(ctx.Expectation, TimeSpan.FromSeconds(toleranceSec))
-        //         )
-        //         .WhenTypeIs<TimeSpan>()
-        // );
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
@@ -1,4 +1,5 @@
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Entities.Abstract;
 using FluentAssertions;
 using FluentAssertions.Equivalency;
 
@@ -37,6 +38,40 @@ public static class CommonAssertionOptions
             )
             .WhenTypeIs<DateTimeOffset>();
 
+        return options;
+    }
+
+    /// <summary>
+    /// Applies a tolerance when comparing <see cref="TimeSpan"/> properties in FluentAssertions equivalency.
+    /// </summary>
+    /// <param name="options">Instance of <see cref="EquivalencyAssertionOptions{TExpectation}"/>.</param>
+    /// <param name="tolerance">The tolerance to apply.</param>
+    /// <typeparam name="T">The root type of object being compared.</typeparam>
+    /// <returns>The same instance given by <paramref name="options"/>, for chaining calls.</returns>
+    public static EquivalencyAssertionOptions<T> WithTimeSpanTolerance<T>(
+        this EquivalencyAssertionOptions<T> options,
+        TimeSpan tolerance
+    )
+    {
+        options
+            .Using<TimeSpan>(ctx => ctx.Subject.Should().BeCloseTo(ctx.Expectation, tolerance))
+            .WhenTypeIs<TimeSpan>();
+
+        return options;
+    }
+
+    /// <summary>
+    /// Excludes the <see cref="DbPlayerData.Owner"/> navigation property from equivalency assertions.
+    /// </summary>
+    /// <param name="options">Instance of <see cref="EquivalencyAssertionOptions{TExpectation}"/>.</param>
+    /// <typeparam name="T">The root type of object being compared.</typeparam>
+    /// <returns>The same instance given by <paramref name="options"/>, for chaining calls.</returns>
+    public static EquivalencyAssertionOptions<T> ExcludingOwner<T>(
+        this EquivalencyAssertionOptions<T> options
+    )
+        where T : DbPlayerData
+    {
+        options.Excluding(x => x.Owner);
         return options;
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
+++ b/DragaliaAPI/DragaliaAPI.Test.Utils/CommonAssertionOptions.cs
@@ -1,35 +1,35 @@
 using DragaliaAPI.Database.Entities;
 using FluentAssertions;
+using FluentAssertions.Equivalency;
 
 namespace DragaliaAPI.Test.Utils;
 
 public static class CommonAssertionOptions
 {
-    public static void ApplyTimeOptions(int toleranceSec = 1)
+    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(this EquivalencyAssertionOptions<T> options) => WithDateTimeTolerance(options, TimeSpan.FromSeconds(1));
+    
+    public static EquivalencyAssertionOptions<T> WithDateTimeTolerance<T>(this EquivalencyAssertionOptions<T> options, TimeSpan tolerance)
     {
-        AssertionOptions.AssertEquivalencyUsing(options =>
-            options
-                .Using<DateTimeOffset>(ctx =>
-                    ctx.Subject.Should()
-                        .BeCloseTo(ctx.Expectation, TimeSpan.FromSeconds(toleranceSec))
-                )
-                .WhenTypeIs<DateTimeOffset>()
-        );
 
-        AssertionOptions.AssertEquivalencyUsing(options =>
-            options
-                .Using<TimeSpan>(ctx =>
-                    ctx.Subject.Should()
-                        .BeCloseTo(ctx.Expectation, TimeSpan.FromSeconds(toleranceSec))
-                )
-                .WhenTypeIs<TimeSpan>()
-        );
+        options
+            .Using<DateTimeOffset>(ctx =>
+                ctx.Subject.Should()
+                    .BeCloseTo(ctx.Expectation, tolerance)
+            )
+            .WhenTypeIs<DateTimeOffset>();
+
+        return options;
+
+
+        // AssertionOptions.AssertEquivalencyUsing(options =>
+        //     options
+        //         .Using<TimeSpan>(ctx =>
+        //             ctx.Subject.Should()
+        //                 .BeCloseTo(ctx.Expectation, TimeSpan.FromSeconds(toleranceSec))
+        //         )
+        //         .WhenTypeIs<TimeSpan>()
+        // );
     }
 
-    public static void ApplyIgnoreOwnerOptions()
-    {
-        AssertionOptions.AssertEquivalencyUsing(options =>
-            options.Excluding(x => x.Type == typeof(DbPlayer))
-        );
-    }
+
 }

--- a/DragaliaAPI/DragaliaAPI.Test/Features/AbilityCrests/AbilityCrestRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/AbilityCrests/AbilityCrestRepositoryTest.cs
@@ -24,9 +24,6 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
             IdentityTestUtils.MockPlayerDetailsService.Object,
             this.logger.Object
         );
-
-        CommonAssertionOptions.ApplyTimeOptions();
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]
@@ -45,7 +42,8 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
                 {
                     ViewerId = IdentityTestUtils.ViewerId,
                     AbilityCrestId = AbilityCrestId.ADogsDay,
-                }
+                },
+                opts => opts.ExcludingOwner().WithDateTimeTolerance()
             );
     }
 
@@ -89,7 +87,8 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
                 {
                     ViewerId = IdentityTestUtils.ViewerId,
                     AbilityCrestId = AbilityCrestId.FlashofGenius,
-                }
+                },
+                opts => opts.ExcludingOwner().WithDateTimeTolerance()
             );
 
         (await this.abilityCrestRepository.FindAsync(AbilityCrestId.TheBridalDragon))
@@ -109,7 +108,10 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
                 x.ViewerId == IdentityTestUtils.ViewerId && x.AbilityCrestSetNo == 54
             )
             .Should()
-            .BeEquivalentTo(new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 54));
+            .BeEquivalentTo(
+                new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 54),
+                opts => opts.ExcludingOwner()
+            );
 
         await this.abilityCrestRepository.AddOrUpdateSet(
             new DbAbilityCrestSet()
@@ -131,7 +133,8 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
                     ViewerId = IdentityTestUtils.ViewerId,
                     AbilityCrestSetNo = 54,
                     CrestSlotType1CrestId1 = AbilityCrestId.WorthyRivals,
-                }
+                },
+                opts => opts.ExcludingOwner()
             );
     }
 
@@ -145,7 +148,10 @@ public class AbilityCrestRepositoryTest : IClassFixture<DbTestFixture>
 
         (await this.abilityCrestRepository.FindSetAsync(1))
             .Should()
-            .BeEquivalentTo(new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 1));
+            .BeEquivalentTo(
+                new DbAbilityCrestSet(IdentityTestUtils.ViewerId, 1),
+                opts => opts.ExcludingOwner()
+            );
 
         (await this.abilityCrestRepository.FindSetAsync(2)).Should().BeNull();
     }

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/DungeonRepositoryTest.cs
@@ -1,4 +1,5 @@
 ﻿using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Database.Entities.Abstract;
 using DragaliaAPI.Database.Entities.Scaffold;
 using DragaliaAPI.Features.Dungeon;
 using DragaliaAPI.Models.Generated;
@@ -23,8 +24,6 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             this.ApiContext,
             this.mockPlayerIdentityService.Object
         );
-
-        CommonAssertionOptions.ApplyIgnoreOwnerOptions();
     }
 
     [Fact]
@@ -46,7 +45,12 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
-        result.Should().BeEquivalentTo(expectedResult);
+        result
+            .Should()
+            .BeEquivalentTo(
+                expectedResult,
+                opts => opts.Excluding(member => member.Name == nameof(DbPlayerData.Owner))
+            );
     }
 
     [Fact]
@@ -67,7 +71,12 @@ public class DungeonRepositoryTest : RepositoryTestFixture
             .First()
             .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        result.Should().BeEquivalentTo(expectedResult);
+        result
+            .Should()
+            .BeEquivalentTo(
+                expectedResult,
+                opts => opts.Excluding(member => member.Name == nameof(DbPlayerData.Owner))
+            );
     }
 
     private async Task<DbDetailedPartyUnit> SeedDatabase()

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
@@ -47,8 +47,6 @@ public class DungeonRecordServiceTest
         );
 
         this.mockTutorialService.Setup(x => x.AddTutorialFlag(1022)).ReturnsAsync(new List<int>());
-
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]
@@ -245,7 +243,8 @@ public class DungeonRecordServiceTest
                     IsBestClearTime = true,
                     ClearTime = playRecord.Time,
                     ConvertedEntityList = new List<ConvertedEntityList>(),
-                }
+                },
+                opts => opts.WithDateTimeTolerance()
             );
 
         this.mockDungeonRewardService.VerifyAll();

--- a/DragaliaAPI/DragaliaAPI.Test/Services/UpdateDataServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Services/UpdateDataServiceTest.cs
@@ -48,8 +48,6 @@ public class UpdateDataServiceTest : RepositoryTestFixture
             this.mockEventService.Object,
             this.mockDmodeService.Object
         );
-
-        CommonAssertionOptions.ApplyTimeOptions();
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
+++ b/DragaliaAPI/DragaliaAPI/appsettings.Testing.json
@@ -26,6 +26,9 @@
     "PhotonOptions": {
         "Token": "supersecrettoken"
     },
+    "TimeAttackOptions": {
+        "GroupId": 9
+    },
     "EventOptions": {
         "EventList": [
             {
@@ -106,6 +109,9 @@
     },
     "HangfireOptions": {
         "Enabled": false
+    },
+    "PostgresOptions": {
+        "DisableAutoMigration": true
     },
     "FeatureManagement": {
         "BoostedDailyEndeavourRewards": true,


### PR DESCRIPTION
Use AssemblyFixture to run the integration tests in parallel, rather than in series with a database reset in-between. This allows the tests to complete a fair bit faster.  
Dawnshard is effectively a multi-tenant system, so in theory each test can run in isolation under its own viewer ID without affecting others. The only exceptions are things that are public information, like the news data on the website and time attack rankings.

- Don't set AssertionOptions globally as this appears to trigger exceptions inside FluentAssertions if done from multiple threads
- Various changes to make the tests not interfere with each other, typically by scoping queries and updates in tests to the current viewer ID