### PR TITLE
Add remaining facility event missions

### DIFF
--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ACrescendoOfCourage.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ACrescendoOfCourage.cs
@@ -1,0 +1,87 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class CrescendoOfCourage
+{
+    // Quest IDs from QuestNames.txt
+    private const int ExtraBossBattleId = 208290401; // A Fiendish Encore
+
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20829)]
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10070101 },
+            // Clear a Boss Battle
+            new EventRegularBattleClearMission() { MissionId = 10070102 },
+            // Clear an "A Crescendo of Courage" Quest with Surfing Siblings Equipped
+            new EventQuestClearWithCrestMission()
+            {
+                MissionId = 10070201,
+                Crest = AbilityCrestId.SurfingSiblings,
+            },
+            // Collect 100 Hype in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10070301 },
+            // Collect 500 Hype in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10070302 },
+            // Collect 1,500 Hype in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10070303 },
+            // Collect 4,000 Hype in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10070304 },
+            // Collect 7,000 Hype in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10070305 },
+            // Clear Five Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10070401 },
+            // Clear 10 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10070402 },
+            // Clear 20 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10070403 },
+            // Clear 30 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10070404 },
+            // Clear Three Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10070501, QuestId = ExtraBossBattleId },
+            // Clear Six Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10070502, QuestId = ExtraBossBattleId },
+            // Clear 10 Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10070503, QuestId = ExtraBossBattleId },
+            // Clear 15 Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10070504, QuestId = ExtraBossBattleId },
+            // Clear Three Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10070601 },
+            // Clear Six Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10070602 },
+            // Clear 10 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10070603 },
+            // Clear 15 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10070604 },
+            // Completely Clear a Challenge Battle on Expert
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10070701,
+                FullClear = true,
+                VariationType = VariationTypes.VeryHard, // Difficulty 3 for Expert Challenge Battle
+            },
+            // Completely Clear a Challenge Battle on Master
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10070801,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Difficulty 4 for Master Challenge Battle
+            },
+            // Earn the "Summer Champion" Epithet
+            // Typically awarded for completing the Master Challenge Battle with all endeavors
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10070901,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Linked to Master Challenge Battle Clear
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ADashOfDisaster.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ADashOfDisaster.cs
@@ -1,0 +1,83 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class ADashOfDisaster
+{
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20841)]
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10180101 },
+            // Clear a Boss Battle
+            new EventRegularBattleClearMission() { MissionId = 10180201 },
+            // Clear an "A Dash of Disaster" Quest with Berry Lovable Friends Equipped
+            new EventQuestClearWithCrestMission()
+            {
+                MissionId = 10180401,
+                Crest = AbilityCrestId.BerryLovableFriends,
+            },
+            // Collect 100 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180501 },
+            // Collect 500 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180502 },
+            // Collect 1,500 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180503 },
+            // Collect 4,000 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180504 },
+            // Collect 6,000 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180505 },
+            // Collect 7,000 Zest in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10180506 },
+            // Clear Five Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10180601 },
+            // Clear 10 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10180602 },
+            // Clear 15 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10180603 },
+            // Clear 20 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10180604 },
+            // Clear 30 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10180605 },
+            // Clear Three Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180801 },
+            // Clear Six Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180802 },
+            // Clear 10 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180803 },
+            // Clear 15 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180804 },
+            // Clear 20 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180805 },
+            // Clear 25 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10180806 },
+            // Completely Clear a Challenge Battle on Expert
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10180901,
+                FullClear = true,
+                VariationType = VariationTypes.VeryHard, // Difficulty 3 for Expert Challenge Battle
+            },
+            // Completely Clear a Challenge Battle on Master
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10181001,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Difficulty 4 for Master Challenge Battle
+            },
+            // Earn the "Chef de Cuisine" Epithet
+            // Typically awarded for completing the Master Challenge Battle with all endeavors
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10181301,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Linked to Master Challenge Battle Clear
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AWishToTheWinds.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AWishToTheWinds.cs
@@ -1,0 +1,90 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+// Named based on the mission content "A Wish to the Winds"
+public static class AWishToTheWinds
+{
+    // Quest IDs from QuestNames.txt
+    private const int ExtraBossBattleId = 208180401; // Mega-Fiend Spotted!
+
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20818)] // Event ID derived from QuestNames.txt IDs
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10030101 },
+            // Defeat the Water Troll King Twice
+            // Typically tracked as standard boss clears in this system.
+            new EventRegularBattleClearMission() { MissionId = 10030102 },
+            // Clear an A Wish to the Winds Quest with Louise's Hobbies Equipped
+            new EventQuestClearWithCrestMission()
+            {
+                MissionId = 10030201,
+                Crest = AbilityCrestId.LouisesHobbies,
+            },
+            // Collect 100 Divine Gales in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10030301 },
+            // Collect 500 Divine Gales in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10030302 },
+            // Collect 1,500 Divine Gales in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10030303 },
+            // Collect 4,000 Divine Gales in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10030304 },
+            // Collect 7,000 Divine Gales in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10030305 },
+            // Clear Five Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10030502 },
+            // Clear 10 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10030503 },
+            // Clear 20 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10030504 },
+            // Clear 30 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10030505 },
+            // Clear Three Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10030601, QuestId = ExtraBossBattleId },
+            // Clear Six Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10030602, QuestId = ExtraBossBattleId },
+            // Clear 10 Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10030603, QuestId = ExtraBossBattleId },
+            // Clear 15 Extra Boss Battles
+            new ClearQuestMission() { MissionId = 10030604, QuestId = ExtraBossBattleId },
+            // Clear Three Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10030701 },
+            // Clear Six Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10030702 },
+            // Clear 10 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10030703 },
+            // Clear 15 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10030704 },
+            // Completely Clear a Challenge Battle on Expert
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10030801,
+                FullClear = true,
+                VariationType = VariationTypes.Normal,
+            },
+            // Completely Clear a Challenge Battle on Master
+            // QuestNames lists "Ruler of the Shore: Master" as difficulty 4 (Extreme).
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10030901,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme,
+            },
+            // Earn the "Wind Wisher" Epithet
+            // Typically awarded for completing the Master Challenge Battle with all endeavors.
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10031001,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Linked to Master Challenge Battle Clear
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AgentsOfTheGoddess.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AgentsOfTheGoddess.cs
@@ -1,0 +1,97 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+using DragaliaAPI.MissionDesigner.Models.RegularMission;
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class AgentsOfTheGoddess
+{
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20839)]
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10130101 },
+            // Clear a Boss Battle
+            new EventRegularBattleClearMission() { MissionId = 10130201 },
+            // Clear an Agents of the Goddess Quest with Wings in the Night Equipped
+            new EventQuestClearWithCrestMission()
+            {
+                MissionId = 10130401,
+                Crest = AbilityCrestId.WingsintheNight,
+            },
+            // Collect 100 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130501 },
+            // Collect 500 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130502 },
+            // Collect 1,500 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130503 },
+            // Collect 4,000 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130504 },
+            // Collect 6,000 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130505 },
+            // Collect 7,000 Sanctity in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10130506 },
+            // Clear Five Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10130601 },
+            // Clear 10 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10130602 },
+            // Clear 15 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10130603 },
+            // Clear 20 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10130604 },
+            // Clear 30 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10130605 },
+            // Clear Three Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130801 },
+            // Clear Six Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130802 },
+            // Clear 10 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130803 },
+            // Clear 15 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130804 },
+            // Clear 20 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130805 },
+            // Clear 25 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10130806 },
+            // Completely Clear a Challenge Battle on Expert
+            // Quest 208390501 "Divine Deliverance: Expert" has difficulty 3 (VeryHard)
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10130901,
+                FullClear = true,
+                VariationType = VariationTypes.VeryHard,
+            },
+            // Completely Clear a Challenge Battle on Master
+            // Quest 208390502 "Divine Deliverance: Master" has difficulty 4 (Extreme)
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10131001,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme,
+            },
+            // Clear an "Agents of the Goddess" Trial on Standard
+            new ClearQuestMission()
+            {
+                // Human note: the trials for this one use a non-standard quest ID and don't work with the
+                // usual progression type. Rather than widen the detection for trial clears, and risk false
+                // positives, hardcode these as normal 'clear quest' missions
+                MissionId = 10131101,
+                QuestId = 208390304,
+            },
+            // Clear an "Agents of the Goddess" Trial on Expert
+            new ClearQuestMission() { MissionId = 10131201, QuestId = 208390305 },
+            // Earn the "Goddess's Proxy" Epithet
+            // Typically awarded for completing the Master Challenge Battle with all endeavors.
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10131301,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Linked to Master Challenge Battle Clear
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ThePhantomsRansom.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ThePhantomsRansom.cs
@@ -1,0 +1,94 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class PhantomsRansom
+{
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20843)]
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10200101 },
+            // Clear a Boss Battle
+            new EventRegularBattleClearMission() { MissionId = 10200201 },
+            // Clear a "The Phantom's Ransom" Quest with Free-Spirited Opera Equipped
+            new EventQuestClearWithCrestMission()
+            {
+                MissionId = 10200401,
+                Crest = AbilityCrestId.FreeSpiritedOpera,
+            },
+            // Collect 100 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200501 },
+            // Collect 500 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200502 },
+            // Collect 1,500 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200503 },
+            // Collect 4,000 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200504 },
+            // Collect 6,000 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200505 },
+            // Collect 7,000 Vibrato in One Go
+            new EventPointCollectionRecordMission() { MissionId = 10200506 },
+            // Clear Five Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10200601 },
+            // Clear 10 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10200602 },
+            // Clear 15 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10200603 },
+            // Clear 20 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10200604 },
+            // Clear 30 Boss Battles
+            new EventRegularBattleClearMission() { MissionId = 10200605 },
+            // Clear Three Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200801 },
+            // Clear Six Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200802 },
+            // Clear 10 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200803 },
+            // Clear 15 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200804 },
+            // Clear 20 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200805 },
+            // Clear 25 Challenge Battles
+            new EventChallengeBattleClearMission() { MissionId = 10200806 },
+            // Completely Clear a Challenge Battle on Expert
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10200901,
+                FullClear = true,
+                VariationType = VariationTypes.VeryHard, // Expert maps to VeryHard
+            },
+            // Completely Clear a Challenge Battle on Master
+            new EventChallengeBattleClearMission()
+            {
+                MissionId = 10201001,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Master maps to Extreme
+            },
+            // Clear a "The Phantom's Ransom" Trial on Standard
+            new EventTrialClearMission()
+            {
+                MissionId = 10201101,
+                VariationType = VariationTypes.Hell,
+            },
+            // Clear a "The Phantom's Ransom" Trial on Expert
+            new EventTrialClearMission()
+            {
+                MissionId = 10201201,
+                VariationType = VariationTypes.Variation6,
+            },
+            // Earn the "Opera-Troupe Owner" Epithet
+            new EventChallengeBattleClearMission() // Epithets are typically awarded for Master full clear
+            {
+                MissionId = 10201301,
+                FullClear = true,
+                VariationType = VariationTypes.Extreme, // Master maps to Extreme
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -7056,6 +7056,880 @@
     "_Parameter4": 208310502
   },
   {
+    "_Id": 1007010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007010206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070102,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070201,
+    "_CompleteType": "EventQuestClearWithCrest",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829,
+    "_Parameter2": 40050068
+  },
+  {
+    "_Id": 1007030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070301,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007030206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070302,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007030306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070303,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007030406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070304,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007030506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070305,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070401,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007040206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070402,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007040306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070403,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007040406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070404,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070501,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208290401
+  },
+  {
+    "_Id": 1007050206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070502,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208290401
+  },
+  {
+    "_Id": 1007050306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070503,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208290401
+  },
+  {
+    "_Id": 1007050406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070504,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208290401
+  },
+  {
+    "_Id": 1007060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070601,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007060206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070602,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007060306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070603,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007060406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070604,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829
+  },
+  {
+    "_Id": 1007070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070701,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829,
+    "_Parameter2": 3,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1007080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070801,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1007090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10070901,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20829,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1018010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180201,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180401,
+    "_CompleteType": "EventQuestClearWithCrest",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841,
+    "_Parameter2": 40050094
+  },
+  {
+    "_Id": 1018050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180501,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018050206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180502,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018050306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180503,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018050406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180504,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018050506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180505,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018050606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180506,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180601,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018060206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180602,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018060306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180603,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018060406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180604,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018060506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180605,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180801,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180802,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180803,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180804,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180805,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018080606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180806,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841
+  },
+  {
+    "_Id": 1018090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10180901,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841,
+    "_Parameter2": 3,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1018100106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10181001,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1018130106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10181301,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20841,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1013010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130201,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130401,
+    "_CompleteType": "EventQuestClearWithCrest",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839,
+    "_Parameter2": 40050113
+  },
+  {
+    "_Id": 1013050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130501,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013050206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130502,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013050306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130503,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013050406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130504,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013050506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130505,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013050606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130506,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130601,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013060206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130602,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013060306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130603,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013060406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130604,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013060506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130605,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130801,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130802,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130803,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130804,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130805,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013080606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130806,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839
+  },
+  {
+    "_Id": 1013090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10130901,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839,
+    "_Parameter2": 3,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1013100106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10131001,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1013110106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10131101,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208390304
+  },
+  {
+    "_Id": 1013120106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10131201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208390305
+  },
+  {
+    "_Id": 1013130106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10131301,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20839,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1003010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003010206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030102,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030201,
+    "_CompleteType": "EventQuestClearWithCrest",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818,
+    "_Parameter2": 40050023
+  },
+  {
+    "_Id": 1003030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030301,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003030206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030302,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003030306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030303,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003030406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030304,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003030506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030305,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003050206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030502,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003050306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030503,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003050406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030504,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003050506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030505,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030601,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208180401
+  },
+  {
+    "_Id": 1003060206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030602,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208180401
+  },
+  {
+    "_Id": 1003060306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030603,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208180401
+  },
+  {
+    "_Id": 1003060406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030604,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 208180401
+  },
+  {
+    "_Id": 1003070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030701,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003070206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030702,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003070306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030703,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003070406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030704,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818
+  },
+  {
+    "_Id": 1003080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030801,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818,
+    "_Parameter2": 1,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1003090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10030901,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1003100106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10031001,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20818,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
     "_Id": 1021010106,
     "_MissionType": "MemoryEvent",
     "_MissionId": 10210101,
@@ -8593,6 +9467,240 @@
     "_UseTotalValue": 0,
     "_UnlockedOnComplete": [],
     "_Parameter": 20822,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1020010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200201,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200401,
+    "_CompleteType": "EventQuestClearWithCrest",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
+    "_Parameter2": 40050119
+  },
+  {
+    "_Id": 1020050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200501,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020050206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200502,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020050306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200503,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020050406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200504,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020050506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200505,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020050606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200506,
+    "_CompleteType": "EventPointCollection",
+    "_UseTotalValue": 1,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200601,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020060206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200602,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020060306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200603,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020060406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200604,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020060506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200605,
+    "_CompleteType": "EventRegularBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200801,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080206,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200802,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080306,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200803,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080406,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200804,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080506,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200805,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020080606,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200806,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843
+  },
+  {
+    "_Id": 1020090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10200901,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
+    "_Parameter2": 3,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1020100106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10201001,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
+    "_Parameter2": 4,
+    "_Parameter3": 1
+  },
+  {
+    "_Id": 1020110106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10201101,
+    "_CompleteType": "EventTrialClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
+    "_Parameter2": 5
+  },
+  {
+    "_Id": 1020120106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10201201,
+    "_CompleteType": "EventTrialClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
+    "_Parameter2": 6
+  },
+  {
+    "_Id": 1020130106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10201301,
+    "_CompleteType": "EventChallengeBattleClear",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20843,
     "_Parameter2": 4,
     "_Parameter3": 1
   },


### PR DESCRIPTION
Adds the remaining event compendium endeavours for facility events.

I had a go at generating these using Gemini 2.5. I fed it some sample mission lists and some text files with data from the master asset. I had to fix about 5 missions out of ~125 in the end, but it was otherwise pretty much spot on. There could be some bugs I haven't seen, but from manual testing it looks to all function roughly correctly.