### PR TITLE
Send quest ID with hero param request

### DIFF
--- a/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GoToIngameStateManager.cs
+++ b/PhotonPlugin/DragaliaAPI.Photon.Plugin/Plugins/GameLogic/GoToIngameStateManager.cs
@@ -180,6 +180,7 @@ namespace DragaliaAPI.Photon.Plugin.Plugins.GameLogic
             IEnumerable<ActorInfo> heroParamRequest = this.pluginHost.GameActors.Select(
                 x => new ActorInfo()
                 {
+                    QuestId = this.pluginHost.GetQuestId(),
                     ActorNr = x.ActorNr,
                     ViewerId = x.GetViewerId(),
                     PartySlots = x.GetPartySlots(),

--- a/Shared/DragaliaAPI.Photon.Shared/Models/ActorInfo.cs
+++ b/Shared/DragaliaAPI.Photon.Shared/Models/ActorInfo.cs
@@ -1,12 +1,9 @@
 ﻿namespace DragaliaAPI.Photon.Shared.Models;
 
-public class HeroParamRequest
-{
-    public List<ActorInfo> Query { get; set; }
-}
-
 public class ActorInfo
 {
+    public int QuestId { get; set; }
+
     public int ActorNr { get; set; }
 
     public long ViewerId { get; set; }


### PR DESCRIPTION
Needed for Orchis to determine if it should send event boost information without doing a race-condition-prone lookup in its own session records as to the current quest ID for the given user.