### PR TITLE
Add support for temporary characters

### DIFF
--- a/Aspire/Dawnshard.AppHost/Properties/launchSettings.json
+++ b/Aspire/Dawnshard.AppHost/Properties/launchSettings.json
@@ -19,6 +19,7 @@
       "launchBrowser": true,
       "applicationUrl": "http://localhost:15150",
       "environmentVariables": {
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true",
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
         "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19186",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,7 +194,8 @@ dotnet ef database update --project DragaliaAPI.Database --startup-project Draga
 3. Implement the business logic in `DragaliaAPI/Features/<FeatureName>/`. Controllers live in the same feature subfolder.
 4. Use `ApiContext` directly for data access; do **not** add new repository classes.
 5. Write integration tests in `DragaliaAPI.Integration.Test/` to verify the feature end-to-end.
-6. Run `dotnet csharpier format .` to format and `dotnet build DragaliaAPI.slnx` to check for warnings.
+6. Run new tests with `--filter-method` to confirm they pass before committing.
+7. Run `dotnet csharpier format .` to format.
 
 ## CI Workflows
 
@@ -232,7 +233,7 @@ A small ASP.NET Core service that stores Photon room state in Redis. It exposes 
 # Build everything
 dotnet build DragaliaAPI.slnx
 
-# Build everything on Linux platforms (skipping Windows-only .NET Framework components)
+# Build everything on Linux platforms (skipping Windows-only PhotonPlugin projects) — use this when running on Linux
 dotnet build DragaliaAPI.Linux.slnf
 
 # Format C# code

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
@@ -130,6 +130,9 @@ public class DbPlayerCharaData : DbPlayerData
     [Column("IsTemp")]
     public bool IsTemporary { get; set; }
 
+    [Column("FriendshipPoint")]
+    public int FriendshipPoint { get; set; }
+
     [Column("IsUnlockEditSkill")]
     public bool IsUnlockEditSkill { get; set; }
 

--- a/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Entities/DbPlayerCharaData.cs
@@ -127,6 +127,15 @@ public class DbPlayerCharaData : DbPlayerData
     [Column("ExAbility2Lvl")]
     public byte ExAbility2Level { get; set; } = 1;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether the character is temporary.
+    /// </summary>
+    /// <remarks>
+    /// This is relevant to welfare / guest characters from raid events that need to be befriended.
+    ///
+    /// If this is set to true, and the character's event is not active, then they will be automatically hidden by the client.
+    /// This is 'good enough' so we don't validate usage of these characters outside of event windows.
+    /// </remarks>
     [Column("IsTemp")]
     public bool IsTemporary { get; set; }
 

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20260413144300_TemporaryCharaFriendshipPoint.Designer.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20260413144300_TemporaryCharaFriendshipPoint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20260413144300_TemporaryCharaFriendshipPoint")]
+    partial class TemporaryCharaFriendshipPoint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20260413144300_TemporaryCharaFriendshipPoint.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20260413144300_TemporaryCharaFriendshipPoint.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class TemporaryCharaFriendshipPoint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "FriendshipPoint",
+                table: "PlayerCharaData",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "FriendshipPoint",
+                table: "PlayerCharaData");
+        }
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
@@ -6,10 +6,13 @@ namespace DragaliaAPI.Integration.Test.Features.Dungeon;
 
 public partial class DungeonRecordTest
 {
-    // SinDom expert: quest ID 228011101, stamina 9
+    // SinDom expert: quest ID 228011101, stamina 9, Gid 22801 (no event in master data)
     // Audric (10140503) has MaxFriendshipPoint: 500
+    // Audric is EventCharaId for event 20422; quest 204220202 has Gid 20422, stamina 7
     private const int SinDomExpertQuestId = 228011101;
     private const int SinDomExpertStamina = 9;
+    private const int AudricEventQuestId = 204220202;
+    private const int AudricEventQuestStamina = 7;
 
     [Fact]
     public async Task Record_TemporaryCharacter_GrantsFriendshipPoints()
@@ -233,4 +236,112 @@ public partial class DungeonRecordTest
 
         dbFriendshipPoint.Should().Be(maxFriendshipPoint);
     }
