### PR TITLE
Expand CSP policy

### DIFF
--- a/Website/src/routes/csp/+server.ts
+++ b/Website/src/routes/csp/+server.ts
@@ -1,7 +1,14 @@
 import type { RequestHandler } from './$types';
 
 export const POST: RequestHandler = async ({ locals, request }) => {
-  const violation = await request.json();
+  let violation;
+
+  try {
+    violation = await request.json();
+  } catch (error) {
+    locals.logger.debug({ error }, 'Invalid CSP violation report: {error}');
+    return new Response(null, { status: 400 });
+  }
 
   locals.logger.error({ violation }, 'CSP violation reported: {violation}');
 

--- a/Website/svelte.config.js
+++ b/Website/svelte.config.js
@@ -1,12 +1,18 @@
 import adapter from '@sveltejs/adapter-node';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
-const scriptCsp = [
-  'self',
-  // https://github.com/sveltejs/svelte/issues/14014
-  'unsafe-hashes',
-  'sha256-7dQwUgLau1NFCCGjfn9FsYptB6ZtWxJin6VohGIu20I='
-];
+// An ideal script-src policy:
+// - would remove unsafe-hashes:
+//   https://github.com/sveltejs/svelte/issues/14014
+// - would use strict-dynamic + unsafe-inline for backwards compatibility:
+//   https://github.com/sveltejs/kit/issues/3558
+// - would use trusted-types-for
+//   https://github.com/sveltejs/svelte/issues/14438
+const csp = Object.freeze({
+  'script-src': ['self', 'unsafe-hashes', 'sha256-7dQwUgLau1NFCCGjfn9FsYptB6ZtWxJin6VohGIu20I='],
+  'object-src': ['none'],
+  'base-uri': ['none']
+});
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -23,12 +29,13 @@ const config = {
     },
     csp: {
       directives: {
-        'script-src': scriptCsp
+        ...csp
       },
       reportOnly: {
-        'script-src': scriptCsp,
+        ...csp,
         'report-uri': ['/csp']
-      }
+      },
+      mode: 'nonce'
     }
   }
 };


### PR DESCRIPTION
Adding `object-src: none` and `base-uri: none` as per the guidance of https://csp-evaluator.withgoogle.com/

![image](https://github.com/user-attachments/assets/fc44cfe9-beb3-4353-bf8a-f258d5dd0e02)

Note that SvelteKit does not support unsafe-inline fallbacks; we would need to add `strict-dynamic` which is officially unsupported at the minute. Adding `unsafe-inline` also removes the nonce and breaks the entire page as the browser ignores it due to the unsafe-hashes workaround, but the missing nonce means no other scripts can execute.

`require-trusted-types` also is apparently not supported.