### PR TITLE
Fix summon fakeout

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
@@ -6,9 +6,11 @@ public static class SummonEffectHelper
 {
     public static SummonEffect CalculateEffect(SummonService.SummonResultMetaInfo metaInfo)
     {
-        int reversalIndex = metaInfo.LastIndexOfRare5;
-        if (reversalIndex != -1 && new Random().NextSingle() < 0.95)
+        int reversalIndex = 0;
+        if (metaInfo.EligibleForFakeout && new Random().NextSingle() < 0.95)
+        {
             reversalIndex = -1;
+        }
 
         int sageEffect;
         int circleEffect;

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
@@ -7,7 +7,7 @@ public static class SummonEffectHelper
     public static SummonEffect CalculateEffect(SummonService.SummonResultMetaInfo metaInfo)
     {
         int reversalIndex = metaInfo.LastIndexOfNew5Char;
-        if (Random.Shared.NextSingle() < 0.95)
+        if (reversalIndex != -1 && Random.Shared.NextSingle() < 0.95)
         {
             reversalIndex = -1;
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonEffectHelper.cs
@@ -6,8 +6,8 @@ public static class SummonEffectHelper
 {
     public static SummonEffect CalculateEffect(SummonService.SummonResultMetaInfo metaInfo)
     {
-        int reversalIndex = 0;
-        if (metaInfo.EligibleForFakeout && new Random().NextSingle() < 0.95)
+        int reversalIndex = metaInfo.LastIndexOfNew5Char;
+        if (Random.Shared.NextSingle() < 0.95)
         {
             reversalIndex = -1;
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
@@ -400,7 +400,7 @@ public sealed partial class SummonService(
         List<AtgenResultUnitList> returnedResult = [];
         List<AtgenDuplicateEntityList> newGetEntityList = [];
 
-        bool eligibleForFakeout = false;
+        int lastIndexOfNew5Char = -1;
         int countOfRare5Char = 0;
         int countOfRare5Dragon = 0;
         int countOfRare4 = 0;
@@ -465,7 +465,7 @@ public sealed partial class SummonService(
                     {
                         if (isNew)
                         {
-                            eligibleForFakeout = true;
+                            lastIndexOfNew5Char = index;
                         }
 
                         countOfRare5Char++;
@@ -501,7 +501,7 @@ public sealed partial class SummonService(
         return (
             returnedResult,
             new SummonResultMetaInfo(
-                EligibleForFakeout: eligibleForFakeout,
+                LastIndexOfNew5Char: lastIndexOfNew5Char,
                 CountOfRare5Char: countOfRare5Char,
                 CountOfRare5Dragon: countOfRare5Dragon,
                 CountOfRare4: countOfRare4
@@ -568,7 +568,7 @@ public sealed partial class SummonService(
     }
 
     public readonly record struct SummonResultMetaInfo(
-        bool EligibleForFakeout,
+        int LastIndexOfNew5Char,
         int CountOfRare5Char,
         int CountOfRare5Dragon,
         int CountOfRare4

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/SummonService.cs
@@ -400,7 +400,7 @@ public sealed partial class SummonService(
         List<AtgenResultUnitList> returnedResult = [];
         List<AtgenDuplicateEntityList> newGetEntityList = [];
 
-        int lastIndexOfRare5 = 0;
+        bool eligibleForFakeout = false;
         int countOfRare5Char = 0;
         int countOfRare5Dragon = 0;
         int countOfRare4 = 0;
@@ -461,11 +461,20 @@ public sealed partial class SummonService(
             {
                 case 5:
                 {
-                    lastIndexOfRare5 = index;
                     if (result.EntityType is EntityTypes.Chara)
+                    {
+                        if (isNew)
+                        {
+                            eligibleForFakeout = true;
+                        }
+
                         countOfRare5Char++;
+                    }
                     else
+                    {
                         countOfRare5Dragon++;
+                    }
+
                     break;
                 }
                 case 4:
@@ -492,7 +501,7 @@ public sealed partial class SummonService(
         return (
             returnedResult,
             new SummonResultMetaInfo(
-                LastIndexOfRare5: lastIndexOfRare5,
+                EligibleForFakeout: eligibleForFakeout,
                 CountOfRare5Char: countOfRare5Char,
                 CountOfRare5Dragon: countOfRare5Dragon,
                 CountOfRare4: countOfRare4
@@ -559,7 +568,7 @@ public sealed partial class SummonService(
     }
 
     public readonly record struct SummonResultMetaInfo(
-        int LastIndexOfRare5,
+        bool EligibleForFakeout,
         int CountOfRare5Char,
         int CountOfRare5Dragon,
         int CountOfRare4


### PR DESCRIPTION
Summoning fake outs were broken in a refactor and can trigger on a summon without any 5* units, because the 'last 5* index' is incorrectly initialized to 0 instead of -1.

Additionally documentary evidence suggests that fake outs can only trigger when the unit is new