### PR TITLE
User impersonation page

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Shared/PlayerDetails/CustomClaimType.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/PlayerDetails/CustomClaimType.cs
@@ -19,4 +19,12 @@ public static class CustomClaimType
     /// Player name from user_data.
     /// </summary>
     public const string PlayerName = "PlayerName";
+
+    /// <summary>
+    /// Whether the user is an admin, based on the corresponding column in the Players table.
+    /// </summary>
+    /// <remarks>
+    /// Being an admin grants access to server administration tools on the website.
+    /// </remarks>
+    public const string IsAdmin = "IsAdmin";
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/FeatureExtensions.cs
@@ -55,6 +55,14 @@ public static partial class FeatureExtensions
                         )
                         .RequireClaim(CustomClaimType.AccountId)
                         .RequireClaim(CustomClaimType.ViewerId)
+            )
+            .AddPolicy(
+                PolicyNames.RequireAdmin,
+                builder =>
+                    builder
+                        .RequireAuthenticatedUser()
+                        .AddAuthenticationSchemes(SchemeNames.WebJwt)
+                        .RequireClaim(CustomClaimType.IsAdmin, "true")
             );
 
         IdentityModelEventSource.ShowPII = true;

--- a/DragaliaAPI/DragaliaAPI/Features/Web/Users/ImpersonationSession.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/Users/ImpersonationSession.cs
@@ -1,0 +1,3 @@
+namespace DragaliaAPI.Features.Web.Users;
+
+public record ImpersonationSession(long? ImpersonatedViewerId);

--- a/DragaliaAPI/DragaliaAPI/Features/Web/WebAuthenticationHelper.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Web/WebAuthenticationHelper.cs
@@ -52,7 +52,8 @@ public static class WebAuthenticationHelper
             context.Principal?.InitializeDawnshardIdentity(
                 playerInfo.AccountId,
                 playerInfo.ViewerId,
-                playerInfo.Name
+                playerInfo.Name,
+                isAdmin: playerInfo.IsAdmin
             );
         }
     }
@@ -94,7 +95,12 @@ public static class WebAuthenticationHelper
         var dbPlayerInfo = await dbContext
             .Players.IgnoreQueryFilters()
             .Where(x => x.AccountId == gameAccountId)
-            .Select(x => new { x.ViewerId, x.UserData!.Name })
+            .Select(x => new
+            {
+                x.ViewerId,
+                x.UserData!.Name,
+                x.IsAdmin,
+            })
             .FirstOrDefaultAsync();
 
         logger.LogDebug(
@@ -113,6 +119,7 @@ public static class WebAuthenticationHelper
             AccountId = gameAccountId,
             Name = dbPlayerInfo.Name,
             ViewerId = dbPlayerInfo.ViewerId,
+            IsAdmin = dbPlayerInfo.IsAdmin,
         };
 
         await cache.SetJsonAsync(
@@ -137,5 +144,7 @@ public static class WebAuthenticationHelper
         public long ViewerId { get; init; }
 
         public required string Name { get; init; }
+
+        public bool IsAdmin { get; init; }
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/AuthConstants.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/AuthConstants.cs
@@ -7,6 +7,8 @@ public static class AuthConstants
         public const string RequireValidWebJwt = "RequireValidWebJwt";
 
         public const string RequireDawnshardIdentity = "RequireDawnshardIdentity";
+
+        public const string RequireAdmin = "RequireAdmin";
     }
 
     public static class IdentityLabels

--- a/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/ClaimsPrincipalExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Infrastructure/Authentication/ClaimsPrincipalExtensions.cs
@@ -12,7 +12,8 @@ internal static class ClaimsPrincipalExtensions
         this ClaimsPrincipal claimsPrincipal,
         string accountId,
         long viewerId,
