### PR TITLE
Force light mode for webview pages

### DIFF
--- a/Website/src/hooks.server.ts
+++ b/Website/src/hooks.server.ts
@@ -53,6 +53,12 @@ export const handleFetch: HandleFetch = ({ request, event, fetch }) => {
 };
 
 const handleHeadScript: Handle = ({ event, resolve }) => {
+  if (event.request.url.includes('webview')) {
+    // Don't inject dark mode script into webview pages, otherwise a user with the storage key set
+    // from visiting the actual website will get dark mode in-game, which looks bad
+    return resolve(event);
+  }
+
   return resolve(event, {
     transformPageChunk: ({ html }) => {
       return html.replace('%modewatcher.snippet%', generateSetInitialModeExpression({}));


### PR DESCRIPTION
Don't inject the mode watcher script for webview pages, otherwise users who have set a preference on the main website will see dark mode pages in-game, which contrasts with the light mode theme of the other game UI elements.

This only seems to happen on iOS, possibly because the browser local storage is shared between web-view and the system browser?