### PR TITLE
Update MSBuild automation

### DIFF
--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -7,9 +7,6 @@ on:
         type: string
         required: true
         description: "Path to project under test"
-      before-test:
-        type: string
-        description: "Any special commands required for the build that should be invoked before dotnet test"
 
 env:
   HUSKY: 0
@@ -73,10 +70,6 @@ jobs:
 
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project }} --packages .nuget-cache --verbosity normal
-
-      - name: Run build script
-        if: ${{ inputs.before-test != '' }}
-        run: ${{ inputs.before-test }}
 
       - name: Test
         run: >

--- a/.github/workflows/test-api.yaml
+++ b/.github/workflows/test-api.yaml
@@ -26,9 +26,6 @@ jobs:
     uses: ./.github/workflows/integration-test.yaml
     with:
       project: DragaliaAPI/DragaliaAPI.Integration.Test
-      before-test: |
-        dotnet restore DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj
-        dotnet restore DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj
     secrets: inherit
   unit-test:
     name: Unit test
@@ -44,6 +41,4 @@ jobs:
     uses: ./.github/workflows/test.yaml
     with:
       project: ${{ matrix.project }}
-      before-test: |
-        dotnet restore DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj
-        dotnet restore DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj
+     

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,9 +7,6 @@ on:
         type: string
         required: true
         description: "Path to project under test"
-      before-test:
-        type: string
-        description: "Any special commands required for the build that should be invoked before dotnet test"
 
 jobs:
   test:
@@ -44,10 +41,6 @@ jobs:
         
       - name: Install dependencies
         run: dotnet restore ${{ inputs.project }} --packages .nuget-cache --verbosity normal
-        
-      - name: Run pre-test script
-        if: ${{ inputs.before-test != '' }}
-        run: ${{ inputs.before-test }}
 
       - name: Test
         run: >

--- a/DragaliaAPI/Directory.Build.props
+++ b/DragaliaAPI/Directory.Build.props
@@ -5,30 +5,26 @@
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest-minimum</AnalysisLevel>
   </PropertyGroup>
-  <PropertyGroup>
-    <!-- Define the TEST condition to allow test runs in release mode to access conditionally
-    compiled controllers. -->
-    <DefineConstants Condition="$(AUTOMATED_TESTING) == 'true'">TEST;$(DefineConstants)</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup>
-    <MasterAssetResources>$(MSBuildThisFileDirectory)DragaliaAPI.Shared\Resources\</MasterAssetResources>
-    <ApiOutputDirectory>$(MSBuildThisFileDirectory)DragaliaAPI\bin\$(Configuration)\$(TargetFramework)\</ApiOutputDirectory>
-  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <MasterAssetResources>$(MSBuildThisFileDirectory)DragaliaAPI.Shared/Resources/</MasterAssetResources>
+    <ApiOutputDirectory>$(MSBuildThisFileDirectory)DragaliaAPI\bin\$(Configuration)\$(TargetFramework)\</ApiOutputDirectory>
+  </PropertyGroup>
+  
   <Target Name="CopyApiMsgpackFiles" AfterTargets="Build" Condition="$(DependsOnApiMsgpackFiles) == 'true'">
     <ItemGroup>
       <MasterAssetMsgpackFiles Include="$(ApiOutputDirectory)Resources\**\*.msgpack" />
     </ItemGroup>
     <Copy SourceFiles="@(MasterAssetMsgpackFiles)" DestinationFolder="$(OutDir)Resources\%(RecursiveDir)" />
-  </Target>
-  <Target Name="CleanMsgpackFiles" AfterTargets="Clean" Condition="$(DependsOnApiMsgpackFiles) == 'true'">
+    
     <ItemGroup>
-      <FilesToDelete Include="$(OutDir)Resources\**\*.msgpack" />
+      <FileWrites Include="@(MasterAssetMessagePackFiles->'$(OutDir)Resources\%(RecursiveDir)%(Filename).msgpack')" />
     </ItemGroup>
-    <Delete Files="@(FilesToDelete)" />
   </Target>
 </Project>

