### PR TITLE
Delete helper use dates on import

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/SavefileImportTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Login/SavefileImportTest.cs
@@ -285,6 +285,28 @@ public class SavefileImportTest : TestFixture
             .Be(500);
     }
 
+    [Fact]
+    public async Task Import_DeletesHelper()
+    {
+        this.ApiContext.PlayerHelperUseDates.Add(
+            new()
+            {
+                Player = new() { AccountId = "helperuser" },
+                HelperViewerId = this.ViewerId,
+            }
+        );
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        HttpContent content = PrepareSavefileRequest("endgame_savefile.json");
+
+        HttpResponseMessage importResponse = await this.Client.PostAsync(
+            $"savefile/import/{this.ViewerId}",
+            content,
+            TestContext.Current.CancellationToken
+        );
+        importResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
     private static HttpContent PrepareSavefileRequest(string path)
     {
         string savefileJson = File.ReadAllText(Path.Join("Data", path));

--- a/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
@@ -432,6 +432,9 @@ internal sealed class SavefileService(
         // Options commented out have been excluded from save import deletion process.
         // They will still be deleted by cascade delete when a player is actually deleted
         // without being re-added as they are in save imports.
+        await apiContext
+            .PlayerHelperUseDates.Where(x => x.HelperViewerId == viewerId)
+            .ExecuteDeleteAsync();
         await apiContext.PlayerHelpers.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
         await apiContext.PlayerUserData.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();
         await apiContext.PlayerCharaData.Where(x => x.ViewerId == viewerId).ExecuteDeleteAsync();


### PR DESCRIPTION
Seeing some problems with save import after #1322 if you have an entry in the PlayerHelperUseDates table:

![image](https://github.com/user-attachments/assets/f7379130-bb54-434e-81a3-f120abc87ca5)

Because we configure restricted deletion on HelperUseDates, you can't delete a helper without first deleting the use dates, which we don't do on save import.

Fix this with an explicit delete on use dates.