### PR TITLE
Add compendium raid endeavours

### DIFF
--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AdventOfTheOrigin.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/AdventOfTheOrigin.cs
@@ -1,0 +1,69 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission; // For EventParticipationMission
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission, ReadQuestStoryMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class AdventOfTheOrigin
+{
+    // Quest IDs from QuestNames.txt
+    private const int VolcanicCyclopsAssaultQuestId = 204620201;
+    private const int TrueBahamutClashExpertQuestId = 204620302;
+    private const int TrueBahamutClashNightmareQuestId = 204620501;
+    private const int TrueBahamutClashOmegaQuestId = 204620601;
+
+    // Story IDs from StorySectionNames.txt
+    private const int EpilogueStoryId = 2046208;
+
+    // Event ID 20462 derived from QuestNames.txt
+
+    [MissionType(MissionType.MemoryEvent)] // Using MemoryEvent as requested
+    [EventId(20462)] // Event ID used directly as requested
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10280101 },
+            // Clear Volcanic Cyclops Assault
+            new ClearQuestMission()
+            {
+                MissionId = 10280201,
+                QuestId = VolcanicCyclopsAssaultQuestId,
+            },
+            // Clear True Bahamut Clash on Expert
+            new ClearQuestMission()
+            {
+                MissionId = 10280301,
+                QuestId = TrueBahamutClashExpertQuestId,
+            },
+            // Clear True Bahamut Clash on Nightmare
+            new ClearQuestMission()
+            {
+                MissionId = 10280401,
+                QuestId = TrueBahamutClashNightmareQuestId,
+            },
+            // Read the Epilogue
+            new ReadQuestStoryMission() { MissionId = 10280501, QuestStoryId = EpilogueStoryId },
+            // Read the Epilogue
+            // Note: Duplicate Mission ID and task as 10280501, generated as requested.
+            new ReadQuestStoryMission() { MissionId = 10280601, QuestStoryId = EpilogueStoryId },
+            // Read the Epilogue
+            // Note: Duplicate Mission ID and task as 10280501, generated as requested.
+            new ReadQuestStoryMission() { MissionId = 10280701, QuestStoryId = EpilogueStoryId },
+            // Read the Epilogue
+            // Note: Duplicate Mission ID and task as 10280501, generated as requested.
+            new ReadQuestStoryMission() { MissionId = 10280801, QuestStoryId = EpilogueStoryId },
+            // Read the Epilogue
+            // Note: Duplicate Mission ID and task as 10280501, generated as requested.
+            new ReadQuestStoryMission() { MissionId = 10280901, QuestStoryId = EpilogueStoryId },
+            // Clear True Bahamut Clash: Omega
+            new ClearQuestMission()
+            {
+                MissionId = 10281001,
+                QuestId = TrueBahamutClashOmegaQuestId,
+            },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FaithForsakenPartOne.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FaithForsakenPartOne.cs
@@ -1,0 +1,51 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission; // For EventParticipationMission
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission, ReadQuestStoryMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class FaithForsakenPartOne
+{
+    // Quest IDs from QuestNames.txt
+    private const int ResistanceOfTheInnocentQuestId = 204430101;
+    private const int TheMightOfHeavenQuestId = 204430102;
+    private const int AssaultOnMichaelQuestId = 204430202;
+    private const int AsuraClashExpertQuestId = 204430302;
+    private const int AsuraClashNightmareQuestId = 204430501;
+    private const int AsuraClashOmegaQuestId = 204430601;
+
+    // Story IDs from StorySectionNames.txt
+    private const int EpilogueStoryId = 2044309;
+
+    // Event ID 20443 derived from QuestNames.txt
+
+    [MissionType(MissionType.MemoryEvent)] // Using MemoryEvent as requested
+    [EventId(20443)] // Event ID used directly as requested
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10160101 },
+            // Clear Resistance of the Innocent
+            new ClearQuestMission()
+            {
+                MissionId = 10160201,
+                QuestId = ResistanceOfTheInnocentQuestId,
+            },
+            // Clear The Might of Heaven
+            new ClearQuestMission() { MissionId = 10160301, QuestId = TheMightOfHeavenQuestId },
+            // Clear Assault on Michael
+            new ClearQuestMission() { MissionId = 10160401, QuestId = AssaultOnMichaelQuestId },
+            // Clear Asura Clash on Expert
+            new ClearQuestMission() { MissionId = 10160501, QuestId = AsuraClashExpertQuestId },
+            // Clear Asura Clash on Nightmare
+            new ClearQuestMission() { MissionId = 10160601, QuestId = AsuraClashNightmareQuestId },
+            // Read the Epilogue
+            new ReadQuestStoryMission() { MissionId = 10160701, QuestStoryId = EpilogueStoryId },
+            // Clear Asura Clash: Omega
+            new ClearQuestMission() { MissionId = 10160801, QuestId = AsuraClashOmegaQuestId },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FaithForsakenPartTwo.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FaithForsakenPartTwo.cs
@@ -1,0 +1,46 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission; // For EventParticipationMission
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission, ReadQuestStoryMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class FaithForsakenPartTwo
+{
+    // Quest IDs from QuestNames.txt
+    private const int CeaselessTragedyQuestId = 204440101;
+    private const int AGlimmerOfHopeQuestId = 204440102;
+    private const int AssaultOnLilithQuestId = 204440202;
+    private const int SatanClashExpertQuestId = 204440302;
+    private const int SatanClashNightmareQuestId = 204440501;
+    private const int SatanClashOmegaQuestId = 204440601;
+
+    private const int EpilogueStoryId = 2044409;
+
+    // Event ID 20444 derived from QuestNames.txt
+
+    [MissionType(MissionType.MemoryEvent)] // Using MemoryEvent as requested
+    [EventId(20444)] // Event ID used directly as requested
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10170101 },
+            // Clear Ceaseless Tragedy
+            new ClearQuestMission() { MissionId = 10170201, QuestId = CeaselessTragedyQuestId },
+            // Clear A Glimmer of Hope
+            new ClearQuestMission() { MissionId = 10170301, QuestId = AGlimmerOfHopeQuestId },
+            // Clear Assault on Lilith
+            new ClearQuestMission() { MissionId = 10170401, QuestId = AssaultOnLilithQuestId },
+            // Clear Satan Clash on Expert
+            new ClearQuestMission() { MissionId = 10170501, QuestId = SatanClashExpertQuestId },
+            // Clear Satan Clash on Nightmare
+            new ClearQuestMission() { MissionId = 10170601, QuestId = SatanClashNightmareQuestId },
+            // Read the Epilogue
+            new ReadQuestStoryMission() { MissionId = 10170701, QuestStoryId = EpilogueStoryId },
+            // Clear Satan Clash: Omega
+            new ClearQuestMission() { MissionId = 10170801, QuestId = SatanClashOmegaQuestId },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ForgottenTruths.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/ForgottenTruths.cs
@@ -1,0 +1,44 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission; // For EventParticipationMission
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission, ReadQuestStoryMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent; // Namespace adjusted for Raid Event
+
+[ContainsMissionList]
+public static class ForgottenTruths
+{
+    // Quest IDs from QuestNames.txt
+    private const int AssaultOnZephyrId = 204280202;
+    private const int MorsayatiClashExpertId = 204280302;
+    private const int MorsayatiClashNightmareId = 204280501;
+    private const int MorsayatiClashOmegaId = 204280601;
+    private const int WarOfBindingClimaxId = 204280602;
+
+    // Story IDs from StorySectionNames.txt
+    private const int EpilogueStoryId = 2042811;
+
+    // Event ID 20428 derived from QuestNames.txt
+
+    [MissionType(MissionType.MemoryEvent)] // Identified as Raid Event
+    [EventId(20428)] // Event ID used directly as requested
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10080101 },
+            // Clear Assault on Zephyr
+            new ClearQuestMission() { MissionId = 10080201, QuestId = AssaultOnZephyrId },
+            // Clear Morsayati Clash on Expert
+            new ClearQuestMission() { MissionId = 10080301, QuestId = MorsayatiClashExpertId },
+            // Clear Morsayati Clash on Nightmare
+            new ClearQuestMission() { MissionId = 10080401, QuestId = MorsayatiClashNightmareId },
+            // Read the Epilogue
+            new ReadQuestStoryMission() { MissionId = 10080501, QuestStoryId = EpilogueStoryId },
+            // Clear Morsayati Clash: Omega
+            new ClearQuestMission() { MissionId = 10080601, QuestId = MorsayatiClashOmegaId },
+            // Clear The War of Binding's Climax
+            new ClearQuestMission() { MissionId = 10080701, QuestId = WarOfBindingClimaxId },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FracturedFutures.cs
+++ b/DragaliaAPI/DragaliaAPI.MissionDesigner/Missions/MemoryEvent/FracturedFutures.cs
@@ -1,0 +1,58 @@
+/* This file was AI-generated */
+
+using DragaliaAPI.MissionDesigner.Models;
+using DragaliaAPI.MissionDesigner.Models.Attributes;
+using DragaliaAPI.MissionDesigner.Models.EventMission;
+using DragaliaAPI.MissionDesigner.Models.RegularMission; // For ClearQuestMission and ReadQuestStoryMission
+
+namespace DragaliaAPI.MissionDesigner.Missions.MemoryEvent;
+
+[ContainsMissionList]
+public static class FracturedFutures
+{
+    // Event ID 20427 derived from QuestNames.txt/StorySectionNames.txt
+
+    // Quest IDs from QuestNames.txt
+    private const int ShiningCyclopsAssaultQuestId = 204270202;
+    private const int ChronosClashQuestId = 204270302;
+    private const int ChronosNyxClashQuestId = 204270501;
+    private const int ChronosClashOmegaQuestId = 204270601;
+    private const int ChronosNyxClashOmegaQuestId = 204270602;
+    private const int TheDecisiveBattleQuestId = 204270603;
+    private const int TimesEndQuestId = 204270604;
+
+    // Story IDs from StorySectionNames.txt
+    private const int EpilogueStoryId = 2042707;
+
+    [MissionType(MissionType.MemoryEvent)]
+    [EventId(20427)] // Event ID used directly as requested
+    public static List<Mission> Missions { get; } =
+        [
+            // Participate in the Event
+            new EventParticipationMission() { MissionId = 10090101 },
+            // Clear Shining Cyclops Assault
+            new ClearQuestMission()
+            {
+                MissionId = 10090201,
+                QuestId = ShiningCyclopsAssaultQuestId,
+            },
+            // Clear Chronos Clash
+            new ClearQuestMission() { MissionId = 10090301, QuestId = ChronosClashQuestId },
+            // Clear Chronos Nyx Clash
+            new ClearQuestMission() { MissionId = 10090401, QuestId = ChronosNyxClashQuestId },
+            // Read the Epilogue
+            new ReadQuestStoryMission() { MissionId = 10090501, QuestStoryId = EpilogueStoryId },
+            // Clear Chronos Clash: Omega
+            new ClearQuestMission() { MissionId = 10090601, QuestId = ChronosClashOmegaQuestId },
+            // Clear Chronos Nyx Clash: Omega
+            new ClearQuestMission()
+            {
+                MissionId = 10090701,
+                QuestId = ChronosNyxClashOmegaQuestId,
+            },
+            // Clear The Decisive Battle
+            new ClearQuestMission() { MissionId = 10090801, QuestId = TheDecisiveBattleQuestId },
+            // Clear Time's End
+            new ClearQuestMission() { MissionId = 10090901, QuestId = TimesEndQuestId },
+        ];
+}