--- a/DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj
+++ b/DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DragaliaAPI/DragaliaAPI.MasterAssetConverter/MasterAssetConverter.targets
+++ b/DragaliaAPI/DragaliaAPI.MasterAssetConverter/MasterAssetConverter.targets
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <PropertyGroup>
+    <_InvokeConverterCommand>&quot;$(MSBuildThisFileDirectory)bin/$(Configuration)/DragaliaAPI.MasterAssetConverter&quot;</_InvokeConverterCommand>
+    <!-- For Docker builds, where we pass /p:UseAppHost=false -->
+    <_InvokeConverterCommand Condition="$(UseAppHost) == 'false'">dotnet &quot;$(MSBuildThisFileDirectory)bin/$(Configuration)/DragaliaAPI.MasterAssetConverter.dll&quot;</_InvokeConverterCommand>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <_MasterAssetJsonFiles Visible="false" Include="$(MasterAssetResources)**/*.json" Exclude="$(MasterAssetResources)**/*.schema.json" />
+  </ItemGroup>
+  
+  <!-- Hook into build before CopyFilesToOutputDirectory so that we update FileWrites before FileListAbsolute.txt gets written -->
+  <Target Name="MasterAssetConverter"
+          BeforeTargets="CopyFilesToOutputDirectory"
+          DependsOnTargets="MissionDesigner"
+          Inputs="@(_MasterAssetJsonFiles)" Outputs="@(_MasterAssetJsonFiles->'$(OutDir)Resources/%(RecursiveDir)%(Filename).msgpack')">
+   
+    <Exec
+      Command="$(_InvokeConverterCommand) &quot;$(MasterAssetResources)&quot; &quot;$(OutDir)Resources&quot;" 
+      ConsoleToMSBuild="true" />
+
+    <ItemGroup>
+      <MasterAssetMessagePackFiles Include="$(OutDir)Resources/**/*.msgpack" />
+      <FileWrites Include="@(MasterAssetMessagePackFiles)"/>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="CopyMsgpackToPublish" AfterTargets="Publish" DependsOnTargets="MasterAssetConverter">
+    <Copy SourceFiles="@(MasterAssetMessagePackFiles)" DestinationFolder="$(PublishDir)Resources/%(RecursiveDir)" />
+  </Target>
+</Project>

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/MissionDesigner.targets
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/MissionDesigner.targets
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project>
+  <PropertyGroup>
+    <_InvokeMissionDesignerCommand>&quot;$(MSBuildThisFileDirectory)bin/$(Configuration)/DragaliaAPI.MissionDesigner&quot;</_InvokeMissionDesignerCommand>
+    <!-- For Docker builds, where we pass /p:UseAppHost=false -->
+    <_InvokeMissionDesignerCommand Condition="$(UseAppHost) == 'false'">dotnet &quot;$(MSBuildThisFileDirectory)bin/$(Configuration)/DragaliaAPI.MissionDesigner.dll&quot;</_InvokeMissionDesignerCommand>
+  </PropertyGroup>
+  
+  <Target Name="PrepareForMissionDesigner">
+    <PropertyGroup>
+      <MissionDesignerStampFile>$(IntermediateOutputPath).mission-designer</MissionDesignerStampFile>
+    </PropertyGroup>
+  </Target>
+  
+  <Target Name="MissionDesigner" 
+          AfterTargets="Build" DependsOnTargets="PrepareForMissionDesigner" 
+          Inputs="$(MissionDesignerStampFile)"
+          Outputs="$(MasterAssetResources)/Missions/MissionProgressionInfo.json"
+    >
+    
+    <Message Importance="high" Text="Generating MissionProgressionInfo.json into $(MasterAssetResources)"/>
+    <Exec
+      Command="$(_InvokeMissionDesignerCommand) &quot;$(MasterAssetResources)&quot;"
+      ConsoleToMSBuild="true" />
+    
+    <Touch Files="$(MissionDesignerStampFile)" AlwaysCreate="true"/>
+    
+    <ItemGroup>
+      <FileWrites Include="$(MissionDesignerStampFile)"/>
+    </ItemGroup>
+  </Target>
+</Project>  