+
+    [Fact]
+    public async Task Record_TemporaryCharacter_MaxFriendshipReached_FlipsIsTemporaryToFalse()
+    {
+        int maxFriendshipPoint = MasterAsset.CharaData[Charas.Audric].MaxFriendshipPoint;
+
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x =>
+                    x.SetProperty(p => p.IsTemporary, true)
+                        .SetProperty(p => p.FriendshipPoint, maxFriendshipPoint - 1),
+                TestContext.Current.CancellationToken
+            );
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(SinDomExpertQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = [],
+                        LiveUnitNoList = [1],
+                        DamageRecord = [],
+                        DragonDamageRecord = [],
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response
+            .IngameResultData.GrowRecord.CharaFriendshipList.Should()
+            .ContainSingle(x => x.CharaId == Charas.Audric)
+            .Which.IsTemporary.Should()
+            .BeFalse();
+
+        bool dbIsTemporary = await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .Select(x => x.IsTemporary)
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        dbIsTemporary.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Record_TemporaryCharacter_AssociatedEventQuest_GrantsDoubledFriendshipPoints()
+    {
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x => x.SetProperty(p => p.IsTemporary, true),
+                TestContext.Current.CancellationToken
+            );
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(AudricEventQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = [],
+                        LiveUnitNoList = [1],
+                        DamageRecord = [],
+                        DragonDamageRecord = [],
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response
+            .IngameResultData.GrowRecord.CharaFriendshipList.Should()
+            .ContainSingle(x =>
+                x.CharaId == Charas.Audric
+                && x.AddPoint == AudricEventQuestStamina * 2
+                && x.TotalPoint == AudricEventQuestStamina * 2
+            );
+    }
+
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
@@ -343,5 +343,4 @@ public partial class DungeonRecordTest
                 && x.TotalPoint == AudricEventQuestStamina * 2
             );
     }
