### PR TITLE
Story skip fixes

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StorySkipTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Story/StorySkipTest.cs
@@ -2,6 +2,7 @@ using System.Collections.Frozen;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Utils;
 using DragaliaAPI.Features.Story.Skip;
+using DragaliaAPI.Features.Tutorial;
 using DragaliaAPI.Shared.Features.StorySkip;
 using Microsoft.EntityFrameworkCore;
 using static DragaliaAPI.Shared.Features.StorySkip.StorySkipRewards;
@@ -137,6 +138,29 @@ public class StorySkipTest : TestFixture
                 ViewerId = this.ViewerId,
                 LastClaimDate = DateTimeOffset.UnixEpoch,
             }
+        );
+
+        await this
+            .Client.Invoking(x =>
+                x.PostMsgpack<StorySkipSkipResponse>(
+                    "story_skip/skip",
+                    cancellationToken: TestContext.Current.CancellationToken
+                )
+            )
+            .Should()
+            .NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task StorySkip_AlreadyInitializedWall_DoesNotThrow()
+    {
+        await this.Client.PostMsgpack(
+            "quest/read_story",
+            new QuestReadStoryRequest()
+            {
+                QuestStoryId = TutorialService.TutorialStoryIds.MercurialGauntlet,
+            },
+            cancellationToken: TestContext.Current.CancellationToken
         );
 
         await this

--- a/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Wall/WallService.cs
@@ -95,6 +95,8 @@ public partial class WallService(
                     }
                 );
             }
+
+            await this.InitializeWallMissions();
         }
 
         if (!await apiContext.WallRewardDates.AnyAsync())
@@ -107,8 +109,6 @@ public partial class WallService(
                 }
             );
         }
-
-        await this.InitializeWallMissions();
     }
 
     public async Task GrantMonthlyRewardEntityList(IList<AtgenBuildEventRewardEntityList> rewards)


### PR DESCRIPTION
- Ensure we add dragon reliability for dragons added during story skip. Otherwise players will encounter server errors when interacting with new dragons in the roost.
- Ensure we add the first episode of character stories for characters added during story skip.
- Fix InitializeWall not being idempotent and causing a PK conflict in the PlayerMissions table if the player has already unlocked MG prior to doing a story skip.