### PR TITLE
Don't log error for FriendTargetNone result

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
@@ -13,6 +13,7 @@ internal partial class ResultCodeLoggingMiddleware(ILogger<ResultCodeLoggingMidd
             ResultCode.CommonTimeout,
             ResultCode.MatchingRoomIdNotFound,
             ResultCode.FriendIdsearchError,
+            ResultCode.FriendTargetNone,
             ResultCode.FriendTargetAlready,
             ResultCode.FriendApplyExists,
         ];


### PR DESCRIPTION
This code is returned when you enter an invalid ID, it isn't an actual error