### PR TITLE
Fix room count metric

### DIFF
--- a/PhotonStateManager/DragaliaAPI.Photon.StateManager/PhotonStateManagerMetrics.cs
+++ b/PhotonStateManager/DragaliaAPI.Photon.StateManager/PhotonStateManagerMetrics.cs
@@ -25,30 +25,18 @@ public class PhotonStateManagerMetrics
 
     private IEnumerable<Measurement<int>> GetRoomCount()
     {
-        List<RedisGame> games = this.connectionProvider.RedisCollection<RedisGame>().ToList();
+        int publicRooms = this
+            .connectionProvider.RedisCollection<RedisGame>()
+            .Count(x => x.MatchingType == MatchingTypes.Anyone);
 
-        List<Measurement<int>> measurements = games
-            .GroupBy(
-                RoomTags.Create,
-                (tags, rooms) => new Measurement<int>(rooms.Count(), tags.ToTagList())
-            )
-            .DefaultIfEmpty(new Measurement<int>(0))
-            .ToList();
+        int privateRooms = this
+            .connectionProvider.RedisCollection<RedisGame>()
+            .Count(x => x.MatchingType != MatchingTypes.Anyone);
 
-        return measurements;
+        return
+        [
+            new Measurement<int>(publicRooms, [new("room.public", true)]),
+            new Measurement<int>(privateRooms, [new("room.public", false)]),
+        ];
     }
-}
-
-file record RoomTags(MatchingTypes MatchingType, int PlayerCount, bool Visible)
-{
-    public static RoomTags Create(RedisGame game) =>
-        new(game.MatchingType, game.Players.Count, game.Visible);
-
-    public TagList ToTagList() =>
-        new()
-        {
-            new("room.matching_type", this.MatchingType.ToString()),
-            new("room.player_count", this.PlayerCount),
-            new("room.visible", this.Visible),
-        };
 }


### PR DESCRIPTION
The room count data currently shows up like this:

![image](https://github.com/user-attachments/assets/dadba373-9619-4d9a-b027-0015c2f5e9e9)

But there are no keys in the Redis database for those rooms.

I think this is because Prometheus scrapes when there are open rooms, and then when these rooms are removed, simply returning a single measurement of 0 doesn't overwrite the more specific room measurements we returned earlier.

Fix this by making the metric dumber and always returning two measurements (for public/private) which may or may not be 0.