### PR TITLE
Reward handling rework

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/QuestBonusTest.cs
@@ -26,7 +26,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -96,7 +97,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse.Data.UpdateDataList.MaterialList.Should().NotBeEmpty();
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -139,7 +141,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -179,7 +182,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -226,7 +230,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -261,7 +266,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse.Data.UpdateDataList.MaterialList.Should().BeNullOrEmpty();
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -289,7 +295,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -324,7 +331,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse.Data.UpdateDataList.MaterialList.Should().BeNullOrEmpty();
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -367,7 +375,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -401,7 +410,8 @@ public class QuestBonusTest : TestFixture
 
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -444,7 +454,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -478,7 +489,8 @@ public class QuestBonusTest : TestFixture
 
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -519,7 +531,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -561,7 +574,8 @@ public class QuestBonusTest : TestFixture
 
         response
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -595,7 +609,8 @@ public class QuestBonusTest : TestFixture
 
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
-            .ContainEquivalentOf(
+            .Contain(x => x.QuestEventId == questEventId)
+            .Which.Should.BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/QuestBonusTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/QuestBonusTest.cs
@@ -27,7 +27,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -98,7 +99,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -142,7 +144,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -183,7 +186,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -231,7 +235,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -267,7 +272,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -296,7 +302,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -332,7 +339,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -376,7 +384,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -411,7 +420,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -455,7 +465,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -490,7 +501,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -532,7 +544,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -575,7 +588,8 @@ public class QuestBonusTest : TestFixture
         response
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -585,11 +599,10 @@ public class QuestBonusTest : TestFixture
                     QuestBonusStackCount = 1,
                     QuestBonusStackTime = response.Data.IngameResultData.EndTime,
                     LastDailyResetTime = response.Data.IngameResultData.EndTime,
-                    LastWeeklyResetTime = yesterday,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance()
+                opts => opts.WithDateTimeTolerance().Excluding(x => x.LastWeeklyResetTime)
             );
 
         DragaliaResponse<DungeonReceiveQuestBonusResponse> bonusResponse =
@@ -610,7 +623,8 @@ public class QuestBonusTest : TestFixture
         bonusResponse
             .Data.UpdateDataList.QuestEventList.Should()
             .Contain(x => x.QuestEventId == questEventId)
-            .Which.Should.BeEquivalentTo(
+            .Which.Should()
+            .BeEquivalentTo(
                 new QuestEventList()
                 {
                     QuestEventId = questEventId,
@@ -620,11 +634,10 @@ public class QuestBonusTest : TestFixture
                     QuestBonusStackCount = 0,
                     QuestBonusStackTime = DateTimeOffset.UtcNow,
                     LastDailyResetTime = response.Data.IngameResultData.EndTime,
-                    LastWeeklyResetTime = yesterday,
                     DailyPlayCount = 1,
                     WeeklyPlayCount = 1,
                 },
-                opts => opts.WithDateTimeTolerance()
+                opts => opts.WithDateTimeTolerance().Excluding(x => x.LastWeeklyResetTime)
             );
     }
 

--- a/DragaliaAPI/DragaliaAPI.Shared/Generated/Microsoft.Extensions.Logging.Generators/Microsoft.Extensions.Logging.Generators.LoggerMessageGenerator/LoggerMessage.g.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/Generated/Microsoft.Extensions.Logging.Generators/Microsoft.Extensions.Logging.Generators.LoggerMessageGenerator/LoggerMessage.g.cs
@@ -7,11 +7,11 @@ namespace DragaliaAPI.Shared.PlayerDetails
     {
         partial class Log
         {
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "42.42.42.42")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "10.0.14.15411")]
             private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.Object, global::System.Exception?> __StartingUserImpersonationCallback =
                 global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::System.Object>(global::Microsoft.Extensions.Logging.LogLevel.Debug, new global::Microsoft.Extensions.Logging.EventId(187340990, nameof(StartingUserImpersonation)), "Starting user impersonation: {@context}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true }); 
 
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "42.42.42.42")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "10.0.14.15411")]
             public static partial void StartingUserImpersonation(global::Microsoft.Extensions.Logging.ILogger logger, global::System.Object context)
             {
                 if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))
@@ -19,11 +19,11 @@ namespace DragaliaAPI.Shared.PlayerDetails
                     __StartingUserImpersonationCallback(logger, context, null);
                 }
             }
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "42.42.42.42")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "10.0.14.15411")]
             private static readonly global::System.Action<global::Microsoft.Extensions.Logging.ILogger, global::System.Object, global::System.Exception?> __StoppingUserImpersonationCallback =
                 global::Microsoft.Extensions.Logging.LoggerMessage.Define<global::System.Object>(global::Microsoft.Extensions.Logging.LogLevel.Debug, new global::Microsoft.Extensions.Logging.EventId(1307607602, nameof(StoppingUserImpersonation)), "Stopping user impersonation: {@context}", new global::Microsoft.Extensions.Logging.LogDefineOptions() { SkipEnabledCheck = true }); 
 
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "42.42.42.42")]
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.Extensions.Logging.Generators", "10.0.14.15411")]
             public static partial void StoppingUserImpersonation(global::Microsoft.Extensions.Logging.ILogger logger, global::System.Object context)
             {
                 if (logger.IsEnabled(global::Microsoft.Extensions.Logging.LogLevel.Debug))

--- a/DragaliaAPI/DragaliaAPI/Features/Event/Summon/EventSummonService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/Summon/EventSummonService.cs
@@ -200,19 +200,18 @@ internal class EventSummonService(
             }
         }
 
