### PR TITLE
Avoid adding duplicate Authorization headers

### DIFF
--- a/Website/src/hooks.server.ts
+++ b/Website/src/hooks.server.ts
@@ -44,7 +44,9 @@ export const handleFetch: HandleFetch = ({ request, event, fetch }) => {
     // We need to explicitly add the JWT back in, because SvelteKit seems to refuse to forward cookies here; it's
     // possible it views the request as changing origins and no longer internal.
     const idToken = event.cookies.get(Cookies.IdToken);
-    if (idToken) {
+
+    // /api/user/me will manually attach the header, avoid adding a second header in this case.
+    if (idToken && !request.headers.has('Authorization')) {
       request.headers.append('Authorization', `Bearer ${idToken}`);
     }
 


### PR DESCRIPTION
Every so often in the website logs we get:

```
Error: Unexpected /user/me response in OAuth callback: 401
```

Looking at the same time period in the API logs there will be a token validation failure like 

```
System.ArgumentException: IDX14309: Unable to decode the initialization vector as Base64Url encoded string.
 ---> System.FormatException: IDX10400: Unable to decode: '<redacted token bytes>, Bearer <redacted token bytes>' as Base64url encoded string.
```

I suspect this could be caused by having two `Authorization` headers based off of the `, Bearer` component (and maybe Identity is truncating them both?

I was able to reproduce this error on the production website by logging in, and then manually browing to `/login` and logging in again, in which scenario I have a cookie to add to the request which is then stacked up with the existing header added by `fetch`. I got the same internal error with the same cause in the logs. I wasn't able to reproduce it on my local dev environment however, so this fix is a bit speculative.

