### PR TITLE
Include package versions in Nerdbank version calculation

### DIFF
--- a/DragaliaAPI/version.json
+++ b/DragaliaAPI/version.json
@@ -9,6 +9,7 @@
     "setVersionVariables": false
   },
   "pathFilters": [
-    "."
+    ".",
+    "../Directory.Packages.props"
   ]
 }

--- a/PhotonStateManager/version.json
+++ b/PhotonStateManager/version.json
@@ -9,6 +9,7 @@
     "setVersionVariables": false
   },
   "pathFilters": [
-    "."
+    ".",
+    "../Directory.Packages.props"
   ]
 }


### PR DESCRIPTION
Makes it so Dependabot NuGet upgrades actually bump the nerdbank version