### PR TITLE
Fix disabling settings

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Web/Settings/SettingsController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Settings/SettingsController.cs
@@ -11,8 +11,10 @@ namespace DragaliaAPI.Features.Web.Settings;
 internal sealed class SettingsController(SettingsService settingsService) : ControllerBase
 {
     [HttpPut]
-    public async Task SetSettings(PlayerSettings settings, CancellationToken cancellationToken)
+    public async Task SetSettings(SettingsDto settings, CancellationToken cancellationToken)
     {
-        await settingsService.SetSettings(settings, cancellationToken);
+        PlayerSettings internalSettings = new() { DailyGifts = settings.DailyGifts };
+
+        await settingsService.SetSettings(internalSettings, cancellationToken);
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Web/Settings/SettingsDto.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Settings/SettingsDto.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace DragaliaAPI.Features.Web.Settings;
+
+internal sealed class SettingsDto
+{
+    [JsonRequired]
+    public bool DailyGifts { get; set; }
+}

--- a/Website/src/routes/(main)/account/profile/+page.server.ts
+++ b/Website/src/routes/(main)/account/profile/+page.server.ts
@@ -1,4 +1,8 @@
+import { userProfileSchema } from '$main/account/profile/userProfile.ts';
+
 import type { Actions } from './$types';
+
+const settingKeys = Object.keys(userProfileSchema.shape.settings.shape) as const;
 
 export const actions = {
   settings: async ({ request, fetch, url }) => {
@@ -7,8 +11,8 @@ export const actions = {
     let requestObject = {};
 
     // Convert values to actual booleans
-    for (const [key, value] of Object.entries(dataObject)) {
-      requestObject = { ...requestObject, [key]: value === 'on' };
+    for (const key of settingKeys) {
+      requestObject = { ...requestObject, [key]: data.get(key) === 'on' };
     }
 
     const fetchRequest = new Request(new URL('/api/settings', url.origin), {
@@ -26,6 +30,6 @@ export const actions = {
       throw new Error(`Failed to save settings: status ${response.status}`);
     }
 
-    return { ...requestObject };
+    return { ...dataObject };
   }
 } satisfies Actions;

--- a/Website/src/routes/(main)/account/profile/+page.server.ts
+++ b/Website/src/routes/(main)/account/profile/+page.server.ts
@@ -2,7 +2,7 @@ import { userProfileSchema } from '$main/account/profile/userProfile.ts';
 
 import type { Actions } from './$types';
 
-const settingKeys = Object.keys(userProfileSchema.shape.settings.shape) as const;
+const settingKeys = Object.freeze(Object.keys(userProfileSchema.shape.settings.shape));
 
 export const actions = {
   settings: async ({ request, fetch, url }) => {


### PR DESCRIPTION
When a switch is toggled off, it is absent from the form data. This leads to it being defaulted to true, meaning it is impossible to toggle off. Iterate a known set of setting keys so that our request object contains all of them with true/false values. Additionally introduce validation that all keys are in the request object with JsonRequired.