### PR TITLE
Fix co-op error when using static helpers

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Friends/SupportCharaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Friends/SupportCharaTest.cs
@@ -292,6 +292,32 @@ public class SupportCharaTest : TestFixture
     }
 
     [Fact]
+    public async Task GetSupportCharaDetail_StaticEnabled_SendsRealViewerId_GetsCorrectCharacter()
+    {
+        // See comment in StaticHelperDataService explaining why this is a valid scenario
+
+        this.ApiContext.PlayerSettings.Add(
+            new()
+            {
+                ViewerId = this.ViewerId,
+                SettingsJson = new() { UseLegacyHelpers = true },
+            }
+        );
+        await this.ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        DragaliaResponse<FriendGetSupportCharaDetailResponse> response = (
+            await this.Client.PostMsgpack<FriendGetSupportCharaDetailResponse>(
+                "/friend/get_support_chara_detail",
+                new FriendGetSupportCharaDetailRequest() { SupportViewerId = (ulong)this.ViewerId },
+                cancellationToken: TestContext.Current.CancellationToken,
+                ensureSuccessHeader: false
+            )
+        );
+
+        response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+    }
+
+    [Fact]
     public async Task GetSupportCharaDetail_RealViewerId_GetsSupportCharaDetail()
     {
         await this.AddSupportCharaEquipment();


### PR DESCRIPTION
When playing co-op, if you view details for another player, the client will make a call to /friend/get_support_chara_detail with their ID. If you have static helpers enabled, this will fail. We should fall back to real helper data to handle this case.

We expect this particular case to always hit this path rather than a static helper shadowing a real player, because all the static helper IDs are near ulong.MaxValue. So there is a clear separation, unless we get a LOT of new players.

Note: it shouldn't be necessary to do this for GetHelper above as that is only called from /friend/id_search.