--- a/DragaliaAPI/DragaliaAPI/Dockerfile
+++ b/DragaliaAPI/DragaliaAPI/Dockerfile
@@ -5,14 +5,17 @@ WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0.101 AS build
 WORKDIR /src
-COPY ["DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj", "DragaliaAPI/DragaliaAPI.MissionDesigner/"]
-COPY ["DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj", "DragaliaAPI/DragaliaAPI.MasterAssetConverter/"]
 COPY ["DragaliaAPI/Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
 COPY ["nuget.config", "."]
-RUN dotnet restore "DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj"
-RUN dotnet restore "DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj"
+COPY ["Aspire/Dawnshard.ServiceDefaults/Dawnshard.ServiceDefaults.csproj", "Aspire/Dawnshard.ServiceDefaults/"]
+COPY ["Shared/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj", "Shared/DragaliaAPI.Photon.Shared/"]
 COPY ["DragaliaAPI/DragaliaAPI/DragaliaAPI.csproj", "DragaliaAPI/DragaliaAPI/"]
+COPY ["DragaliaAPI/DragaliaAPI.Database/DragaliaAPI.Database.csproj", "DragaliaAPI/DragaliaAPI.Database/"]
+COPY ["DragaliaAPI/DragaliaAPI.Shared/DragaliaAPI.Shared.csproj", "DragaliaAPI/DragaliaAPI.Shared/"]
+COPY ["DragaliaAPI/DragaliaAPI.Shared.SourceGenerator/DragaliaAPI.Shared.SourceGenerator.csproj", "DragaliaAPI/DragaliaAPI.Shared.SourceGenerator/"]
+COPY ["DragaliaAPI/DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj", "DragaliaAPI/DragaliaAPI.MasterAssetConverter/"]
+COPY ["DragaliaAPI/DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj", "DragaliaAPI/DragaliaAPI.MissionDesigner/"]
 RUN dotnet restore "DragaliaAPI/DragaliaAPI/DragaliaAPI.csproj"
 COPY [".editorconfig", ".editorconfig"]
 COPY ["DragaliaAPI/", "DragaliaAPI/"]

--- a/DragaliaAPI/DragaliaAPI/DragaliaAPI.csproj
+++ b/DragaliaAPI/DragaliaAPI/DragaliaAPI.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
+  <Import Project="..\DragaliaAPI.MasterAssetConverter\MasterAssetConverter.targets" />
+  <Import Project="..\DragaliaAPI.MissionDesigner\MissionDesigner.targets" />
+  
   <PropertyGroup>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <DockerComposeProjectPath>..\docker-compose.dcproj</DockerComposeProjectPath>
@@ -80,54 +83,11 @@
   
   <ItemGroup>
     <ProjectReference Include="..\..\Aspire\Dawnshard.ServiceDefaults\Dawnshard.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\DragaliaAPI.Database\DragaliaAPI.Database.csproj" />
     <ProjectReference Include="..\..\Shared\DragaliaAPI.Photon.Shared\DragaliaAPI.Photon.Shared.csproj" />
+    <ProjectReference Include="..\DragaliaAPI.Database\DragaliaAPI.Database.csproj" />
     <ProjectReference Include="..\DragaliaAPI.Shared\DragaliaAPI.Shared.csproj" />
+    <ProjectReference Include="..\DragaliaAPI.MissionDesigner\DragaliaAPI.MissionDesigner.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\DragaliaAPI.MasterAssetConverter\DragaliaAPI.MasterAssetConverter.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
-
-  <ItemGroup>
-    <MasterAssetJsonFiles Visible="false" Include="$(MasterAssetResources)**\*.json" Exclude="$(MasterAssetResources)**\*.schema.json" />
-    <MissionProgressionInfoCs Visible="false" Include="../DragaliaAPI.MissionDesigner/**/*.cs" Exclude="../DragaliaAPI.MissionDesigner/obj/**/*.*" />
-  </ItemGroup>
-
-  <Target Name="MissionDesigner" BeforeTargets="MasterAssetConverter" Inputs="@(MissionProgressionInfoCs)" Outputs="$(MasterAssetResources)/Missions/MissionProgressionInfo.json">
-    <MSBuild Projects="../DragaliaAPI.MissionDesigner/DragaliaAPI.MissionDesigner.csproj">
-      <Output ItemName="DesignerOutputs" TaskParameter="TargetOutputs" />
-    </MSBuild>
-
-    <PropertyGroup>
-      <MissionDesignerDll>%(DesignerOutputs.Identity)</MissionDesignerDll>
-    </PropertyGroup>
-
-    <Exec Command="dotnet $(MissionDesignerDll) $(MasterAssetResources)" ConsoleToMSBuild="true" />
-  </Target>
-
-  <Target Name="MasterAssetConverter" AfterTargets="Build" Inputs="@(MasterAssetJsonFiles)" Outputs="@(MasterAssetJsonFiles->'$(OutDir)Resources\%(RecursiveDir)%(Filename).msgpack')">
-    <Message Text="Building MasterAssetConverter" Importance="high" />
-    <MSBuild Projects="../DragaliaAPI.MasterAssetConverter/DragaliaAPI.MasterAssetConverter.csproj">
-      <Output ItemName="ConverterOutputs" TaskParameter="TargetOutputs" />
-    </MSBuild>
-
-    <PropertyGroup>
-      <MasterAssetConverterDll>%(ConverterOutputs.Identity)</MasterAssetConverterDll>
-    </PropertyGroup>
-
-    <Exec Command="dotnet $(MasterAssetConverterDll) $(MasterAssetResources) $(OutDir)Resources\" ConsoleToMSBuild="true" />
-
-    <ItemGroup>
-      <MasterAssetMessagePackFiles Include="$(OutDir)Resources\**\*.msgpack" />
-    </ItemGroup>
-  </Target>
-
-  <Target Name="CopyMsgpackToPublish" AfterTargets="Publish" DependsOnTargets="MasterAssetConverter">
-    <Copy SourceFiles="@(MasterAssetMessagePackFiles)" DestinationFolder="$(PublishDir)Resources\%(RecursiveDir)" />
-  </Target>
-
-  <Target Name="CleanMsgpackFiles" AfterTargets="Clean">
-    <ItemGroup>
-      <FilesToDelete Include="$(OutDir)Resources\**\*.msgpack" />
-    </ItemGroup>
-    <Delete Files="@(FilesToDelete)" />
-  </Target>
 
 </Project>

--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/Dockerfile
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/Dockerfile
@@ -5,10 +5,12 @@ WORKDIR /app
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0.101 AS build
 WORKDIR /src
-COPY ["PhotonStateManager/DragaliaAPI.Photon.StateManager/DragaliaAPI.Photon.StateManager.csproj", "PhotonStateManager/DragaliaAPI.Photon.StateManager/"]
 COPY ["PhotonStateManager/Directory.Build.props", "."]
 COPY ["Directory.Packages.props", "."]
 COPY ["nuget.config", "."]
+COPY ["PhotonStateManager/DragaliaAPI.Photon.StateManager/DragaliaAPI.Photon.StateManager.csproj", "PhotonStateManager/DragaliaAPI.Photon.StateManager/"]
+COPY ["Aspire/Dawnshard.ServiceDefaults/Dawnshard.ServiceDefaults.csproj", "Aspire/Dawnshard.ServiceDefaults/"]
+COPY ["Shared/DragaliaAPI.Photon.Shared/DragaliaAPI.Photon.Shared.csproj", "Shared/DragaliaAPI.Photon.Shared/"]
 RUN dotnet restore "PhotonStateManager/DragaliaAPI.Photon.StateManager/DragaliaAPI.Photon.StateManager.csproj"
 COPY [".editorconfig", ".editorconfig"]
 COPY ["PhotonStateManager/", "PhotonStateManager/"]


### PR DESCRIPTION
Updates the automated generation of mission progression info and msgpack master asset files to leverage MSBuild a bit better:

- Use actual project references instead of manual builds. Allows removing random restore steps from Dockerfiles/CI
- Split the targets into their own files to clean up DragaliaAPI.csproj
- Use FileWrites instead of manually deleting files on clean