--- a/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
+++ b/DragaliaAPI/DragaliaAPI.Shared/Resources/Missions/MissionProgressionInfo.json
@@ -7484,6 +7484,96 @@
     "_Parameter3": 1
   },
   {
+    "_Id": 1028010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20462
+  },
+  {
+    "_Id": 1028020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204620201
+  },
+  {
+    "_Id": 1028030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280301,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204620302
+  },
+  {
+    "_Id": 1028040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280401,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204620501
+  },
+  {
+    "_Id": 1028050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280501,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2046208
+  },
+  {
+    "_Id": 1028060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280601,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2046208
+  },
+  {
+    "_Id": 1028070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280701,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2046208
+  },
+  {
+    "_Id": 1028080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280801,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2046208
+  },
+  {
+    "_Id": 1028090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10280901,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2046208
+  },
+  {
+    "_Id": 1028100106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10281001,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204620601
+  },
+  {
     "_Id": 1013010106,
     "_MissionType": "MemoryEvent",
     "_MissionId": 10130101,
@@ -8378,6 +8468,150 @@
     "_Parameter4": 208200501
   },
   {
+    "_Id": 1016010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20443
+  },
+  {
+    "_Id": 1016020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430101
+  },
+  {
+    "_Id": 1016030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160301,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430102
+  },
+  {
+    "_Id": 1016040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160401,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430202
+  },
+  {
+    "_Id": 1016050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160501,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430302
+  },
+  {
+    "_Id": 1016060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160601,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430501
+  },
+  {
+    "_Id": 1016070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160701,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2044309
+  },
+  {
+    "_Id": 1016080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10160801,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204430601
+  },
+  {
+    "_Id": 1017010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20444
+  },
+  {
+    "_Id": 1017020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440101
+  },
+  {
+    "_Id": 1017030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170301,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440102
+  },
+  {
+    "_Id": 1017040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170401,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440202
+  },
+  {
+    "_Id": 1017050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170501,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440302
+  },
+  {
+    "_Id": 1017060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170601,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440501
+  },
+  {
+    "_Id": 1017070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170701,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2044409
+  },
+  {
+    "_Id": 1017080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10170801,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204440601
+  },
+  {
     "_Id": 1001010106,
     "_MissionType": "MemoryEvent",
     "_MissionId": 10010101,
@@ -8587,6 +8821,150 @@
     "_UnlockedOnComplete": [],
     "_Parameter": 20816,
     "_Parameter2": 4
+  },
+  {
+    "_Id": 1008010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20428
+  },
+  {
+    "_Id": 1008020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204280202
+  },
+  {
+    "_Id": 1008030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080301,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204280302
+  },
+  {
+    "_Id": 1008040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080401,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204280501
+  },
+  {
+    "_Id": 1008050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080501,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2042811
+  },
+  {
+    "_Id": 1008060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080601,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204280601
+  },
+  {
+    "_Id": 1008070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10080701,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204280602
+  },
+  {
+    "_Id": 1009010106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090101,
+    "_CompleteType": "EventParticipation",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 20427
+  },
+  {
+    "_Id": 1009020106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090201,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270202
+  },
+  {
+    "_Id": 1009030106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090301,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270302
+  },
+  {
+    "_Id": 1009040106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090401,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270501
+  },
+  {
+    "_Id": 1009050106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090501,
+    "_CompleteType": "QuestStoryCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 2042707
+  },
+  {
+    "_Id": 1009060106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090601,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270601
+  },
+  {
+    "_Id": 1009070106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090701,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270602
+  },
+  {
+    "_Id": 1009080106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090801,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270603
+  },
+  {
+    "_Id": 1009090106,
+    "_MissionType": "MemoryEvent",
+    "_MissionId": 10090901,
+    "_CompleteType": "QuestCleared",
+    "_UseTotalValue": 0,
+    "_UnlockedOnComplete": [],
+    "_Parameter": 204270604
   },
   {
     "_Id": 1002010106,


### PR DESCRIPTION
Adds endeavours for the following compendium events:

- Advent of the Origin
- Faith Forsaken Part One
- Faith Forsaken Part Two
- Forgotten Truths
- Fractured Futures