-
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.TemporaryCharaFriendship.cs
@@ -1,0 +1,236 @@
+using DragaliaAPI.Features.Dungeon;
+using DragaliaAPI.Shared.MasterAsset;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Integration.Test.Features.Dungeon;
+
+public partial class DungeonRecordTest
+{
+    // SinDom expert: quest ID 228011101, stamina 9
+    // Audric (10140503) has MaxFriendshipPoint: 500
+    private const int SinDomExpertQuestId = 228011101;
+    private const int SinDomExpertStamina = 9;
+
+    [Fact]
+    public async Task Record_TemporaryCharacter_GrantsFriendshipPoints()
+    {
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x => x.SetProperty(p => p.IsTemporary, true),
+                TestContext.Current.CancellationToken
+            );
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(SinDomExpertQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = [],
+                        LiveUnitNoList = [1],
+                        DamageRecord = [],
+                        DragonDamageRecord = [],
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response
+            .IngameResultData.GrowRecord.CharaFriendshipList.Should()
+            .ContainSingle(x =>
+                x.CharaId == Charas.Audric
+                && x.AddPoint == SinDomExpertStamina
+                && x.TotalPoint == SinDomExpertStamina
+                && x.IsTemporary
+            );
+
+        int dbFriendshipPoint = await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .Select(x => x.FriendshipPoint)
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        dbFriendshipPoint.Should().Be(SinDomExpertStamina);
+    }
+
+    [Fact]
+    public async Task Record_TemporaryCharacter_FriendshipPointsAccumulate()
+    {
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x => x.SetProperty(p => p.IsTemporary, true),
+                TestContext.Current.CancellationToken
+            );
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(SinDomExpertQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        PlayRecord playRecord = new()
+        {
+            Time = 10,
+            TreasureRecord = [],
+            LiveUnitNoList = [1],
+            DamageRecord = [],
+            DragonDamageRecord = [],
+            BattleRoyalRecord = new(),
+        };
+
+        await Client.PostMsgpack<DungeonRecordRecordResponse>(
+            "/dungeon_record/record",
+            new DungeonRecordRecordRequest()
+            {
+                DungeonKey = await this.StartDungeon(mockSession),
+                PlayRecord = playRecord,
+            },
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = await this.StartDungeon(mockSession),
+                    PlayRecord = playRecord,
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response
+            .IngameResultData.GrowRecord.CharaFriendshipList.Should()
+            .ContainSingle(x =>
+                x.CharaId == Charas.Audric
+                && x.AddPoint == SinDomExpertStamina
+                && x.TotalPoint == SinDomExpertStamina * 2
+            );
+
+        int dbFriendshipPoint = await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .Select(x => x.FriendshipPoint)
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        dbFriendshipPoint.Should().Be(SinDomExpertStamina * 2);
+    }
+
+    [Fact]
+    public async Task Record_NonTemporaryCharacter_DoesNotReceiveFriendshipPoints()
+    {
+        this.AddCharacter(Charas.Audric);
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(SinDomExpertQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = [],
+                        LiveUnitNoList = [1],
+                        DamageRecord = [],
+                        DragonDamageRecord = [],
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response.IngameResultData.GrowRecord.CharaFriendshipList.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Record_TemporaryCharacter_FriendshipPointsClampedAtMax()
+    {
+        int maxFriendshipPoint = MasterAsset.CharaData[Charas.Audric].MaxFriendshipPoint;
+
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x =>
+                    x.SetProperty(p => p.IsTemporary, true)
+                        .SetProperty(
+                            p => p.FriendshipPoint,
+                            maxFriendshipPoint - SinDomExpertStamina + 1
+                        ),
+                TestContext.Current.CancellationToken
+            );
+
+        DungeonSession mockSession = new()
+        {
+            Party = [new() { CharaId = Charas.Audric, UnitNo = 1 }],
+            QuestData = MasterAsset.QuestData.Get(SinDomExpertQuestId),
+            EnemyList = new() { { 1, [] } },
+        };
+
+        string key = await this.StartDungeon(mockSession);
+
+        DungeonRecordRecordResponse response = (
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = [],
+                        LiveUnitNoList = [1],
+                        DamageRecord = [],
+                        DragonDamageRecord = [],
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        ).Data;
+
+        response
+            .IngameResultData.GrowRecord.CharaFriendshipList.Should()
+            .ContainSingle(x =>
+                x.CharaId == Charas.Audric
+                && x.AddPoint == SinDomExpertStamina - 1
+                && x.TotalPoint == maxFriendshipPoint
+            );
+
+        int dbFriendshipPoint = await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .Select(x => x.FriendshipPoint)
+            .SingleAsync(TestContext.Current.CancellationToken);
+
+        dbFriendshipPoint.Should().Be(maxFriendshipPoint);
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -69,6 +69,50 @@ public class RaidEventTest : TestFixture
     }
 
     [Fact]
+    public async Task GetEventData_EventHasTemporaryChara_ReturnsCharaFriendshipList()
+    {
+        // Fractured Futures (20427) has Audric as its EventCharaId
+        const int fracturedFuturesId = 20427;
+
+        await this.Client.PostMsgpack(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(fracturedFuturesId),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        this.AddCharacter(Charas.Audric);
+        await this
+            .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
+            .ExecuteUpdateAsync(
+                x =>
+                    x.SetProperty(p => p.IsTemporary, true)
+                        .SetProperty(p => p.FriendshipPoint, 50),
+                TestContext.Current.CancellationToken
+            );
+
+        DragaliaResponse<RaidEventGetEventDataResponse> response =
+            await this.Client.PostMsgpack<RaidEventGetEventDataResponse>(
+                "raid_event/get_event_data",
+                new RaidEventGetEventDataRequest(fracturedFuturesId),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        response
+            .Data.CharaFriendshipList.Should()
+            .ContainSingle(x => x.CharaId == Charas.Audric)
+            .Which.Should()
+            .BeEquivalentTo(
+                new CharaFriendshipList()
+                {
+                    CharaId = Charas.Audric,
+                    AddPoint = 0,
+                    TotalPoint = 50,
+                    IsTemporary = true,
+                }
+            );
+    }
+
+    [Fact]
     public async Task Entry_EventHasNoItems_InitializesUserData()
     {
         const int fracturedFuturesId = 20427;

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/RaidEventTest.cs
@@ -85,8 +85,7 @@ public class RaidEventTest : TestFixture
             .ApiContext.PlayerCharaData.Where(x => x.CharaId == Charas.Audric)
             .ExecuteUpdateAsync(
                 x =>
-                    x.SetProperty(p => p.IsTemporary, true)
-                        .SetProperty(p => p.FriendshipPoint, 50),
+                    x.SetProperty(p => p.IsTemporary, true).SetProperty(p => p.FriendshipPoint, 50),
                 TestContext.Current.CancellationToken
             );
 

--- a/DragaliaAPI/DragaliaAPI.Shared.Test/Unit/MasterAssetTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared.Test/Unit/MasterAssetTest.cs
@@ -102,7 +102,8 @@ public class MasterAssetTest
                     EditReleaseEntityId1: 201019011,
                     EditReleaseEntityQuantity1: 5,
                     BaseId: 100032,
-                    VariationId: 4
+                    VariationId: 4,
+                    MaxFriendshipPoint: 0
                 )
             );
     }

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/CharaData.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/CharaData.cs
@@ -87,7 +87,8 @@ public record CharaData(
     int EditReleaseEntityId1,
     int EditReleaseEntityQuantity1,
     int BaseId,
-    int VariationId
+    int VariationId,
+    int MaxFriendshipPoint
 ) : IUnitData
 {
     [IgnoreMember]

--- a/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Test/Features/Dungeon/Record/DungeonRecordServiceTest.cs
@@ -171,6 +171,8 @@ public class DungeonRecordServiceTest
             );
         this.mockDungeonRewardService.Setup(x => x.ProcessDraconicEssenceDrops(session))
             .ReturnsAsync([]);
+        this.mockDungeonRewardService.Setup(x => x.ProcessTemporaryCharaFriendship(session))
+            .ReturnsAsync([]);
 
         this.mockQuestService.Setup(x => x.GetQuestStamina(lSurtrSoloId, StaminaType.Single))
             .ReturnsAsync(40);

--- a/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
@@ -16,12 +16,12 @@ public static class NumberExtensions
         /// <returns>The lower of <paramref name="cap"/> or the addition result.</returns>
         public T AddWithCap(T amount, T cap, out T amountAdded)
         {
-            ArgumentOutOfRangeException.ThrowIfNegative(value);
+            ArgumentOutOfRangeException.ThrowIfNegative(amount);
 
             if (value >= cap)
             {
                 amountAdded = T.Zero;
-                return value;
+                return cap;
             }
 
             amountAdded = T.Min(amount, cap - value);

--- a/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
@@ -4,14 +4,15 @@ namespace DragaliaAPI.Extensions;
 
 public static class NumberExtensions
 {
-    extension<T>(T value) where T : IBinaryInteger<T>
+    extension<T>(T value)
+        where T : IBinaryInteger<T>
     {
         /// <summary>
         /// Computes the result of adding <paramref name="amount"/> to the value, capped at <paramref name="cap"/>.
         /// </summary>
         /// <param name="amount">The amount to add. Must not be negative.</param>
         /// <param name="cap">The maximum value.</param>
-        /// <param name="amountAdded">Out parameter containing the value difference.</param> 
+        /// <param name="amountAdded">Out parameter containing the value difference.</param>
         /// <returns>The lower of <paramref name="cap"/> or the addition result.</returns>
         public T AddWithCap(T amount, T cap, out T amountAdded)
         {
@@ -28,4 +29,3 @@ public static class NumberExtensions
         }
     }
 }
-

--- a/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI/Extensions/NumberExtensions.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+
+namespace DragaliaAPI.Extensions;
+
+public static class NumberExtensions
+{
+    extension<T>(T value) where T : IBinaryInteger<T>
+    {
+        /// <summary>
+        /// Computes the result of adding <paramref name="amount"/> to the value, capped at <paramref name="cap"/>.
+        /// </summary>
+        /// <param name="amount">The amount to add. Must not be negative.</param>
+        /// <param name="cap">The maximum value.</param>
+        /// <param name="amountAdded">Out parameter containing the value difference.</param> 
+        /// <returns>The lower of <paramref name="cap"/> or the addition result.</returns>
+        public T AddWithCap(T amount, T cap, out T amountAdded)
+        {
+            ArgumentOutOfRangeException.ThrowIfNegative(value);
+
+            if (value >= cap)
+            {
+                amountAdded = T.Zero;
+                return value;
+            }
+
+            amountAdded = T.Min(amount, cap - value);
+            return value + amountAdded;
+        }
+    }
+}
+

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -1,5 +1,6 @@
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Extensions;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Present;
@@ -11,6 +12,7 @@ using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models.Event;
 using DragaliaAPI.Shared.MasterAsset.Models.QuestRewards;
 using Microsoft.EntityFrameworkCore;
+using System.Diagnostics;
 
 namespace DragaliaAPI.Features.Dungeon.Record;
 
@@ -292,9 +294,13 @@ public partial class DungeonRecordRewardService(
             return [];
         }
 
-        ArgumentNullException.ThrowIfNull(session.QuestData);
+        if (session.QuestData is null)
+        {
+            throw new UnreachableException("Wall request reached friendship calculation");
+        }
 
         int stamina = session.QuestData.PayStaminaSingle;
+
         if (stamina == 0)
         {
             return [];
@@ -309,7 +315,13 @@ public partial class DungeonRecordRewardService(
             .PlayerCharaData.Where(x => partyCharaIds.Contains(x.CharaId) && x.IsTemporary)
             .ToListAsync();
 
-        int pointsToAdd = stamina * session.PlayCount;
+        Charas? eventCharaId = MasterAsset.EventData.TryGetValue(
+            session.QuestData.Gid,
+            out EventData? eventData
+        )
+            ? eventData.EventCharaId
+            : null;
+
         List<CharaFriendshipList> result = [];
 
         foreach (DbPlayerCharaData chara in temporaryCharas)
@@ -320,18 +332,26 @@ public partial class DungeonRecordRewardService(
                 continue;
             }
 
-            int actualPointsAdded = Math.Min(
+            int multiplier = chara.CharaId == eventCharaId ? 2 : 1;
+            int pointsToAdd = stamina * session.PlayCount * multiplier;
+
+            chara.FriendshipPoint = chara.FriendshipPoint.AddWithCap(
                 pointsToAdd,
-                maxFriendshipPoint - chara.FriendshipPoint
+                maxFriendshipPoint,
+                out int actualPointsAdded
             );
-            chara.FriendshipPoint += actualPointsAdded;
+
+            if (chara.FriendshipPoint >= maxFriendshipPoint)
+            {
+                chara.IsTemporary = false;
+            }
 
             result.Add(
                 new CharaFriendshipList(
-                    chara.CharaId,
-                    actualPointsAdded,
-                    chara.FriendshipPoint,
-                    isTemporary: true
+                    charaId: chara.CharaId,
+                    addPoint: actualPointsAdded,
+                    totalPoint: chara.FriendshipPoint,
+                    isTemporary: chara.IsTemporary
                 )
             );
         }

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -302,7 +302,7 @@ public partial class DungeonRecordRewardService(
         // We will assume that quests which take getherwings instead of stamina don't increase friendship - this also saves us from having to deal
         // with party logic i.e. whether the temporary unit was the lead/ai used in multiplayer.
         // Note that this doesn't include the actual raid event co-op quests; those use stamina and otherworld fragments.
-        
+
         int stamina = session.QuestData.PayStaminaSingle;
         if (stamina == 0)
         {

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -1,7 +1,8 @@
+using System.Diagnostics;
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
-using DragaliaAPI.Extensions;
 using DragaliaAPI.Database.Repositories;
+using DragaliaAPI.Extensions;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Present;
 using DragaliaAPI.Features.Shared.Reward;
@@ -12,7 +13,6 @@ using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models.Event;
 using DragaliaAPI.Shared.MasterAsset.Models.QuestRewards;
 using Microsoft.EntityFrameworkCore;
-using System.Diagnostics;
 
 namespace DragaliaAPI.Features.Dungeon.Record;
 
@@ -312,7 +312,8 @@ public partial class DungeonRecordRewardService(
             .ToList();
 
         List<DbPlayerCharaData> temporaryCharas = await apiContext
-            .PlayerCharaData.Where(x => partyCharaIds.Contains(x.CharaId) && x.IsTemporary)
+            .PlayerCharaData.AsTracking()
+            .Where(x => partyCharaIds.Contains(x.CharaId) && x.IsTemporary)
             .ToListAsync();
 
         Charas? eventCharaId = MasterAsset.EventData.TryGetValue(

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -1,3 +1,4 @@
+using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Features.Missions;
@@ -9,6 +10,7 @@ using DragaliaAPI.Shared.Features.Presents;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models.Event;
 using DragaliaAPI.Shared.MasterAsset.Models.QuestRewards;
+using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Features.Dungeon.Record;
 
@@ -19,6 +21,7 @@ public partial class DungeonRecordRewardService(
     EventDropService eventDropService,
     IMissionProgressionService missionProgressionService,
     IQuestRepository questRepository,
+    ApiContext apiContext,
     ILogger<DungeonRecordRewardService> logger
 ) : IDungeonRecordRewardService
 {
@@ -278,6 +281,62 @@ public partial class DungeonRecordRewardService(
             Headcount = connectingViewerIdList.Count,
             TotalQuantity = quantity,
         };
+    }
+
+    public async Task<IEnumerable<CharaFriendshipList>> ProcessTemporaryCharaFriendship(
+        DungeonSession session
+    )
+    {
+        if (session.IsSkipTicket)
+        {
+            return [];
+        }
+
+        ArgumentNullException.ThrowIfNull(session.QuestData);
+
+        int stamina = session.QuestData.PayStaminaSingle;
+        if (stamina == 0)
+        {
+            return [];
+        }
+
+        List<Charas> partyCharaIds = session
+            .Party.Where(x => x.CharaId != 0)
+            .Select(x => x.CharaId)
+            .ToList();
+
+        List<DbPlayerCharaData> temporaryCharas = await apiContext
+            .PlayerCharaData.Where(x => partyCharaIds.Contains(x.CharaId) && x.IsTemporary)
+            .ToListAsync();
+
+        int pointsToAdd = stamina * session.PlayCount;
+        List<CharaFriendshipList> result = [];
+
+        foreach (DbPlayerCharaData chara in temporaryCharas)
+        {
+            int maxFriendshipPoint = MasterAsset.CharaData[chara.CharaId].MaxFriendshipPoint;
+            if (maxFriendshipPoint == 0)
+            {
+                continue;
+            }
+
+            int actualPointsAdded = Math.Min(
+                pointsToAdd,
+                maxFriendshipPoint - chara.FriendshipPoint
+            );
+            chara.FriendshipPoint += actualPointsAdded;
+
+            result.Add(
+                new CharaFriendshipList(
+                    chara.CharaId,
+                    actualPointsAdded,
+                    chara.FriendshipPoint,
+                    isTemporary: true
+                )
+            );
+        }
+
+        return result;
     }
 
     public record EventRewardData(

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordRewardService.cs
@@ -299,8 +299,11 @@ public partial class DungeonRecordRewardService(
             throw new UnreachableException("Wall request reached friendship calculation");
         }
 
+        // We will assume that quests which take getherwings instead of stamina don't increase friendship - this also saves us from having to deal
+        // with party logic i.e. whether the temporary unit was the lead/ai used in multiplayer.
+        // Note that this doesn't include the actual raid event co-op quests; those use stamina and otherworld fragments.
+        
         int stamina = session.QuestData.PayStaminaSingle;
-
         if (stamina == 0)
         {
             return [];

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/DungeonRecordService.cs
@@ -63,6 +63,9 @@ internal partial class DungeonRecordService(
 
         await this.ProcessCharaHonors(playRecord, session);
 
+        ingameResultData.GrowRecord.CharaFriendshipList =
+            await dungeonRecordRewardService.ProcessTemporaryCharaFriendship(session);
+
         ingameResultData.RewardRecord.FirstClearSet = firstClearSets;
         ingameResultData.RewardRecord.MissionsClearSet = missionStatus.MissionsClearSet;
         ingameResultData.RewardRecord.MissionComplete = missionStatus.MissionCompleteSet;

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/Record/IDungeonRecordRewardService.cs
@@ -21,4 +21,5 @@ public interface IDungeonRecordRewardService
 
     AtgenFirstMeeting ProcessFirstMeetingRewards(IList<long> connectingViewerIdList);
     Task<IList<AtgenDropAll>> ProcessDraconicEssenceDrops(DungeonSession session);
+    Task<IEnumerable<CharaFriendshipList>> ProcessTemporaryCharaFriendship(DungeonSession session);
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
@@ -288,6 +288,35 @@ public partial class EventService(
             ?? throw new DragaliaException(ResultCode.CommonDbError, "No event data found");
     }
 
+    public async Task<IEnumerable<CharaFriendshipList>> GetEventCharaFriendshipList(int eventId)
+    {
+        Charas eventCharaId = MasterAsset.EventData[eventId].EventCharaId;
+        if (eventCharaId == Charas.Empty)
+        {
+            return [];
+        }
+
+        DbPlayerCharaData? charaData = await apiContext.PlayerCharaData.SingleOrDefaultAsync(x =>
+            x.CharaId == eventCharaId
+        );
+
+        if (charaData is null)
+        {
+            return [];
+        }
+
+        return
+        [
+            new CharaFriendshipList()
+            {
+                CharaId = charaData.CharaId,
+                AddPoint = 0,
+                TotalPoint = charaData.FriendshipPoint,
+                IsTemporary = charaData.IsTemporary,
+            },
+        ];
+    }
+
     #region User Data Providers
 
     private async Task<Dictionary<int, int>> GetEventItemDictionary(int eventId)

--- a/DragaliaAPI/DragaliaAPI/Features/Event/IEventService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/IEventService.cs
@@ -23,6 +23,8 @@ public interface IEventService
 
     Task CreateEventData(int eventId);
 
+    Task<IEnumerable<CharaFriendshipList>> GetEventCharaFriendshipList(int eventId);
+
     #region User Data Providers
 
     Task<BuildEventUserList?> GetBuildEventUserData(int eventId);

--- a/DragaliaAPI/DragaliaAPI/Features/Event/RaidEventController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/RaidEventController.cs
@@ -17,8 +17,6 @@ public class RaidEventController(
     ITradeService tradeService
 ) : DragaliaControllerBase
 {
-    // TODO: Friendship, passive boosts, summons
-
     [HttpPost("get_event_data")]
     public async Task<DragaliaResult> GetEventData(RaidEventGetEventDataRequest request)
     {
@@ -38,6 +36,10 @@ public class RaidEventController(
             );
 
             resp.EventPassiveList = [await eventService.GetEventPassiveList(request.RaidEventId)];
+
+            resp.CharaFriendshipList = await eventService.GetEventCharaFriendshipList(
+                request.RaidEventId
+            );
         }
 
         if (

--- a/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
@@ -146,6 +146,13 @@ internal sealed partial class SavefileService(
                 .CharaList.ParallelMap(playerIdentityService.ViewerId, CharaMapper.ToDbPlayerChara)
                 .ToList();
 
+            // Characters imported with is_temporary = true become permanently inaccessible
+            // when their event is not active, so clear the flag on savefile import.
+            foreach (DbPlayerCharaData chara in player.CharaList)
+            {
+                chara.IsTemporary = false;
+            }
+
             Log.MappingDbPlayerCharaDataStepDoneAfterMs(
                 logger,
                 stopwatch.Elapsed.TotalMilliseconds

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Entity.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Entity.cs
@@ -10,7 +10,8 @@ public record Entity(
     int Quantity = 1,
     int? LimitBreakCount = null,
     int? BuildupCount = null,
-    int? EquipableCount = null
+    int? EquipableCount = null,
+    bool IsTemporary = false
 // TODO: int? Level = null
 )
 {

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/CharaHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/CharaHandler.cs
@@ -32,7 +32,9 @@ public partial class CharaHandler(
             return GrantReturn.Discarded();
         }
 
-        apiContext.PlayerCharaData.Add(new(playerIdentityService.ViewerId, chara));
+        apiContext.PlayerCharaData.Add(
+            new(playerIdentityService.ViewerId, chara) { IsTemporary = entity.IsTemporary }
+        );
 
         if (
             MasterAsset.CharaStories.TryGetValue((int)chara, out StoryData? storyData)
@@ -95,7 +97,9 @@ public partial class CharaHandler(
                 continue;
             }
 
-            apiContext.PlayerCharaData.Add(new(playerIdentityService.ViewerId, chara));
+            apiContext.PlayerCharaData.Add(
+                new(playerIdentityService.ViewerId, chara) { IsTemporary = entity.IsTemporary }
+            );
             result.Add(key, GrantReturn.Added());
             ownedCharacters.Add(chara);
 

--- a/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
@@ -296,11 +296,7 @@ public partial class StoryService(
             Log.GrantingEventCharacter(logger, eventData.EventCharaId, isTemporary);
 
             await rewardService.GrantReward(
-                new(
-                    EntityTypes.Chara,
-                    Id: (int)eventData.EventCharaId,
-                    IsTemporary: isTemporary
-                )
+                new(EntityTypes.Chara, Id: (int)eventData.EventCharaId, IsTemporary: isTemporary)
             );
 
             rewardList.Add(

--- a/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Story/StoryService.cs
@@ -287,14 +287,20 @@ public partial class StoryService(
 
         if (
             MasterAsset.EventData.TryGetValue(story.GroupId, out EventData? eventData)
-            && eventData.IsMemoryEvent // Real events need to set is_temporary and do friendship points
             && eventData.GuestJoinStoryId == storyId
         )
         {
-            Log.GrantingMemoryEventCharacter(logger, eventData.EventCharaId);
+            // 'Real' events grant temporary characters that need to be unlocked with friendship, whilst compendium / memory events grant the character already fully unlocked.
+            bool isTemporary = !eventData.IsMemoryEvent;
+
+            Log.GrantingEventCharacter(logger, eventData.EventCharaId, isTemporary);
 
             await rewardService.GrantReward(
-                new(EntityTypes.Chara, Id: (int)eventData.EventCharaId)
+                new(
+                    EntityTypes.Chara,
+                    Id: (int)eventData.EventCharaId,
+                    IsTemporary: isTemporary
+                )
             );
 
             rewardList.Add(
@@ -431,8 +437,15 @@ public partial class StoryService(
             List<AtgenBuildEventRewardEntityList> rewards
         );
 
-        [LoggerMessage(LogLevel.Debug, "Granting memory event character {chara}")]
-        public static partial void GrantingMemoryEventCharacter(ILogger logger, Charas chara);
+        [LoggerMessage(
+            LogLevel.Debug,
+            "Granting event character {Chara} with temporary status {IsTemporary}"
+        )]
+        public static partial void GrantingEventCharacter(
+            ILogger logger,
+            Charas chara,
+            bool isTemporary
+        );
 
         [LoggerMessage(LogLevel.Debug, "Granting player experience for chapter 10 completion.")]
         public static partial void GrantingPlayerExperienceForChapter10Completion(ILogger logger);

--- a/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
+++ b/DragaliaAPI/DragaliaAPI/Mapping/Mapperly/CharaMapper.cs
@@ -60,7 +60,7 @@ public static partial class CharaMapper
             AttackNode = (ushort)attackNode,
             ExAbilityLevel = (byte)charaList.ExAbilityLevel,
             ExAbility2Level = (byte)charaList.ExAbility2Level,
-            IsTemporary = false, // Ignore characters imported with is_temporary = true; this renders them permanently inaccessible
+            IsTemporary = charaList.IsTemporary,
             IsUnlockEditSkill = charaList.IsUnlockEditSkill,
             ListViewFlag = charaList.ListViewFlag,
             GetTime = charaList.GetTime,


### PR DESCRIPTION
Adds support for temporary characters earned from regular events. These characters have a friendship meter which must be maxed before they can be used when the event is not running. From the wiki:

> Most Raid Events include a free adventurer that temporarily joins the player's roster.
>
> By completing quests with this character on the team, raid event-related or otherwise, friendship points can be earned. Points earned are equal to the stamina cost for the quest cleared, but if a raid event-related quest is cleared, then the points gained are doubled.
>
> Once friendship points reach their maximum, the adventurer will permanently join the player's roster. Assuming the appropriate Mana Circle nodes have been unlocked, maxing friendship points will also make the adventurer's stories available to view. Befriending the free adventurer will also unlock a daily special endeavor when all other daily raid endeavors are complete.
>
> If a raid event ends but the free adventurer's friendship points were never maxed, then they will not join the player's roster. However, should the raid event be rerun, the adventurer will retain their friendship points and any level or Mana Circle upgrades applied when the player last had them.
>
> While the event remains active, their [Mana Circles](https://dragalialost.wiki/w/Mana_Circles) can be unlocked with special items that are obtained from the event (e.g. [Wu Kong's Conviction](https://dragalialost.wiki/w/Wu_Kong%27s_Conviction)), greatly decreasing the cost of empowering them.


TODO (maybe in subsequent pull requests):

- [x] Allow mana circle upgrades with convictions
- [ ] Handle story logic and block viewing before befriending - client might hide these for us?
- [ ] Add mission progression trigger when maxing friendship