-        IDictionary<int, RewardGrantResult> resultDict = await rewardService.BatchGrantRewards(
-            rewards
-        );
-
-        foreach ((int rewardId, RewardGrantResult grantResult) in resultDict)
-        {
-            if (grantResult == RewardGrantResult.Limit)
+        await rewardService.BatchGrantRewards(
+            rewards,
+            (_, entity, grantResult) =>
             {
-                presentService.AddPresent(
-                    new Present.Present(PresentMessage.EventSummonReward, rewards[rewardId])
-                );
+                if (grantResult == RewardGrantResult.Limit)
+                {
+                    presentService.AddPresent(
+                        new Present.Present(PresentMessage.EventSummonReward, entity)
+                    );
+                }
             }
-        }
+        );
 
         BoxSummonInfo newBoxSummonInfo = EventSummonLogic.GetBoxSummonInfo(
             userData.BoxNumber,

--- a/DragaliaAPI/DragaliaAPI/Features/Present/PresentControllerService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Present/PresentControllerService.cs
@@ -95,43 +95,40 @@ public partial class PresentControllerService(
         List<long> notReceivedIds = [];
         List<long> removedIds = [];
 
-        IDictionary<long, RewardGrantResult> result = await rewardService.BatchGrantRewards(
-            presentEntities
+        await rewardService.BatchGrantRewards(
+            presentEntities,
+            (presentId, _, grantResult) =>
+            {
+                DbPlayerPresent present = presents[presentId];
+
+                switch (grantResult)
+                {
+                    case RewardGrantResult.Added:
+                    case RewardGrantResult.Converted:
+                        receivedIds.Add(present.PresentId);
+                        break;
+                    case RewardGrantResult.Limit:
+                        notReceivedIds.Add(present.PresentId);
+                        break;
+                    case RewardGrantResult.Discarded:
+                        removedIds.Add(present.PresentId);
+                        break;
+                }
+
+                Log.ClaimedPresent(logger, present);
+
+                if (
+                    grantResult
+                    is RewardGrantResult.Added
+                        or RewardGrantResult.Converted
+                        or RewardGrantResult.Discarded
+                )
+                {
+                    apiContext.PlayerPresents.Remove(present);
+                    apiContext.PlayerPresentHistory.Add(present.MapToPresentHistory());
+                }
+            }
         );
-
-        foreach ((long presentId, RewardGrantResult grantResult) in result)
-        {
-            DbPlayerPresent present = presents[presentId];
-
-            switch (grantResult)
-            {
-                case RewardGrantResult.Added:
-                    receivedIds.Add(present.PresentId);
-                    break;
-                case RewardGrantResult.Converted:
-                    receivedIds.Add(present.PresentId);
-                    break;
-                case RewardGrantResult.Limit:
-                    notReceivedIds.Add(present.PresentId);
-                    break;
-                case RewardGrantResult.Discarded:
-                    removedIds.Add(present.PresentId);
-                    break;
-            }
-
-            Log.ClaimedPresent(logger, present);
-
-            if (
-                grantResult
-                is RewardGrantResult.Added
-                    or RewardGrantResult.Converted
-                    or RewardGrantResult.Discarded
-            )
-            {
-                apiContext.PlayerPresents.Remove(present);
-                apiContext.PlayerPresentHistory.Add(present.MapToPresentHistory());
-            }
-        }
 
         return new(receivedIds, notReceivedIds, removedIds);
     }

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/IRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/IRewardService.cs
@@ -38,8 +38,9 @@ public interface IRewardService
 
     IEnumerable<ConvertedEntity> GetConvertedEntityList();
 
-    Task<IDictionary<TKey, RewardGrantResult>> BatchGrantRewards<TKey>(
-        IDictionary<TKey, Entity> entities
+    Task BatchGrantRewards<TKey>(
+        IDictionary<TKey, Entity> entities,
+        Action<TKey, Entity, RewardGrantResult> onResult
     )
         where TKey : struct;
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/RewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/RewardService.cs
@@ -49,13 +49,12 @@ public partial class RewardService(
         }
     }
 
-    public async Task<IDictionary<TKey, RewardGrantResult>> BatchGrantRewards<TKey>(
-        IDictionary<TKey, Entity> entities
+    public async Task BatchGrantRewards<TKey>(
+        IDictionary<TKey, Entity> entities,
+        Action<TKey, Entity, RewardGrantResult> onResult
     )
         where TKey : struct
     {
-        Dictionary<TKey, RewardGrantResult> result = [];
-
         IEnumerable<(EntityTypes type, Dictionary<TKey, Entity>)> grouping = entities.GroupBy(
             x => x.Value.Type,
             (type, group) => (type, group.ToDictionary())
@@ -79,8 +78,9 @@ public partial class RewardService(
 
                 foreach ((TKey key, GrantReturn grantReturn) in batchResult)
                 {
-                    await this.ProcessGrantResult(grantReturn, dictionary[key]);
-                    result.Add(key, grantReturn.Result);
+                    Entity entity = dictionary[key];
+                    await this.ProcessGrantResult(grantReturn, entity);
+                    onResult(key, entity, grantReturn.Result);
                 }
             }
             else
@@ -91,12 +91,10 @@ public partial class RewardService(
                 {
                     GrantReturn grantReturn = await handler.Grant(entity);
                     await this.ProcessGrantResult(grantReturn, entity);
-                    result.Add(key, grantReturn.Result);
+                    onResult(key, entity, grantReturn.Result);
                 }
             }
         }
-
-        return result;
     }
 
     private async Task ProcessGrantResult(GrantReturn grantReturn, Entity entity)

--- a/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
@@ -296,6 +296,7 @@ public partial class StoryService(
             await rewardService.GrantReward(
                 new(EntityTypes.Chara, Id: (int)eventData.EventCharaId)
             );
+
             rewardList.Add(
                 new()
                 {

--- a/DragaliaAPI/DragaliaAPI/Features/Summoning/UnitService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Summoning/UnitService.cs
@@ -32,15 +32,15 @@ public class UnitService(
             .Select((x, index) => KeyValuePair.Create(index, new Entity(EntityTypes.Chara, (int)x)))
             .ToDictionary();
 
-        IDictionary<int, RewardGrantResult> outputRewardDict =
-            await rewardService.BatchGrantRewards(inputRewardDict);
-
         List<CharaNewCheckResult> result = [];
 
-        foreach ((int key, RewardGrantResult grantResult) in outputRewardDict)
-        {
-            result.Add(((Charas)inputRewardDict[key].Id, grantResult == RewardGrantResult.Added));
-        }
+        await rewardService.BatchGrantRewards(
+            inputRewardDict,
+            (_, entity, grantResult) =>
+            {
+                result.Add(((Charas)entity.Id, grantResult == RewardGrantResult.Added));
+            }
+        );
 
         return result;
     }
@@ -53,18 +53,18 @@ public class UnitService(
             )
             .ToDictionary();
 
-        IDictionary<int, RewardGrantResult> outputRewardDict =
-            await rewardService.BatchGrantRewards(inputRewardDict);
-
-        IEnumerable<Present.Present> presentsToAdd = outputRewardDict
-            .Where(kvp => kvp.Value == RewardGrantResult.Limit)
-            .Select(x => new Present.Present(
-                PresentMessage.SummonShowcase,
-                EntityTypes.Dragon,
-                inputRewardDict[x.Key].Id
-            ));
-
-        presentService.AddPresent(presentsToAdd);
+        await rewardService.BatchGrantRewards(
+            inputRewardDict,
+            (_, entity, grantResult) =>
+            {
+                if (grantResult == RewardGrantResult.Limit)
+                {
+                    presentService.AddPresent(
+                        new Present.Present(PresentMessage.SummonShowcase, entity.Type, entity.Id)
+                    );
+                }
+            }
+        );
 
         List<DragonId> ownedDragons = await apiContext
             .PlayerDragonData.Select(x => x.DragonId)

--- a/DragaliaAPI/DragaliaAPI/Features/Trade/TradeService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Trade/TradeService.cs
@@ -193,23 +193,18 @@ public partial class TradeService(
             };
         }
 
-        IDictionary<int, RewardGrantResult> batchResult = await rewardService.BatchGrantRewards(
-            entities
-        );
-
-        foreach ((_, RewardGrantResult result) in batchResult)
-        {
-            if (result == RewardGrantResult.Limit)
+        await rewardService.BatchGrantRewards(
+            entities,
+            (_, entity, result) =>
             {
-                presentService.AddPresent(
-                    new Present.Present(
-                        PresentMessage.TreasureTrade,
-                        trade.DestinationEntityType,
-                        trade.DestinationEntityId
-                    )
-                );
+                if (result == RewardGrantResult.Limit)
+                {
+                    presentService.AddPresent(
+                        new Present.Present(PresentMessage.TreasureTrade, entity.Type, entity.Id)
+                    );
+                }
             }
-        }
+        );
 
         await tradeRepository.AddTrade(tradeType, tradeId, count, DateTimeOffset.UtcNow);
 


### PR DESCRIPTION
Rather than iterating over a returned dictionary, have the reward service support callbacks as a way to react to reward grant results.