### PR TITLE
Fix Mercurial Gauntlet reward check January error

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallTimeProviderExtensionsTests.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Wall/WallTimeProviderExtensionsTests.cs
@@ -31,6 +31,10 @@ public class WallTimeProviderExtensionsTests
                 DateTimeOffset.Parse("2024-05-15T06:00:00Z"),
                 DateTimeOffset.Parse("2024-05-15T06:00:00Z")
             },
+            {
+                DateTimeOffset.Parse("2025-01-01T10:44:00Z"),
+                DateTimeOffset.Parse("2024-12-15T06:00:00Z")
+            },
         };
 
     [Theory]

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallTimeProviderExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallTimeProviderExtensions.cs
@@ -7,6 +7,7 @@ public static class WallTimeProviderExtensions
         DateTimeOffset lastReset = timeProvider.GetLastDailyReset();
 
         int month;
+        int year = lastReset.Year;
 
         if (lastReset.Day >= 15)
         {
@@ -17,8 +18,15 @@ public static class WallTimeProviderExtensions
             month = lastReset.Month - 1;
         }
 
+        // Don't form an invalid date if we're in January
+        if (month == 0)
+        {
+            month = 12;
+            year -= 1;
+        }
+
         return new DateTimeOffset(
-            lastReset.Year,
+            year,
             month,
             15,
             lastReset.Hour,


### PR DESCRIPTION
Happy New Year!

Players are being greeted today by a server error when calling `/login/index` because we are trying to create a `DateTimeOffset` with a date of `15/0/2024` as the last MG reward date.

This code was written this year and failed to account for the January edge case where subtracting 1 from the month is not valid.