-        string? playerName = null
+        string? playerName = null,
+        bool isAdmin = false
     )
     {
         ClaimsIdentity dawnshardIdentity = new(
@@ -28,6 +29,11 @@ internal static class ClaimsPrincipalExtensions
         if (playerName is not null)
         {
             dawnshardIdentity.AddClaim(new Claim(CustomClaimType.PlayerName, playerName));
+        }
+
+        if (isAdmin)
+        {
+            dawnshardIdentity.AddClaim(new Claim(CustomClaimType.IsAdmin, "true"));
         }
 
         claimsPrincipal.AddIdentity(dawnshardIdentity);

--- a/Website/src/app.d.ts
+++ b/Website/src/app.d.ts
@@ -7,6 +7,7 @@ declare global {
     // interface Error {}
     interface Locals {
       hasValidJwt: boolean;
+      isAdmin: boolean;
       logger: bunyan.Logger;
     }
     // interface PageData {}

--- a/Website/src/hooks.server.ts
+++ b/Website/src/hooks.server.ts
@@ -101,34 +101,16 @@ const handleAuth: Handle = ({ event, resolve }) => {
   return resolve(event);
 };
 
-const handleClaims: Handle = ({ event, resolve }) => {
+const handleIsAdmin: Handle = ({ event, resolve }) => {
   event.locals.isAdmin = false;
-  const claims = event.cookies.get(Cookies.Claims);
+  const isAdminString = event.cookies.get(Cookies.IsAdmin);
 
-  if (!claims) {
-    return resolve(event);
-  }
-
-  let claimsObject: unknown;
-
-  try {
-    claimsObject = JSON.parse(claims);
-  } catch (err) {
-    console.error('Failed to parse claim cookie: ', err);
-    return resolve(event);
-  }
-
-  if (!claimsObject || typeof claimsObject !== 'object') {
-    console.error('Cookie was valid JSON but invalid type');
-    return resolve(event);
-  }
-
-  event.locals.isAdmin = 'admin' in claimsObject;
+  event.locals.isAdmin = isAdminString === 'true';
 
   return resolve(event);
 };
 
-export const handle = sequence(handleHeadScript, handleLogger, handleAuth, handleClaims);
+export const handle = sequence(handleHeadScript, handleLogger, handleAuth, handleIsAdmin);
 
 export const handleError: HandleServerError = ({ error, event, status, message }) => {
   event.locals.logger.error({ error, status, message }, 'Unhandled error occurred: {message}');

--- a/Website/src/hooks.server.ts
+++ b/Website/src/hooks.server.ts
@@ -101,7 +101,34 @@ const handleAuth: Handle = ({ event, resolve }) => {
   return resolve(event);
 };
 
-export const handle = sequence(handleHeadScript, handleLogger, handleAuth);
+const handleClaims: Handle = ({ event, resolve }) => {
+  event.locals.isAdmin = false;
+  const claims = event.cookies.get(Cookies.Claims);
+
+  if (!claims) {
+    return resolve(event);
+  }
+
+  let claimsObject: unknown;
+
+  try {
+    claimsObject = JSON.parse(claims);
+  } catch (err) {
+    console.error('Failed to parse claim cookie: ', err);
+    return resolve(event);
+  }
+
+  if (!claimsObject || typeof claimsObject !== 'object') {
+    console.error('Cookie was valid JSON but invalid type');
+    return resolve(event);
+  }
+
+  event.locals.isAdmin = 'admin' in claimsObject;
+
+  return resolve(event);
+};
+
+export const handle = sequence(handleHeadScript, handleLogger, handleAuth, handleClaims);
 
 export const handleError: HandleServerError = ({ error, event, status, message }) => {
   event.locals.logger.error({ error, status, message }, 'Unhandled error occurred: {message}');

--- a/Website/src/lib/auth/cookies.ts
+++ b/Website/src/lib/auth/cookies.ts
@@ -1,7 +1,7 @@
 enum Cookies {
   ChallengeString = 'challengeString',
   IdToken = 'idToken',
-  Claims = 'claims'
+  IsAdmin = 'isAdmin'
 }
 
 export default Cookies;

--- a/Website/src/lib/auth/cookies.ts
+++ b/Website/src/lib/auth/cookies.ts
@@ -1,6 +1,7 @@
 enum Cookies {
   ChallengeString = 'challengeString',
-  IdToken = 'idToken'
+  IdToken = 'idToken',
+  Claims = 'claims'
 }
 
 export default Cookies;

--- a/Website/src/lib/shadcn/components/ui/input/input.svelte
+++ b/Website/src/lib/shadcn/components/ui/input/input.svelte
@@ -1,25 +1,36 @@
 <script lang="ts">
-	import type { HTMLInputAttributes } from "svelte/elements";
-	import type { WithElementRef } from "bits-ui";
-	import { cn } from "$lib/shadcn/utils.js.js";
-	import type { Field } from 'svelte-form-helper';
+  import type { HTMLInputAttributes } from 'svelte/elements';
+  import type { WithElementRef } from 'bits-ui';
+  import { cn } from '$lib/shadcn/utils.js.js';
+  import type { Field } from 'svelte-form-helper';
 
-	let {
-		ref = $bindable(null),
-		value = $bindable(),
-		field,
-		class: className,
-		...restProps
-	}: WithElementRef<HTMLInputAttributes> & {field: Field} = $props();
+  let {
+    ref = $bindable(null),
+    value = $bindable(),
+    field,
+    class: className,
+    ...restProps
+  }: WithElementRef<HTMLInputAttributes> & { field?: Field } = $props();
+
+  const mergedClass = cn(
+    'border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+    className
+  );
 </script>
 
-<input
-	bind:this={ref}
-	class={cn(
-		"border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-10 w-full rounded-md border px-3 py-2 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-		className
-	)}
-	bind:value
-	use:field
-	{...restProps}
-/>
+{#if field}
+  <input
+    bind:this={ref}
+    class={mergedClass}
+    bind:value
+    use:field
+    {...restProps}
+  />
+{:else}
+  <input
+    bind:this={ref}
+    class={mergedClass}
+    bind:value
+    {...restProps}
+  />
+{/if}

--- a/Website/src/mocks/handlers/handlers.ts
+++ b/Website/src/mocks/handlers/handlers.ts
@@ -11,6 +11,7 @@ import { handleSavefileEdit, handleSavefileExport } from './savefile.ts';
 import { handleSettings } from './settings.ts';
 import { handleQuests, handleRankings } from './timeAttack.ts';
 import {
+  handleClearUserImpersonation,
   handleSetUserImpersonation,
   handleUser,
   handleUserImpersonation,
@@ -61,6 +62,10 @@ export const handlers = [
   http.get(`${BASE_URL}/api/time_attack/quests`, handleQuests),
   http.get(`${BASE_URL}/api/time_attack/rankings/*`, handleRankings),
 
-  http.get(`${BASE_URL}/api/user/impersonation_session`, withAuth(handleUserImpersonation)),
-  http.put(`${BASE_URL}/api/user/impersonation_session`, withAuth(handleSetUserImpersonation))
+  http.get(`${BASE_URL}/api/user/me/impersonation_session`, withAuth(handleUserImpersonation)),
+  http.put(`${BASE_URL}/api/user/me/impersonation_session`, withAuth(handleSetUserImpersonation)),
+  http.delete(
+    `${BASE_URL}/api/user/me/impersonation_session`,
+    withAuth(handleClearUserImpersonation)
+  )
 ];

--- a/Website/src/mocks/handlers/handlers.ts
+++ b/Website/src/mocks/handlers/handlers.ts
@@ -10,7 +10,12 @@ import { handleNews, handleNewsItem } from './news.ts';
 import { handleSavefileEdit, handleSavefileExport } from './savefile.ts';
 import { handleSettings } from './settings.ts';
 import { handleQuests, handleRankings } from './timeAttack.ts';
-import { handleUser, handleUserProfile } from './user.ts';
+import {
+  handleSetUserImpersonation,
+  handleUser,
+  handleUserImpersonation,
+  handleUserProfile
+} from './user.ts';
 import { handlePresentData } from './widgets.ts';
 
 // We need to be able to intercept requests to the Vite proxy (http://localhost:3001) as well as
@@ -54,5 +59,8 @@ export const handlers = [
   http.get(`${BASE_URL}/api/savefile/edit/widgets/present`, withAuth(handlePresentData)),
 
   http.get(`${BASE_URL}/api/time_attack/quests`, handleQuests),
-  http.get(`${BASE_URL}/api/time_attack/rankings/*`, handleRankings)
+  http.get(`${BASE_URL}/api/time_attack/rankings/*`, handleRankings),
+
+  http.get(`${BASE_URL}/api/user/impersonation_session`, withAuth(handleUserImpersonation)),
+  http.put(`${BASE_URL}/api/user/impersonation_session`, withAuth(handleSetUserImpersonation))
 ];

--- a/Website/src/mocks/handlers/user.ts
+++ b/Website/src/mocks/handlers/user.ts
@@ -1,4 +1,4 @@
-import { HttpResponse, type HttpResponseResolver } from 'msw';
+import { HttpResponse, type HttpResponseResolver, type PathParams } from 'msw';
 
 import type { UserProfile } from '$main/account/profile/userProfile.ts';
 
@@ -7,7 +7,7 @@ export const handleUser: HttpResponseResolver = () => {
     viewerId: 1,
     name: 'Euden',
     claims: {
-      admin: "true"
+      admin: 'true'
     }
   });
 };
@@ -19,5 +19,39 @@ export const handleUserProfile: HttpResponseResolver = () => {
     lastSaveImportTime: '2024-06-29T11:57:40Z',
     lastLoginTime: '2024-06-28T11:57:40Z',
     settings
+  });
+};
+
+export const handleUserImpersonation: HttpResponseResolver = () => {
+  return HttpResponse.json({
+    impersonatedViewerId: 2
+  });
+};
+
+export const handleSetUserImpersonation: HttpResponseResolver<
+  PathParams,
+  { target: number | null }
+> = async ({ request }) => {
+  const body = await request.clone().formData();
+
+  const viewerId = body.get('impersonatedViewerId');
+  if (!viewerId || typeof viewerId !== 'string') {
+    return HttpResponse.text(undefined, { status: 400 });
+  }
+
+  if (viewerId === 'null') {
+    // clear
+    return HttpResponse.json({
+      impersonatedViewerId: null
+    });
+  }
+
+  const viewerIdNumber = parseInt(viewerId);
+  if (!viewerIdNumber) {
+    return HttpResponse.text(undefined, { status: 400 });
+  }
+
+  return HttpResponse.json({
+    impersonatedViewerId: viewerIdNumber
   });
 };

--- a/Website/src/mocks/handlers/user.ts
+++ b/Website/src/mocks/handlers/user.ts
@@ -5,7 +5,10 @@ import type { UserProfile } from '$main/account/profile/userProfile.ts';
 export const handleUser: HttpResponseResolver = () => {
   return HttpResponse.json({
     viewerId: 1,
-    name: 'Euden'
+    name: 'Euden',
+    claims: {
+      admin: "true"
+    }
   });
 };
 

--- a/Website/src/mocks/handlers/user.ts
+++ b/Website/src/mocks/handlers/user.ts
@@ -30,9 +30,9 @@ export const handleSetUserImpersonation: HttpResponseResolver<
   PathParams,
   { target: number | null }
 > = async ({ request }) => {
-  const body = await request.clone().formData();
+  const data = await request.clone().formData();
 
-  const viewerId = body.get('impersonatedViewerId');
+  const viewerId = data.get('impersonatedViewerId');
   if (!viewerId || typeof viewerId !== 'string') {
     return HttpResponse.text(undefined, { status: 400 });
   }
@@ -52,4 +52,8 @@ export const handleSetUserImpersonation: HttpResponseResolver<
   return HttpResponse.json({
     impersonatedViewerId: viewerIdNumber
   });
+};
+
+export const handleClearUserImpersonation: HttpResponseResolver = () => {
+  return new HttpResponse(null, { status: 200 });
 };

--- a/Website/src/mocks/handlers/user.ts
+++ b/Website/src/mocks/handlers/user.ts
@@ -6,9 +6,7 @@ export const handleUser: HttpResponseResolver = () => {
   return HttpResponse.json({
     viewerId: 1,
     name: 'Euden',
-    claims: {
-      admin: 'true'
-    }
+    isAdmin: true
   });
 };
 

--- a/Website/src/routes/(main)/+layout.server.ts
+++ b/Website/src/routes/(main)/+layout.server.ts
@@ -1,12 +1,9 @@
-import Cookies from '$lib/auth/cookies.ts';
-
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = ({ locals, depends, url }) => {
-  depends(`cookie:${Cookies.IdToken}`);
-
   return {
     hasValidJwt: locals.hasValidJwt,
+    isAdmin: locals.isAdmin,
     urlOrigin: url.origin
   };
 };

--- a/Website/src/routes/(main)/+layout.server.ts
+++ b/Website/src/routes/(main)/+layout.server.ts
@@ -1,6 +1,6 @@
 import type { LayoutServerLoad } from './$types';
 
-export const load: LayoutServerLoad = ({ locals, depends, url }) => {
+export const load: LayoutServerLoad = ({ locals, url }) => {
   return {
     hasValidJwt: locals.hasValidJwt,
     isAdmin: locals.isAdmin,

--- a/Website/src/routes/(main)/+layout.svelte
+++ b/Website/src/routes/(main)/+layout.svelte
@@ -3,11 +3,10 @@
 
   import { Toaster } from '$shadcn/components/ui/sonner';
 
-  import type { LayoutData } from './$types';
   import Header from './header.svelte';
   import SideNav from './sideNav.svelte';
 
-  export let data: LayoutData;
+  const { data } = $props();
 </script>
 
 <svelte:head>
@@ -16,7 +15,7 @@
 
 <ModeWatcher disableHeadScriptInjection />
 <Header hasValidJwt={data.hasValidJwt} />
-<SideNav hasValidJwt={data.hasValidJwt} />
+<SideNav hasValidJwt={data.hasValidJwt} isAdmin={data.isAdmin} />
 <Toaster richColors />
 
 <main class="pl-0 md:pl-[var(--navigation-width)]" style:padding-top="var(--header-height)">

--- a/Website/src/routes/(main)/+layout.svelte
+++ b/Website/src/routes/(main)/+layout.svelte
@@ -3,10 +3,11 @@
 
   import { Toaster } from '$shadcn/components/ui/sonner';
 
+  import type { LayoutProps } from './$types';
   import Header from './header.svelte';
   import SideNav from './sideNav.svelte';
 
-  const { data } = $props();
+  const { data, children }: LayoutProps = $props();
 </script>
 
 <svelte:head>
@@ -14,10 +15,10 @@
 </svelte:head>
 
 <ModeWatcher disableHeadScriptInjection />
-<Header hasValidJwt={data.hasValidJwt} />
+<Header hasValidJwt={data.hasValidJwt} isAdmin={data.isAdmin} />
 <SideNav hasValidJwt={data.hasValidJwt} isAdmin={data.isAdmin} />
 <Toaster richColors />
 
 <main class="pl-0 md:pl-[var(--navigation-width)]" style:padding-top="var(--header-height)">
-  <slot />
+  {@render children?.()}
 </main>

--- a/Website/src/routes/(main)/account/user.ts
+++ b/Website/src/routes/(main)/account/user.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const userSchema = z.object({
   viewerId: z.number().positive(),
   name: z.string(),
-  claims: z.record(z.string(), z.string())
+  isAdmin: z.boolean()
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/Website/src/routes/(main)/account/user.ts
+++ b/Website/src/routes/(main)/account/user.ts
@@ -2,7 +2,8 @@ import { z } from 'zod';
 
 export const userSchema = z.object({
   viewerId: z.number().positive(),
-  name: z.string()
+  name: z.string(),
+  claims: z.record(z.string(), z.string())
 });
 
 export type User = z.infer<typeof userSchema>;

--- a/Website/src/routes/(main)/admin/+layout.ts
+++ b/Website/src/routes/(main)/admin/+layout.ts
@@ -22,7 +22,7 @@ export const load: LayoutLoad = async ({ fetch, url }) => {
 
   const user = userSchema.parse(await response.json());
 
-  if (!('admin' in user.claims)) {
+  if (!user.isAdmin) {
     redirect(303, `/unauthorized/403?originalPage=${encodeURIComponent(url.pathname)}`);
   }
 };

--- a/Website/src/routes/(main)/admin/+layout.ts
+++ b/Website/src/routes/(main)/admin/+layout.ts
@@ -1,0 +1,28 @@
+import { redirect } from '@sveltejs/kit';
+
+import { userSchema } from '$main/account/user.ts';
+
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = async ({ fetch, url }) => {
+  const userRequest = new URL('/api/user/me', url.origin);
+
+  const response = await fetch(userRequest);
+
+  if (!response.ok) {
+    if (response.status >= 400 && response.status <= 499) {
+      redirect(
+        303,
+        `/unauthorized/${response.status}?originalPage=${encodeURIComponent(url.pathname)}`
+      );
+    } else {
+      throw new Error(`/user/me error: HTTP ${response.status}`);
+    }
+  }
+
+  const user = userSchema.parse(await response.json());
+
+  if (!('admin' in user.claims)) {
+    redirect(303, `/unauthorized/403?originalPage=${encodeURIComponent(url.pathname)}`);
+  }
+};

--- a/Website/src/routes/(main)/admin/impersonation/+page.svelte
+++ b/Website/src/routes/(main)/admin/impersonation/+page.svelte
@@ -1,0 +1,1 @@
+<p>hello world</p>

--- a/Website/src/routes/(main)/admin/impersonation/+page.svelte
+++ b/Website/src/routes/(main)/admin/impersonation/+page.svelte
@@ -8,6 +8,8 @@
 
   import type { PageProps } from './$types';
 
+  const endpoint = '/api/user/me/impersonation_session';
+
   const { data }: PageProps = $props();
 
   let impersonatedViewerId = $state(data.impersonatedViewerId);
@@ -18,10 +20,8 @@
     event.preventDefault();
     const data = new FormData(event.currentTarget);
 
-    let response;
-
     try {
-      response = await fetch('/api/user/impersonation_session', {
+      const response = await fetch(endpoint, {
         method: 'PUT',
         body: data
       });
@@ -29,43 +29,32 @@
       if (!response.ok) {
         throw new Error('Invalid status code: ' + response.status);
       }
+
+      const parsedResponse = impersonationSessionSchema.parse(await response.json());
+      impersonatedViewerId = parsedResponse.impersonatedViewerId;
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);
       toast.error('Failed to set impersonation session');
-
-      return;
     }
-
-    const parsedResponse = impersonationSessionSchema.parse(await response.json());
-    impersonatedViewerId = parsedResponse.impersonatedViewerId;
   }
 
   async function handleClear() {
-    const data = new FormData();
-    data.set('impersonatedViewerId', 'null');
-
-    let response;
-
     try {
-      response = await fetch('/api/user/impersonation_session', {
-        method: 'PUT',
-        body: data
+      const response = await fetch(endpoint, {
+        method: 'DELETE'
       });
 
       if (!response.ok) {
         throw new Error('Invalid status code: ' + response.status);
       }
+
+      impersonatedViewerId = null;
     } catch (error) {
       // eslint-disable-next-line
       console.error(error);
-      toast.error('Failed to set impersonation session');
-
-      return;
+      toast.error('Failed to clear impersonation session');
     }
-
-    const parsedResponse = impersonationSessionSchema.parse(await response.json());
-    impersonatedViewerId = parsedResponse.impersonatedViewerId;
   }
 </script>
 

--- a/Website/src/routes/(main)/admin/impersonation/+page.svelte
+++ b/Website/src/routes/(main)/admin/impersonation/+page.svelte
@@ -62,7 +62,7 @@
   <div class="flex w-[350px] flex-col gap-4">
     <div class="flex flex-col gap-3">
       <p>Current impersonation session: {impersonatedViewerId ?? 'null'}</p>
-      <Button variant="secondary" dsabled={!impersonatedViewerId} onclick={handleClear}>
+      <Button variant="secondary" disabled={!impersonatedViewerId} onclick={handleClear}>
         Clear impersonation
       </Button>
     </div>

--- a/Website/src/routes/(main)/admin/impersonation/+page.svelte
+++ b/Website/src/routes/(main)/admin/impersonation/+page.svelte
@@ -62,12 +62,9 @@
   <div class="flex w-[350px] flex-col gap-4">
     <div class="flex flex-col gap-3">
       <p>Current impersonation session: {impersonatedViewerId ?? 'null'}</p>
-      <Button
-        variant="secondary"
-        disabled={!impersonatedViewerId}
-        onclick={() => {
-          handleClear();
-        }}>Clear impersonation</Button>
+      <Button variant="secondary" dsabled={!impersonatedViewerId} onclick={handleClear}>
+        Clear impersonation
+      </Button>
     </div>
     <hr />
     <form class="flex flex-col gap-3" onsubmit={handleSubmit}>

--- a/Website/src/routes/(main)/admin/impersonation/+page.svelte
+++ b/Website/src/routes/(main)/admin/impersonation/+page.svelte
@@ -1,1 +1,95 @@
-<p>hello world</p>
+<script lang="ts">
+  import { toast } from 'svelte-sonner';
+
+  import Page from '$lib/components/page.svelte';
+  import { impersonationSessionSchema } from '$main/admin/impersonation/impersonationSession.ts';
+  import { Button } from '$shadcn/components/ui/button';
+  import { Input } from '$shadcn/components/ui/input/index.js';
+
+  import type { PageProps } from './$types';
+
+  const { data }: PageProps = $props();
+
+  let impersonatedViewerId = $state(data.impersonatedViewerId);
+
+  async function handleSubmit(
+    event: SubmitEvent & { currentTarget: EventTarget & HTMLFormElement }
+  ) {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+
+    let response;
+
+    try {
+      response = await fetch('/api/user/impersonation_session', {
+        method: 'PUT',
+        body: data
+      });
+
+      if (!response.ok) {
+        throw new Error('Invalid status code: ' + response.status);
+      }
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+      toast.error('Failed to set impersonation session');
+
+      return;
+    }
+
+    const parsedResponse = impersonationSessionSchema.parse(await response.json());
+    impersonatedViewerId = parsedResponse.impersonatedViewerId;
+  }
+
+  async function handleClear() {
+    const data = new FormData();
+    data.set('impersonatedViewerId', 'null');
+
+    let response;
+
+    try {
+      response = await fetch('/api/user/impersonation_session', {
+        method: 'PUT',
+        body: data
+      });
+
+      if (!response.ok) {
+        throw new Error('Invalid status code: ' + response.status);
+      }
+    } catch (error) {
+      // eslint-disable-next-line
+      console.error(error);
+      toast.error('Failed to set impersonation session');
+
+      return;
+    }
+
+    const parsedResponse = impersonationSessionSchema.parse(await response.json());
+    impersonatedViewerId = parsedResponse.impersonatedViewerId;
+  }
+</script>
+
+<Page title="User Impersonation">
+  <div class="flex w-[350px] flex-col gap-4">
+    <div class="flex flex-col gap-3">
+      <p>Current impersonation session: {impersonatedViewerId ?? 'null'}</p>
+      <Button
+        variant="secondary"
+        disabled={!impersonatedViewerId}
+        onclick={() => {
+          handleClear();
+        }}>Clear impersonation</Button>
+    </div>
+    <hr />
+    <form class="flex flex-col gap-3" onsubmit={handleSubmit}>
+      <label for="impersonation-viewer-id">Enter a viewer ID to impersonate:</label>
+      <Input
+        name="impersonatedViewerId"
+        id="impersonated-viewer-id"
+        required
+        type="number"
+        min="1" />
+      <Button type="submit">Submit</Button>
+    </form>
+  </div>
+</Page>

--- a/Website/src/routes/(main)/admin/impersonation/+page.ts
+++ b/Website/src/routes/(main)/admin/impersonation/+page.ts
@@ -2,7 +2,7 @@ import { impersonationSessionSchema } from '$main/admin/impersonation/impersonat
 
 import type { PageLoad } from './$types';
 
-const endpoint = '/api/user/impersonation_session';
+const endpoint = '/api/user/me/impersonation_session';
 
 export const load: PageLoad = async ({ fetch, url }) => {
   const presentRequest = new URL(endpoint, url.origin);

--- a/Website/src/routes/(main)/admin/impersonation/+page.ts
+++ b/Website/src/routes/(main)/admin/impersonation/+page.ts
@@ -1,0 +1,17 @@
+import { impersonationSessionSchema } from '$main/admin/impersonation/impersonationSession.ts';
+
+import type { PageLoad } from './$types';
+
+const endpoint = '/api/user/impersonation_session';
+
+export const load: PageLoad = async ({ fetch, url }) => {
+  const presentRequest = new URL(endpoint, url.origin);
+
+  const response = await fetch(presentRequest);
+
+  if (!response.ok) {
+    throw new Error(`${endpoint} error: HTTP ${response.status}`);
+  }
+
+  return impersonationSessionSchema.parse(await response.json());
+};

--- a/Website/src/routes/(main)/admin/impersonation/impersonationSession.ts
+++ b/Website/src/routes/(main)/admin/impersonation/impersonationSession.ts
@@ -1,0 +1,5 @@
+import { z } from 'zod';
+
+export const impersonationSessionSchema = z.object({
+  impersonatedViewerId: z.number().nullable()
+});

--- a/Website/src/routes/(main)/header.svelte
+++ b/Website/src/routes/(main)/header.svelte
@@ -10,9 +10,9 @@
 
   import HeaderContents from './headerContents.svelte';
 
-  let enhance = false;
+  let enhance = $state(false);
 
-  export let hasValidJwt: boolean;
+  const { hasValidJwt, isAdmin }: { hasValidJwt: boolean; isAdmin: boolean } = $props();
 
   onMount(() => {
     enhance = true;
@@ -39,7 +39,7 @@
                   Close <Close class="mt-0.5 ml-2 h-5 w-5" />
                 </Button>
               </Drawer.Close>
-              <Routes {hasValidJwt} drawer={true} />
+              <Routes {hasValidJwt} {isAdmin} drawer={true} />
             </div>
           </Drawer.Content>
         </Drawer.Portal>

--- a/Website/src/routes/(main)/logout/+page.server.ts
+++ b/Website/src/routes/(main)/logout/+page.server.ts
@@ -6,7 +6,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies }) => {
   cookies.delete(Cookies.IdToken, { path: '/' });
-  cookies.delete(Cookies.Claims, { path: '/' });
+  cookies.delete(Cookies.IsAdmin, { path: '/' });
 
   redirect(302, '/');
 };

--- a/Website/src/routes/(main)/logout/+page.server.ts
+++ b/Website/src/routes/(main)/logout/+page.server.ts
@@ -6,6 +6,7 @@ import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ cookies }) => {
   cookies.delete(Cookies.IdToken, { path: '/' });
+  cookies.delete(Cookies.Claims, { path: '/' });
 
   redirect(302, '/');
 };

--- a/Website/src/routes/(main)/navigation/+page.server.ts
+++ b/Website/src/routes/(main)/navigation/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = ({ locals }) => ({
-  hasValidJwt: locals.hasValidJwt
+  hasValidJwt: locals.hasValidJwt,
+  isAdmin: locals.isAdmin
 });

--- a/Website/src/routes/(main)/navigation/+page@.svelte
+++ b/Website/src/routes/(main)/navigation/+page@.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import Routes from '$main/routes.svelte';
 
-  import type { PageData } from './$types';
+  import type { PageProps } from './$types';
 
-  export let data: PageData;
+  let { data }: PageProps = $props();
 </script>
 
 <nav class="flex flex-col justify-center gap-1 p-3">
   <h1 class="mb-4 text-3xl font-bold">Navigation</h1>
-  <Routes hasValidJwt={data.hasValidJwt} />
+  <Routes hasValidJwt={data.hasValidJwt} isAdmin={data.isAdmin} />
 </nav>

--- a/Website/src/routes/(main)/oauth/+page.server.ts
+++ b/Website/src/routes/(main)/oauth/+page.server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { PUBLIC_BAAS_CLIENT_ID, PUBLIC_BAAS_URL, PUBLIC_ENABLE_MSW } from '$env/static/public';
 import Cookies from '$lib/auth/cookies.ts';
 import getJwtMetadata from '$lib/auth/jwt.ts';
+import { userSchema } from '$main/account/user.ts';
 
 import type { PageServerLoad } from './$types';
 
@@ -17,6 +18,16 @@ const sessionTokenResponseSchema = z.object({
 
 const sdkTokenResponseSchema = z.object({
   idToken: z.string()
+});
+
+const baseCookieSettings = Object.freeze({
+  path: '/',
+  httpOnly: false,
+  ...(!PUBLIC_ENABLE_MSW && {
+    sameSite: 'lax',
+    httpOnly: true,
+    secure: true
+  })
 });
 
 export const load: PageServerLoad = async ({ cookies, locals, url, fetch }) => {
@@ -53,20 +64,16 @@ export const load: PageServerLoad = async ({ cookies, locals, url, fetch }) => {
 
   const maxAge = (jwtMetadata.expiryTimestampMs - Date.now()) / 1000;
 
-  if (!(await checkUserExists(idToken, url, fetch))) {
+  const userInfo = await getUserInfo(idToken, url, fetch);
+
+  if (!userInfo) {
     redirect(302, '/unauthorized/404');
   }
 
-  cookies.set(Cookies.IdToken, idToken, {
-    path: '/',
-    maxAge,
-    httpOnly: false,
-    ...(!PUBLIC_ENABLE_MSW && {
-      sameSite: 'lax',
-      httpOnly: true,
-      secure: true
-    })
-  });
+  const cookieSettings = { ...baseCookieSettings, maxAge };
+
+  cookies.set(Cookies.IdToken, idToken, cookieSettings);
+  cookies.set(Cookies.Claims, JSON.stringify(userInfo.claims), cookieSettings);
 
   cookies.delete('challengeString', {
     path: '/'
@@ -140,7 +147,7 @@ const getBaasToken = async (
   return idToken;
 };
 
-const checkUserExists = async (
+const getUserInfo = async (
   idToken: string,
   url: URL,
   fetch: (url: URL, req: RequestInit) => Promise<Response>
@@ -152,9 +159,9 @@ const checkUserExists = async (
   });
 
   if (userMeResponse.ok) {
-    return true;
+    return userSchema.parse(await userMeResponse.json());
   } else if (userMeResponse.status === 404) {
-    return false;
+    return null;
   } else {
     throw new Error(`Unexpected /user/me response in OAuth callback: ${userMeResponse.status}`);
   }

--- a/Website/src/routes/(main)/oauth/+page.server.ts
+++ b/Website/src/routes/(main)/oauth/+page.server.ts
@@ -73,7 +73,7 @@ export const load: PageServerLoad = async ({ cookies, locals, url, fetch }) => {
   const cookieSettings = { ...baseCookieSettings, maxAge };
 
   cookies.set(Cookies.IdToken, idToken, cookieSettings);
-  cookies.set(Cookies.Claims, JSON.stringify(userInfo.claims), cookieSettings);
+  cookies.set(Cookies.IsAdmin, userInfo.isAdmin.toString(), cookieSettings);
 
   cookies.delete('challengeString', {
     path: '/'

--- a/Website/src/routes/(main)/routes.svelte
+++ b/Website/src/routes/(main)/routes.svelte
@@ -4,25 +4,31 @@
   import RouteButton from './routeButton.svelte';
   import { routeGroups } from './routes.ts';
 
-  let { hasValidJwt, drawer }: { hasValidJwt: boolean; drawer?: boolean } = $props();
+  let {
+    hasValidJwt,
+    isAdmin,
+    drawer
+  }: { hasValidJwt: boolean; isAdmin: boolean; drawer?: boolean } = $props();
 </script>
 
 {#each routeGroups as routeGroup (routeGroup.title)}
-  {#if !routeGroup.requireAuth || (routeGroup.requireAuth && hasValidJwt)}
-    <div>
-      <h2 class="mb-1 scroll-m-20 text-lg font-semibold tracking-tight">{routeGroup.title}</h2>
-      {#if drawer}
-        <Close class="flex w-full flex-col">
+  {#if !routeGroup.requireAuth || hasValidJwt}
+    {#if !routeGroup.requireAdmin || isAdmin}
+      <div>
+        <h2 class="mb-1 scroll-m-20 text-lg font-semibold tracking-tight">{routeGroup.title}</h2>
+        {#if drawer}
+          <Close class="flex w-full flex-col">
+            {#each routeGroup.routes as route (route.href)}
+              <RouteButton {route} />
+            {/each}
+          </Close>
+        {:else}
           {#each routeGroup.routes as route (route.href)}
             <RouteButton {route} />
           {/each}
-        </Close>
-      {:else}
-        {#each routeGroup.routes as route (route.href)}
-          <RouteButton {route} />
-        {/each}
-      {/if}
-    </div>
+        {/if}
+      </div>
+    {/if}
   {/if}
 {/each}
 

--- a/Website/src/routes/(main)/routes.ts
+++ b/Website/src/routes/(main)/routes.ts
@@ -4,12 +4,14 @@ import House from 'lucide-svelte/icons/house';
 import Newspaper from 'lucide-svelte/icons/newspaper';
 import Pencil from 'lucide-svelte/icons/pencil';
 import User from 'lucide-svelte/icons/user';
+import VenetianMask from 'lucide-svelte/icons/venetian-mask';
 import type { ComponentType } from 'svelte';
 
 export type RouteGroup = {
   title: string;
   routes: Route[];
   requireAuth?: boolean;
+  requireAdmin?: boolean;
 };
 
 export type Route = {
@@ -48,5 +50,10 @@ export const routeGroups: RouteGroup[] = [
         icon: Pencil
       }
     ]
+  },
+  {
+    title: 'Administration',
+    requireAdmin: true,
+    routes: [{ title: 'User Impersonation', href: '/admin/impersonation', icon: VenetianMask }]
   }
 ];

--- a/Website/src/routes/(main)/sideNav.svelte
+++ b/Website/src/routes/(main)/sideNav.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import Routes from '$main/routes.svelte';
 
-  export let hasValidJwt: boolean;
+  const { hasValidJwt, isAdmin }: { hasValidJwt: boolean; isAdmin: boolean } = $props();
 </script>
 
 <div id="navigation" class="hidden flex-col gap-4 py-2 md:flex">
   <nav class="grid gap-1 px-2">
-    <Routes {hasValidJwt} />
+    <Routes {hasValidJwt} {isAdmin} />
   </nav>
 </div>
 

--- a/Website/static/mockServiceWorker.js
+++ b/Website/static/mockServiceWorker.js
@@ -5,24 +5,23 @@
  * Mock Service Worker.
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
- * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.8.4'
-const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
+const PACKAGE_VERSION = '2.10.3'
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
-self.addEventListener('install', function () {
+addEventListener('install', function () {
   self.skipWaiting()
 })
 
-self.addEventListener('activate', function (event) {
+addEventListener('activate', function (event) {
   event.waitUntil(self.clients.claim())
 })
 
-self.addEventListener('message', async function (event) {
-  const clientId = event.source.id
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
 
   if (!clientId || !self.clients) {
     return
@@ -94,17 +93,18 @@ self.addEventListener('message', async function (event) {
   }
 })
 
-self.addEventListener('fetch', function (event) {
-  const { request } = event
-
+addEventListener('fetch', function (event) {
   // Bypass navigation requests.
-  if (request.mode === 'navigate') {
+  if (event.request.mode === 'navigate') {
     return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
     return
   }
 
@@ -115,48 +115,62 @@ self.addEventListener('fetch', function (event) {
     return
   }
 
-  // Generate unique request ID.
   const requestId = crypto.randomUUID()
   event.respondWith(handleRequest(event, requestId))
 })
 
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
 async function handleRequest(event, requestId) {
   const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
   const response = await getResponse(event, client, requestId)
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    ;(async function () {
-      const responseClone = response.clone()
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
-      sendToClient(
-        client,
-        {
-          type: 'RESPONSE',
-          payload: {
-            requestId,
-            isMockedResponse: IS_MOCKED_RESPONSE in response,
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
             type: responseClone.type,
             status: responseClone.status,
             statusText: responseClone.statusText,
-            body: responseClone.body,
             headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
           },
         },
-        [responseClone.body],
-      )
-    })()
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
   }
 
   return response
 }
 
-// Resolve the main client for the given event.
-// Client that issues a request doesn't necessarily equal the client
-// that registered the worker. It's with the latter the worker should
-// communicate with during the response resolving phase.
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId)
 
@@ -184,12 +198,16 @@ async function resolveMainClient(event) {
     })
 }
 
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
 async function getResponse(event, client, requestId) {
-  const { request } = event
-
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone()
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
@@ -230,29 +248,17 @@ async function getResponse(event, client, requestId) {
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer()
+  const serializedRequest = await serializeRequest(event.request)
   const clientMessage = await sendToClient(
     client,
     {
       type: 'REQUEST',
       payload: {
         id: requestId,
-        url: request.url,
-        mode: request.mode,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
-        cache: request.cache,
-        credentials: request.credentials,
-        destination: request.destination,
-        integrity: request.integrity,
-        redirect: request.redirect,
-        referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
-        body: requestBuffer,
-        keepalive: request.keepalive,
+        ...serializedRequest,
       },
     },
-    [requestBuffer],
+    [serializedRequest.body],
   )
 
   switch (clientMessage.type) {
@@ -268,6 +274,12 @@ async function getResponse(event, client, requestId) {
   return passthrough()
 }
 
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel()
@@ -280,14 +292,18 @@ function sendToClient(client, message, transferrables = []) {
       resolve(event.data)
     }
 
-    client.postMessage(
-      message,
-      [channel.port2].concat(transferrables.filter(Boolean)),
-    )
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
   })
 }
 
-async function respondWithMock(response) {
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
   // Setting response status code to 0 is a no-op.
   // However, when responding with a "Response.error()", the produced Response
   // instance will have status code set to 0. Since it's not possible to create
@@ -304,4 +320,25 @@ async function respondWithMock(response) {
   })
 
   return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
 }


### PR DESCRIPTION
Adds an admin-only page that allows access to the existing user impersonation functionality. Previously this had to be accessed via the GraphQL API which was highly inconvenient and unintuitive.

The page is deliberately quite spartan as it is designed only for admins / devs to use.

Access to it and the associated endpoints is driven by the presently unused 'IsAdmin' column in the Players table. Server administrators must manually edit rows in the database to mark them as admins and allow them to access this page.