### PR TITLE
Handle receiving duplicate weapon bodies

### DIFF
--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/WeaponBodyHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/WeaponBodyHandler.cs
@@ -36,7 +36,10 @@ public class WeaponBodyHandler(ApiContext apiContext, IPlayerIdentityService pla
 
             Debug.Assert(MasterAsset.WeaponBody[weaponId].IsPlayable);
 
-            if (owned.Contains(weaponId))
+            if (
+                owned.Contains(weaponId)
+                || apiContext.PlayerWeapons.Local.Any(x => x.WeaponBodyId == weaponId)
+            )
             {
                 // The WeaponBody asset contains 'duplicate entity' information, but attempting to return a
                 // converted entity result doesn't work properly - it brings up an empty window and has text


### PR DESCRIPTION
You can encounter a change tracker conflict error if you add the same weapon twice in the save editor because we don't check against the local view. Fix this scenario to report the second weapon as discarded instead.