### PR TITLE
Fix website URL on main page

### DIFF
--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -43,7 +43,8 @@
       <LinkButton href="https://discord.gg/j9zSttjjWj" icon={Discord}>Discord</LinkButton>
       <LinkButton href="https://patreon.com/dawnshard" icon={Patreon}>Patreon</LinkButton>
       <LinkButton href="https://buymeacoffee.com/dawnshard" icon={BuyMeACoffee}
-        >Buy me a coffee</LinkButton>
+        >Buy me a coffee
+      </LinkButton>
     </Card.Footer>
   </Card.Root>
 </div>
@@ -64,7 +65,7 @@
       <p>
         Setting up access to the server involves configuring a modified version of the original
         Dragalia Lost app to connect to this server at{' '}
-        <a class="link" href="https://dawnshard.co.uk">https://dawnshard.co.uk</a>. It is possible
+        <a class="link" href="https://dawnshard.co.uk/">https://dawnshard.co.uk</a>. It is possible
         to do so on both Android and iOS without jail-breaking or rooting your device. It is also
         possible to do this on an Android emulator, even though the original game could not be
         played on emulators. If you encounter any issues during the set-up process, consider joining
@@ -130,7 +131,8 @@
     <Typography typography="h2">Frequently asked questions</Typography>
     <div>
       <Typography typography="h3"
-        >Can I link an account to save my progress across devices?</Typography>
+        >Can I link an account to save my progress across devices?
+      </Typography>
       <p>
         Yes, if you follow the prompts to link an account in-game, you will be taken to the <a
           class="link"

--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -42,8 +42,8 @@
       </LinkButton>
       <LinkButton href="https://discord.gg/j9zSttjjWj" icon={Discord}>Discord</LinkButton>
       <LinkButton href="https://patreon.com/dawnshard" icon={Patreon}>Patreon</LinkButton>
-      <LinkButton href="https://buymeacoffee.com/dawnshard" icon={BuyMeACoffee}
-        >Buy me a coffee
+      <LinkButton href="https://buymeacoffee.com/dawnshard" icon={BuyMeACoffee}>
+        Buy me a coffee
       </LinkButton>
     </Card.Footer>
   </Card.Root>
@@ -130,8 +130,8 @@
   <div class="flex flex-col gap-3">
     <Typography typography="h2">Frequently asked questions</Typography>
     <div>
-      <Typography typography="h3"
-        >Can I link an account to save my progress across devices?
+      <Typography typography="h3">
+        Can I link an account to save my progress across devices?
       </Typography>
       <p>
         Yes, if you follow the prompts to link an account in-game, you will be taken to the <a

--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -65,7 +65,7 @@
       <p>
         Setting up access to the server involves configuring a modified version of the original
         Dragalia Lost app to connect to this server at{' '}
-        <a class="link" href="https://dawnshard.co.uk/">https://dawnshard.co.uk</a>. It is possible
+        <a class="link" href="https://dawnshard.co.uk/">https://dawnshard.co.uk/</a>. It is possible
         to do so on both Android and iOS without jail-breaking or rooting your device. It is also
         possible to do this on an Android emulator, even though the original game could not be
         played on emulators. If you encounter any issues during the set-up process, consider joining


### PR DESCRIPTION
iOS users entering a server URL require a trailing slash due to limitations of the modded IPA. Android is indifferent towards trailing slash or no slash. The website URL should have a trailing slash to ensure iOS users aren't left with broken apps.