### PR TITLE
Add logging to diagnose server errors

### DIFF
--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -6,6 +6,7 @@
       "command": "dotnet",
       "args": [
         "csharpier",
+        "format",
         "${staged}"
       ],
       "include": [

--- a/DragaliaAPI/DragaliaAPI/Features/Friends/HelperService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Friends/HelperService.cs
@@ -22,7 +22,8 @@ internal sealed class HelperService(
     IPlayerIdentityService playerIdentityService,
     SettingsService settingsService,
     StaticHelperDataService staticDataService,
-    RealHelperDataService realDataService
+    RealHelperDataService realDataService,
+    ILogger<HelperService> logger
 ) : IHelperService
 {
     public async Task<QuestGetSupportUserListResponse> GetHelperList(
@@ -39,6 +40,8 @@ internal sealed class HelperService(
         CancellationToken cancellationToken
     )
     {
+        logger.LogDebug("Looking up UserSupportList for ID: {ViewerId}", viewerId);
+
         IHelperDataService dataService = await this.GetDataService(cancellationToken);
 
         return await dataService.GetHelper(viewerId, cancellationToken);
@@ -49,6 +52,8 @@ internal sealed class HelperService(
         CancellationToken cancellationToken
     )
     {
+        logger.LogDebug("Looking up AtgenSupportUserDataDetail for ID: {ViewerId}", viewerId);
+
         IHelperDataService dataService = await this.GetDataService(cancellationToken);
 
         return await dataService.GetHelperDataDetail(viewerId, cancellationToken);
@@ -189,19 +194,6 @@ internal sealed class HelperService(
         HelperProjection? helper = await GetHelperProjectionOrDefault(viewerId, cancellationToken);
 
         return helper?.MapToUserSupportList();
-    }
-
-    private async Task<HelperProjection> GetHelperProjection(
-        long viewerId,
-        CancellationToken cancellationToken
-    )
-    {
-        return await apiContext
-            .PlayerHelpers.IgnoreQueryFilters()
-            .AsSplitQuery()
-            .Where(x => x.ViewerId == viewerId)
-            .ProjectToHelperProjection()
-            .FirstAsync(cancellationToken);
     }
 
     private async Task<HelperProjection?> GetHelperProjectionOrDefault(

--- a/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
@@ -5,6 +5,7 @@ using DragaliaAPI.Features.Web.Settings;
 using DragaliaAPI.Features.Web.TimeAttack;
 using DragaliaAPI.Features.Web.Users;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.IdentityModel.Logging;
 using static DragaliaAPI.Infrastructure.Authentication.AuthConstants;
 
 // ReSharper disable once CheckNamespace
@@ -55,6 +56,9 @@ public static partial class FeatureExtensions
                         .RequireClaim(CustomClaimType.AccountId)
                         .RequireClaim(CustomClaimType.ViewerId)
             );
+
+        IdentityModelEventSource.ShowPII = true;
+        IdentityModelEventSource.LogCompleteSecurityArtifact = true;
 
         return serviceCollection;
     }

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Middleware/ResultCodeLoggingMiddleware.cs
@@ -16,6 +16,10 @@ internal partial class ResultCodeLoggingMiddleware(ILogger<ResultCodeLoggingMidd
             ResultCode.FriendTargetNone,
             ResultCode.FriendTargetAlready,
             ResultCode.FriendApplyExists,
+            ResultCode.FriendCountLimit,
+            ResultCode.FriendCountOtherLimit,
+            ResultCode.FriendApplyCountLimit,
+            ResultCode.FriendApplyCountOtherLimit,
         ];
 
     public async Task InvokeAsync(HttpContext context, RequestDelegate next)


### PR DESCRIPTION
- Add log of viewer ID to diagnose exceptions when looking up helpers
- Enable PII logging to debug `/api/user/me` request validation

Bonus:
- Don't log errors for friend request validation
- Also, csharpier fix following on from https://github.com/SapiensAnatis/Dawnshard/pull/1333 which upgraded to v2