### PR TITLE
Don't log an error for room not found

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
@@ -29,6 +29,7 @@ internal partial class ResultCodeLoggingMiddleware(ILogger<ResultCodeLoggingMidd
             or ResultCode.Success
             or ResultCode.CommonChangeDate
             or ResultCode.CommonMaintenance
+            or ResultCode.MatchingRoomIdNotFound
             or ResultCode.CommonTimeout => LogLevel.Information,
             _ => LogLevel.Error,
         };


### PR DESCRIPTION
Avoid logging a result code error when someone inputs an invalid room ID