### PR TITLE
Improve support for convictions in mana nodes

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Chara/CharaTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Chara/CharaTest.cs
@@ -3,12 +3,15 @@ using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Database.Utils;
 using DragaliaAPI.Features.Chara;
+using DragaliaAPI.Features.Shared.Options;
 using DragaliaAPI.Infrastructure.Results;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.PlayerDetails;
+using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 
 namespace DragaliaAPI.Integration.Test.Features.Chara;
 
@@ -42,6 +45,7 @@ public class CharaTest : TestFixture
         this.AddCharacter(Charas.Gauld);
         this.AddCharacter(Charas.Valerio);
         this.AddCharacter(Charas.Cleo);
+        this.AddCharacter(Charas.SophiePersona);
     }
 
     [Fact]
@@ -784,5 +788,72 @@ public class CharaTest : TestFixture
             .UpdateDataList.CharaUnitSetList!.Where(x => (Charas)x.CharaId == Charas.Celliera)
             .First();
         responseCharaData.CharaUnitSetDetailList.ToList()[0].DragonKeyId.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task CharaBuildupMana_EventCharaAndEventIsActive_UsesGrowMaterial()
+    {
+        // SophiePersona's event (20429) is configured as active in appsettings.Testing.json
+        DragaliaResponse<CharaBuildupManaResponse> response =
+            await this.Client.PostMsgpack<CharaBuildupManaResponse>(
+                "chara/buildup_mana",
+                new CharaBuildupManaRequest(Charas.SophiePersona, [1], false),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+        response
+            .Data.UpdateDataList.MaterialList.Should()
+            .Contain(x => x.MaterialId == Materials.SophiesConviction);
+    }
+
+    [Fact]
+    public async Task CharaBuildupMana_EventCharaAndEventIsInactive_DoesNotUseGrowMaterial()
+    {
+        // Create a client where SophiePersona's event (20429) is not active
+        HttpClient client = this.CreateClient(builder =>
+        {
+            builder.ConfigureTestServices(services =>
+            {
+                services.PostConfigure<EventOptions>(opts => opts.EventList.Clear());
+            });
+        });
+
+        DragaliaResponse<CharaBuildupManaResponse> response =
+            await client.PostMsgpack<CharaBuildupManaResponse>(
+                "chara/buildup_mana",
+                new CharaBuildupManaRequest(Charas.SophiePersona, [1], false),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+        response.Data.UpdateDataList.MaterialList.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CharaBuildupMana_EventCharaAndEventIsActive_FullCircleConsumesExpectedConvictions()
+    {
+        int convictionQuantity = await this
+            .ApiContext.PlayerMaterials.Where(x =>
+                x.ViewerId == this.ViewerId && x.MaterialId == Materials.SophiesConviction
+            )
+            .Select(x => x.Quantity)
+            .FirstAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        ImmutableArray<int> allNodes = [.. Enumerable.Range(1, 50)];
+
+        DragaliaResponse<CharaBuildupManaResponse> response =
+            await this.Client.PostMsgpack<CharaBuildupManaResponse>(
+                "chara/buildup_mana",
+                new CharaBuildupManaRequest(Charas.SophiePersona, allNodes, false),
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+        response
+            .Data.UpdateDataList.MaterialList.Should()
+            .ContainSingle(x => x.MaterialId == Materials.SophiesConviction)
+            .Which.Quantity.Should()
+            .Be(convictionQuantity - 50);
     }
 }

--- a/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
@@ -825,20 +825,22 @@ public partial class CharaController(
 
     private bool IsCharaEventActive(Charas charaId)
     {
-        EventData? eventData = MasterAsset.EventData.Enumerable.FirstOrDefault(x =>
-            x.EventCharaId == charaId
+        IEnumerable<EventRunInformation> events = eventOptions.CurrentValue.EventList.Where(x =>
+            x.IsActive(timeProvider)
         );
 
-        if (eventData is null)
+        foreach (EventRunInformation activeEvent in events)
         {
-            return false;
+            if (
+                MasterAsset.EventData.TryGetValue(activeEvent.Id, out EventData? eventData)
+                && eventData.EventCharaId == charaId
+            )
+            {
+                return true;
+            }
         }
 
-        EventRunInformation? runInfo = eventOptions.CurrentValue.EventList.Find(x =>
-            x.Id == eventData.Id
-        );
-
-        return runInfo?.IsActive(timeProvider) == true;
+        return false;
     }
 
     private static AtgenCharaUnitSetDetailList ToAtgenCharaUnitSetDetailList(DbSetUnit unit)

--- a/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
@@ -574,6 +574,11 @@ public partial class CharaController(
 
         Log.UnlockingNodes(logger, manaNodes);
 
+        // NOTE: The client determines which material cost to display using _GrowMaterialOnlyStartDate
+        // and _GrowMaterialOnlyEndDate in CharaData. These must be updated in the client's master
+        // asset to match the event schedule for the correct cost to be shown to the player.
+        bool isOnlyUsingGrowMaterial = this.IsCharaEventActive(charaData.Id);
+
         foreach (int nodeNr in manaNodes)
         {
             Log.Node(logger, nodeNr);
@@ -716,11 +721,6 @@ public partial class CharaController(
             {
                 continue;
             }
-
-            // NOTE: The client determines which material cost to display using _GrowMaterialOnlyStartDate
-            // and _GrowMaterialOnlyEndDate in CharaData. These must be updated in the client's master
-            // asset to match the event schedule for the correct cost to be shown to the player.
-            bool isOnlyUsingGrowMaterial = this.IsCharaEventActive(charaData.Id);
 
             if (isOnlyUsingGrowMaterial || useGrowMaterial)
             {

--- a/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Chara/CharaController.cs
@@ -5,6 +5,7 @@ using DragaliaAPI.Database.Repositories;
 using DragaliaAPI.Database.Utils;
 using DragaliaAPI.Features.Missions;
 using DragaliaAPI.Features.Shared;
+using DragaliaAPI.Features.Shared.Options;
 using DragaliaAPI.Features.Shared.Reward;
 using DragaliaAPI.Features.Shop;
 using DragaliaAPI.Features.Story;
@@ -13,9 +14,11 @@ using DragaliaAPI.Models.Generated;
 using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
+using DragaliaAPI.Shared.MasterAsset.Models.Event;
 using DragaliaAPI.Shared.MasterAsset.Models.ManaCircle;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace DragaliaAPI.Features.Chara;
 
@@ -30,7 +33,8 @@ public partial class CharaController(
     IRewardService rewardService,
     TimeProvider timeProvider,
     ICharaService charaService,
-    ApiContext apiContext
+    ApiContext apiContext,
+    IOptionsMonitor<EventOptions> eventOptions
 ) : DragaliaControllerBase
 {
     [HttpPost("awake")]
@@ -513,8 +517,6 @@ public partial class CharaController(
             return;
         }
 
-        DateTimeOffset time = timeProvider.GetUtcNow();
-
         Log.PreUpgradeCharaData(logger, playerCharData);
 
         CharaData charaData = MasterAsset.CharaData[playerCharData.CharaId];
@@ -715,9 +717,10 @@ public partial class CharaController(
                 continue;
             }
 
-            bool isOnlyUsingGrowMaterial =
-                charaData.GrowMaterialOnlyStartDate <= time
-                && charaData.GrowMaterialOnlyEndDate >= time;
+            // NOTE: The client determines which material cost to display using _GrowMaterialOnlyStartDate
+            // and _GrowMaterialOnlyEndDate in CharaData. These must be updated in the client's master
+            // asset to match the event schedule for the correct cost to be shown to the player.
+            bool isOnlyUsingGrowMaterial = this.IsCharaEventActive(charaData.Id);
 
             if (isOnlyUsingGrowMaterial || useGrowMaterial)
             {
@@ -818,6 +821,24 @@ public partial class CharaController(
         Log.NewCharaData(logger, playerCharData);
 
         Log.NewBitmask(logger, Convert.ToString(playerCharData.ManaNodeUnlockCount, 2));
+    }
+
+    private bool IsCharaEventActive(Charas charaId)
+    {
+        EventData? eventData = MasterAsset.EventData.Enumerable.FirstOrDefault(x =>
+            x.EventCharaId == charaId
+        );
+
+        if (eventData is null)
+        {
+            return false;
+        }
+
+        EventRunInformation? runInfo = eventOptions.CurrentValue.EventList.Find(x =>
+            x.Id == eventData.Id
+        );
+
+        return runInfo?.IsActive(timeProvider) == true;
     }
 
     private static AtgenCharaUnitSetDetailList ToAtgenCharaUnitSetDetailList(DbSetUnit unit)


### PR DESCRIPTION
Use the server event time so we have a single source of truth, which will make running events easier for server operators