### PR TITLE
Add User-Agent to CSP reports

### DIFF
--- a/Website/src/routes/csp/+server.ts
+++ b/Website/src/routes/csp/+server.ts
@@ -10,7 +10,12 @@ export const POST: RequestHandler = async ({ locals, request }) => {
     return new Response(null, { status: 400 });
   }
 
-  locals.logger.error({ violation }, 'CSP violation reported: {violation}');
+  const userAgent = request.headers.get('User-Agent');
+
+  locals.logger.error(
+    { violation, userAgent },
+    'CSP violation reported: {violation}. User-Agent: {userAgent}'
+  );
 
   return new Response(null, { status: 200 });
 };


### PR DESCRIPTION
We're getting a lot of CSP violation reports that I am unable to reproduce. The `unsafe-hashes` part of the CSP is only supported by CSP Level 3 browsers, so I'm wondering if the reports are coming from old browsers.

If I can't see a clear pattern in the reports and figure out a way to reproduce them, I will probably just turn them off, as I'm confident the website still works as intended (in my environment/browser at least).