### PR TITLE
Fix website build

### DIFF
--- a/Website/vite.config.ts
+++ b/Website/vite.config.ts
@@ -27,7 +27,7 @@ export default defineConfig(({ mode }) => {
     },
     build: {
       // Hack to get top-level await support required by Mock Service Worker for Playwright
-      target: mode === 'development' ? 'es2022' : 'modules'
+      target: mode === 'development' ? 'es2022' : 'baseline-widely-available'
     },
     preview: {
       port: 3001,


### PR DESCRIPTION
#1360 upgraded to Vite v7 which changes the baseline target from `modules` to `baseline-widely-available`, this was causing the Docker build to fail.