### PR TITLE
Eagerly prevent sending duplicate friend requests

### DIFF
--- a/Aspire/Dawnshard.AppHost/Program.cs
+++ b/Aspire/Dawnshard.AppHost/Program.cs
@@ -15,7 +15,9 @@ IResourceBuilder<PostgresServerResource> postgres = builder
 
 IResourceBuilder<RedisResource> redis = builder
     .AddRedis("redis")
-    .WithImage("redis/redis-stack", "7.4.0-v0")
+    .WithImage("redis/redis-stack", "7.4.0-v3")
+    .WithPassword(null)
+    .WithEntrypoint("/entrypoint.sh") // Default Aspire entrypoint doesn't load modules correctly
     .WithLifetime(ContainerLifetime.Persistent);
 
 IResourceBuilder<ProjectResource> dragaliaApi = builder

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordHelperService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordHelperService.cs
@@ -85,17 +85,20 @@ internal sealed class DungeonRecordHelperService(
             connectingViewerIdList
         );
 
-        List<long> friendsList = await friendService.CheckFriendStatus(connectingViewerIdList);
+        List<(long ViewerId, bool IsFriend, bool HasFriendRequest)> friendCheckList =
+            await friendService.CheckFriendStatus(connectingViewerIdList);
 
         logger.LogDebug("Retrieved teammate support list {@supportList}", teammateSupportLists);
 
-        IEnumerable<AtgenHelperDetailList> teammateDetailLists = connectingViewerIdList.Select(
+        IEnumerable<AtgenHelperDetailList> teammateDetailLists = friendCheckList.Select(
             x => new AtgenHelperDetailList()
             {
-                IsFriend = friendsList.Contains(x),
-                ViewerId = (ulong)x,
-                GetManaPoint = 50,
-                ApplySendStatus = 0,
+                IsFriend = x.IsFriend,
+                ViewerId = (ulong)x.ViewerId,
+                GetManaPoint = x.IsFriend
+                    ? HelperConstants.HelperFriendRewardMana
+                    : HelperConstants.HelperRewardMana,
+                ApplySendStatus = x.HasFriendRequest ? 1 : 0,
             }
         );
 

--- a/DragaliaAPI/DragaliaAPI/Features/Friends/FriendController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Friends/FriendController.cs
@@ -161,6 +161,16 @@ internal sealed class FriendController(
             return this.Code(ResultCode.FriendIdsearchError);
         }
 
+        bool requestAlreadySent = await friendService.CheckIfFriendRequestExists(
+            searchId,
+            cancellationToken
+        );
+
+        if (requestAlreadySent)
+        {
+            return this.Code(ResultCode.FriendApplyExists);
+        }
+
         bool alreadyFriends = await friendService.CheckIfFriendshipExists(
             searchId,
             cancellationToken
@@ -235,18 +245,16 @@ internal sealed class FriendController(
         }
         catch (DbUpdateException ex) when (ex.IsUniqueViolation())
         {
-            throw new DragaliaException(
+            return this.Code(
                 ResultCode.FriendApplyExists,
-                "Cannot send friend request - one already exists",
-                ex
+                "Cannot send friend request - one already exists"
             );
         }
         catch (DbUpdateException ex) when (ex.IsForeignKeyViolation())
         {
-            throw new DragaliaException(
+            return this.Code(
                 ResultCode.FriendApplyError,
-                "Cannot send friend request - foreign key violation",
-                ex
+                "Cannot send friend request - player not found"
             );
         }
 

--- a/DragaliaAPI/DragaliaAPI/Features/Friends/FriendService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Friends/FriendService.cs
@@ -37,6 +37,19 @@ internal sealed partial class FriendService(
             .AnyAsync(x => x.ViewerId == otherPlayerId, cancellationToken);
     }
 
+    public async Task<bool> CheckIfFriendRequestExists(
+        long otherPlayerId,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return await apiContext.PlayerFriendRequests.AnyAsync(
+            x =>
+                x.FromPlayerViewerId == playerIdentityService.ViewerId
+                && x.ToPlayerViewerId == otherPlayerId,
+            cancellationToken
+        );
+    }
+
     public async Task<List<UserSupportList>> GetFriendList(
         CancellationToken cancellationToken = default
     )


### PR DESCRIPTION
We currently return an error for sending a friend request to an existing friend by catching an FK exception from the DB. This works, but yields two error logs each time it happens which leads to false alarm when looking at the logs.

We can instead return `FriendApplyExists` from `id_search` after a manual query to prevent this, but leave the FK check just in case this is bypassed somehow. Most other ways to send a friend request (e.g. from co-op after a quest) should also block this using `ApplySendStatus`. This was not being done correctly which is also fixed in this PR.