### PR TITLE
Fix duplicate key errors on WallRewardDate table

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StorySkipTest.cs
@@ -127,4 +127,26 @@ public class StorySkipTest : TestFixture
 
         this.ApiContext.PlayerQuestWalls.Should().Contain(x => x.ViewerId == this.ViewerId);
     }
+
+    [Fact]
+    public async Task StorySkip_AlreadyInitializedWallReward_DoesNotThrow()
+    {
+        await this.AddToDatabase(
+            new DbWallRewardDate()
+            {
+                ViewerId = this.ViewerId,
+                LastClaimDate = DateTimeOffset.UnixEpoch,
+            }
+        );
+
+        await this
+            .Client.Invoking(x =>
+                x.PostMsgpack<StorySkipSkipResponse>(
+                    "story_skip/skip",
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
+            )
+            .Should()
+            .NotThrowAsync();
+    }
 }

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallControllerTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallControllerTest.cs
@@ -54,7 +54,7 @@ public class WallControllerTest
             RewardStatus = rewardStatus,
         };
 
-        mockWallService.Setup(x => x.CheckWallInitialized()).ReturnsAsync(true);
+        mockWallService.Setup(x => x.CheckWallLevelsInitialized()).ReturnsAsync(true);
         mockWallService.Setup(x => x.GetUserWallRewardList()).ReturnsAsync(rewardList);
 
         WallGetMonthlyRewardResponse data = (
@@ -110,7 +110,7 @@ public class WallControllerTest
 
         DateTimeOffset lastClaimDate = DateTimeOffset.UtcNow.AddDays(-62);
 
-        mockWallService.Setup(x => x.CheckWallInitialized()).ReturnsAsync(true);
+        mockWallService.Setup(x => x.CheckWallLevelsInitialized()).ReturnsAsync(true);
         mockWallService
             .Setup(x => x.GetLastRewardDate())
             .ReturnsAsync(new DbWallRewardDate() { LastClaimDate = lastClaimDate });

--- a/DragaliaAPI/DragaliaAPI/Features/Login/LoginService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/LoginService.cs
@@ -126,7 +126,7 @@ public class LoginService(
 
     public async Task<IList<AtgenMonthlyWallReceiveList>> GetWallMonthlyReceiveList()
     {
-        if (!await wallService.CheckWallInitialized())
+        if (!await wallService.CheckWallLevelsInitialized())
         {
             return [];
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V21Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V21Update.cs
@@ -19,7 +19,7 @@ public partial class V21Update(
     public async Task Apply()
     {
         if (
-            await wallService.CheckWallInitialized()
+            await wallService.CheckWallLevelsInitialized()
             && await apiContext.WallRewardDates.FindAsync(playerIdentityService.ViewerId) is null
         )
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/IWallService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/IWallService.cs
@@ -21,7 +21,7 @@ public interface IWallService
     Task InitializeWall();
     Task<Dictionary<QuestWallTypes, int>> GetWallLevelMap();
     Task<DbWallRewardDate> GetLastRewardDate();
-    Task<bool> CheckWallInitialized();
+    Task<bool> CheckWallLevelsInitialized();
     bool CheckCanClaimReward(DateTimeOffset lastClaimDate);
     Task<DbPlayerQuestWall> GetQuestWall(int wallId);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallController.cs
@@ -52,7 +52,7 @@ public partial class WallController(
     [HttpPost("get_monthly_reward")]
     public async Task<DragaliaResult> GetMonthlyReward()
     {
-        if (!await wallService.CheckWallInitialized())
+        if (!await wallService.CheckWallLevelsInitialized())
         {
             Log.InvalidCheckAttempt(logger);
 
@@ -94,7 +94,7 @@ public partial class WallController(
     {
         // Called when sending `monthly_wall_reward_list` from /login/index
 
-        if (!await wallService.CheckWallInitialized())
+        if (!await wallService.CheckWallLevelsInitialized())
         {
             Log.InvalidClaimAttempt(logger);
 


### PR DESCRIPTION
After I made WallRewardDate entities hang around between save imports in #1186, it became possible to hit a case where unlocking Mercurial Gauntlet through gameplay would attempt to add another row to the table and fail on a primary key error.

This would occur, I assume, if you imported a save that had unlocked MG and then re-imported a fresh save that hadn't, and attempted to unlock it again.

Fix this by changing the initialization method to also lazily initialize WallRewardDates, as it already does for the wall level entities.