### PR TITLE
Enforce friend limit

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Results/ResultCode.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Results/ResultCode.cs
@@ -146,6 +146,13 @@ public enum ResultCode
     WeaponBodyCraftOutOfPeriod,
     WeaponBodyCraftShortWeaponBody,
     WeaponBodyCraftShortAllUnlockWeaponBody,
+
+    /// <summary>
+    /// Shows an error message when attempting to find a player in the friend search:
+    /// <p><i>
+    /// Unable to locate player.
+    /// </i></p>
+    /// </summary>
     FriendTargetNone = 7001,
     FriendTargetAlready,
     FriendIdsearchError = 7004,
@@ -153,9 +160,30 @@ public enum ResultCode
     FriendCountOtherLimit,
     FriendCountLimit,
     FriendApplyCountOtherLimit,
+
+    /// <summary>
+    /// Shows an error message when attempting to send a friend request:
+    /// <p><i>
+    /// You have met the friend request limit. Request cannot be sent.
+    /// </i></p>
+    /// </summary>
     FriendApplyCountLimit,
+
+    /// <summary>
+    /// Shows an error message when attempting to send a friend request:
+    /// <p><i>
+    /// Ten days have passed since the request was made. The request has been deleted.
+    /// </i></p>
+    /// </summary>
     FriendApplyLimitError,
     FriendApplyExists,
+
+    /// <summary>
+    /// Shows an error message when attempting to send a friend request:
+    /// <p><i>
+    /// Friend request not sent.
+    /// </i></p>
+    /// </summary>
     FriendApplyError,
     MemberReinforceSameBaseAndMaterrial = 8001,
     PartyUnexpected,


### PR DESCRIPTION
Enforce the limit to friends, which ranges between 25 and 175 depending on player level.

Some complexity around requests - we want to check 'potential' friends as well, i.e. incoming and outgoing requests, so that it isn't possible to exceed the limit by having many requests accepted at once. The game has a handful of status codes to communicate this for both sides of the interaction.