### PR TITLE
Reset quests on event entry

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
@@ -89,6 +89,8 @@ public class EventQuestResetTest : TestFixture
             cancellationToken: TestContext.Current.CancellationToken
         );
 
+        ApiContext.ChangeTracker.Clear();
+
         DbQuest preserved = await ApiContext
             .PlayerQuests.AsNoTracking()
             .SingleAsync(

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
@@ -8,17 +8,17 @@ public class EventQuestResetTest : TestFixture
     public EventQuestResetTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
         : base(factory, outputHelper) { }
 
-    private const int CombatEventId = 22213;
-    private const int CombatEventQuestId = 222130103;
+    private const int RaidEventId = 20429;
+    private const int RaidEventQuestId = 204290101;
 
     [Fact]
-    public async Task Activate_FirstEntry_ResetsStaleQuestRecords()
+    public async Task Entry_FirstEntry_ResetsStaleQuestRecords()
     {
         ApiContext.PlayerQuests.Add(
             new DbQuest
             {
                 ViewerId = ViewerId,
-                QuestId = CombatEventQuestId,
+                QuestId = RaidEventQuestId,
                 State = 3,
                 IsMissionClear1 = true,
                 IsMissionClear2 = true,
@@ -33,15 +33,15 @@ public class EventQuestResetTest : TestFixture
         await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
-            "memory_event/activate",
-            new MemoryEventActivateRequest(CombatEventId),
+            "raid_event/entry",
+            new RaidEventEntryRequest(RaidEventId),
             cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbQuest reset = await ApiContext
             .PlayerQuests.AsNoTracking()
             .SingleAsync(
-                x => x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId,
+                x => x.ViewerId == ViewerId && x.QuestId == RaidEventQuestId,
                 cancellationToken: TestContext.Current.CancellationToken
             );
 
@@ -56,24 +56,24 @@ public class EventQuestResetTest : TestFixture
     }
 
     [Fact]
-    public async Task Activate_SubsequentEntry_PreservesQuestRecords()
+    public async Task Entry_SubsequentEntry_PreservesQuestRecords()
     {
         await Client.PostMsgpack<MemoryEventActivateResponse>(
-            "memory_event/activate",
-            new MemoryEventActivateRequest(CombatEventId),
+            "raid_event/entry",
+            new RaidEventEntryRequest(RaidEventId),
             cancellationToken: TestContext.Current.CancellationToken
         );
 
         ApiContext.PlayerQuests.RemoveRange(
             ApiContext.PlayerQuests.Where(x =>
-                x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId
+                x.ViewerId == ViewerId && x.QuestId == RaidEventQuestId
             )
         );
         ApiContext.PlayerQuests.Add(
             new DbQuest
             {
                 ViewerId = ViewerId,
-                QuestId = CombatEventQuestId,
+                QuestId = RaidEventQuestId,
                 State = 3,
                 IsMissionClear1 = true,
                 PlayCount = 2,
@@ -84,15 +84,15 @@ public class EventQuestResetTest : TestFixture
         await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
-            "memory_event/activate",
-            new MemoryEventActivateRequest(CombatEventId),
+            "raid_event/entry",
+            new RaidEventEntryRequest(RaidEventId),
             cancellationToken: TestContext.Current.CancellationToken
         );
 
         DbQuest preserved = await ApiContext
             .PlayerQuests.AsNoTracking()
             .SingleAsync(
-                x => x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId,
+                x => x.ViewerId == ViewerId && x.QuestId == RaidEventQuestId,
                 cancellationToken: TestContext.Current.CancellationToken
             );
 
@@ -103,7 +103,7 @@ public class EventQuestResetTest : TestFixture
     }
 
     [Fact]
-    public async Task Activate_FirstEntry_DoesNotResetUnrelatedQuestRecords()
+    public async Task Entry_FirstEntry_DoesNotResetUnrelatedQuestRecords()
     {
         const int unrelatedQuestId = 100010101;
 
@@ -122,8 +122,8 @@ public class EventQuestResetTest : TestFixture
         await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
 
         await Client.PostMsgpack<MemoryEventActivateResponse>(
-            "memory_event/activate",
-            new MemoryEventActivateRequest(CombatEventId),
+            "raid_event/entry",
+            new RaidEventEntryRequest(RaidEventId),
             cancellationToken: TestContext.Current.CancellationToken
         );
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Event/EventQuestResetTest.cs
@@ -1,0 +1,142 @@
+using DragaliaAPI.Database.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Integration.Test.Features.Event;
+
+public class EventQuestResetTest : TestFixture
+{
+    public EventQuestResetTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    private const int CombatEventId = 22213;
+    private const int CombatEventQuestId = 222130103;
+
+    [Fact]
+    public async Task Activate_FirstEntry_ResetsStaleQuestRecords()
+    {
+        ApiContext.PlayerQuests.Add(
+            new DbQuest
+            {
+                ViewerId = ViewerId,
+                QuestId = CombatEventQuestId,
+                State = 3,
+                IsMissionClear1 = true,
+                IsMissionClear2 = true,
+                IsMissionClear3 = true,
+                PlayCount = 5,
+                DailyPlayCount = 5,
+                WeeklyPlayCount = 5,
+                BestClearTime = 12.5f,
+            }
+        );
+
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await Client.PostMsgpack<MemoryEventActivateResponse>(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(CombatEventId),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        DbQuest reset = await ApiContext
+            .PlayerQuests.AsNoTracking()
+            .SingleAsync(
+                x => x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        reset.State.Should().Be(0);
+        reset.IsMissionClear1.Should().BeFalse();
+        reset.IsMissionClear2.Should().BeFalse();
+        reset.IsMissionClear3.Should().BeFalse();
+        reset.PlayCount.Should().Be(0);
+        reset.DailyPlayCount.Should().Be(0);
+        reset.WeeklyPlayCount.Should().Be(0);
+        reset.BestClearTime.Should().Be(-1.0f);
+    }
+
+    [Fact]
+    public async Task Activate_SubsequentEntry_PreservesQuestRecords()
+    {
+        await Client.PostMsgpack<MemoryEventActivateResponse>(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(CombatEventId),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        ApiContext.PlayerQuests.RemoveRange(
+            ApiContext.PlayerQuests.Where(x =>
+                x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId
+            )
+        );
+        ApiContext.PlayerQuests.Add(
+            new DbQuest
+            {
+                ViewerId = ViewerId,
+                QuestId = CombatEventQuestId,
+                State = 3,
+                IsMissionClear1 = true,
+                PlayCount = 2,
+                BestClearTime = 9.5f,
+            }
+        );
+
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await Client.PostMsgpack<MemoryEventActivateResponse>(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(CombatEventId),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        DbQuest preserved = await ApiContext
+            .PlayerQuests.AsNoTracking()
+            .SingleAsync(
+                x => x.ViewerId == ViewerId && x.QuestId == CombatEventQuestId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        preserved.State.Should().Be(3);
+        preserved.IsMissionClear1.Should().BeTrue();
+        preserved.PlayCount.Should().Be(2);
+        preserved.BestClearTime.Should().Be(9.5f);
+    }
+
+    [Fact]
+    public async Task Activate_FirstEntry_DoesNotResetUnrelatedQuestRecords()
+    {
+        const int unrelatedQuestId = 100010101;
+
+        ApiContext.PlayerQuests.Add(
+            new DbQuest
+            {
+                ViewerId = ViewerId,
+                QuestId = unrelatedQuestId,
+                State = 3,
+                IsMissionClear1 = true,
+                PlayCount = 7,
+                BestClearTime = 4.2f,
+            }
+        );
+
+        await ApiContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        await Client.PostMsgpack<MemoryEventActivateResponse>(
+            "memory_event/activate",
+            new MemoryEventActivateRequest(CombatEventId),
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        DbQuest unrelated = await ApiContext
+            .PlayerQuests.AsNoTracking()
+            .SingleAsync(
+                x => x.ViewerId == ViewerId && x.QuestId == unrelatedQuestId,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        unrelated.State.Should().Be(3);
+        unrelated.IsMissionClear1.Should().BeTrue();
+        unrelated.PlayCount.Should().Be(7);
+        unrelated.BestClearTime.Should().Be(4.2f);
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
@@ -165,6 +165,14 @@ public partial class EventService(
             x => MasterAsset.QuestData.Enumerable.Where(y => y.Gid == x).ToList()
         );
 
+    private static readonly Dictionary<int, int[]> NonMemoryEventQuestIdLookup = MasterAsset
+        .EventData.Enumerable.Where(x => !x.IsMemoryEvent)
+        .Select(x => x.Id)
+        .ToDictionary(
+            x => x,
+            x => MasterAsset.QuestData.Enumerable.Where(y => y.Gid == x).Select(y => y.Id).ToArray()
+        );
+
     public async Task CreateEventData(int eventId)
     {
         missionProgressionService.OnEventParticipation(eventId);
@@ -187,6 +195,41 @@ public partial class EventService(
             }
 
             firstEventEnter = true;
+        }
+
+        if (
+            firstEventEnter
+            && !data.IsMemoryEvent
+            && NonMemoryEventQuestIdLookup.TryGetValue(eventId, out int[]? eventQuestIds)
+            && eventQuestIds.Length > 0
+        )
+        {
+            List<DbQuest> staleQuests = await apiContext
+                .PlayerQuests.Where(q => eventQuestIds.Contains(q.QuestId))
+                .ToListAsync();
+
+            // We shouldn't do this with an ExecuteUpdate because it is important the client receives
+            // these entries in an update_data_list
+
+            if (staleQuests.Count > 0)
+            {
+                foreach (DbQuest quest in staleQuests)
+                {
+                    quest.State = 0;
+                    quest.IsMissionClear1 = false;
+                    quest.IsMissionClear2 = false;
+                    quest.IsMissionClear3 = false;
+                    quest.PlayCount = 0;
+                    quest.DailyPlayCount = 0;
+                    quest.WeeklyPlayCount = 0;
+                    quest.LastDailyResetTime = DateTimeOffset.UnixEpoch;
+                    quest.LastWeeklyResetTime = DateTimeOffset.UnixEpoch;
+                    quest.IsAppear = true;
+                    quest.BestClearTime = -1.0f;
+                }
+
+                Log.ResetQuestRecordsForEvent(logger, eventId, staleQuests.Count);
+            }
         }
 
         IEnumerable<int> items = await eventRepository
@@ -519,6 +562,16 @@ public partial class EventService(
 
         [LoggerMessage(LogLevel.Information, "Creating event data for event {eventId}")]
         public static partial void CreatingEventDataForEvent(ILogger logger, int eventId);
+
+        [LoggerMessage(
+            LogLevel.Information,
+            "Reset {count} stale quest record(s) for re-activated event {eventId}"
+        )]
+        public static partial void ResetQuestRecordsForEvent(
+            ILogger logger,
+            int eventId,
+            int count
+        );
 
         [LoggerMessage(
             LogLevel.Debug,

--- a/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Event/EventService.cs
@@ -157,21 +157,14 @@ public partial class EventService(
         return rewardEntities;
     }
 
-    private static readonly Dictionary<int, List<QuestData>> CombatEventQuestLookup = MasterAsset
-        .EventData.Enumerable.Where(x => x.EventKindType == EventKindType.Combat)
-        .Select(x => x.Id)
-        .ToDictionary(
-            x => x,
-            x => MasterAsset.QuestData.Enumerable.Where(y => y.Gid == x).ToList()
-        );
-
-    private static readonly Dictionary<int, int[]> NonMemoryEventQuestIdLookup = MasterAsset
-        .EventData.Enumerable.Where(x => !x.IsMemoryEvent)
-        .Select(x => x.Id)
-        .ToDictionary(
-            x => x,
-            x => MasterAsset.QuestData.Enumerable.Where(y => y.Gid == x).Select(y => y.Id).ToArray()
-        );
+    private static readonly Dictionary<int, QuestData[]> EventQuestLookup = MasterAsset
+        .EventData.Enumerable.GroupJoin(
+            MasterAsset.QuestData.Enumerable,
+            evt => evt.Id,
+            quest => quest.Gid,
+            (evt, quests) => new { EventId = evt.Id, Quests = quests.ToArray() }
+        )
+        .ToDictionary(x => x.EventId, x => x.Quests);
 
     public async Task CreateEventData(int eventId)
     {
@@ -200,12 +193,14 @@ public partial class EventService(
         if (
             firstEventEnter
             && !data.IsMemoryEvent
-            && NonMemoryEventQuestIdLookup.TryGetValue(eventId, out int[]? eventQuestIds)
-            && eventQuestIds.Length > 0
+            && EventQuestLookup.TryGetValue(eventId, out QuestData[]? eventQuests)
+            && eventQuests.Length > 0
         )
         {
+            List<int> questIds = eventQuests.Select(x => x.Id).ToList();
+
             List<DbQuest> staleQuests = await apiContext
-                .PlayerQuests.Where(q => eventQuestIds.Contains(q.QuestId))
+                .PlayerQuests.Where(q => questIds.Contains(q.QuestId))
                 .ToListAsync();
 
             // We shouldn't do this with an ExecuteUpdate because it is important the client receives
@@ -276,9 +271,7 @@ public partial class EventService(
 
     private async Task GrantAlreadyEarnedLocationRewards(int eventId)
     {
-        HashSet<int> relevantQuestIds = CombatEventQuestLookup[eventId]
-            .Select(x => x.Id)
-            .ToHashSet();
+        HashSet<int> relevantQuestIds = EventQuestLookup[eventId].Select(x => x.Id).ToHashSet();
 
         List<int> completedQuestIds = await apiContext
             .PlayerQuests.Where(x => x.State == 3 && relevantQuestIds.Contains(x.QuestId))
@@ -286,7 +279,7 @@ public partial class EventService(
             .ToListAsync();
 
         foreach (
-            (int entityId, int entityQuantity) in CombatEventQuestLookup[eventId]
+            (int entityId, int entityQuantity) in EventQuestLookup[eventId]
                 .Where(x =>
                     completedQuestIds.Contains(x.Id)
                     && x is { HoldEntityType: EntityTypes.CombatEventItem, HoldEntityQuantity: > 0 }

--- a/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/Savefile/SavefileService.cs
@@ -609,6 +609,12 @@ internal sealed partial class SavefileService(
         await apiContext
             .PlayerSummonHistory.Where(x => x.ViewerId == viewerId)
             .ExecuteDeleteAsync();
+        await apiContext
+            .PlayerEventSummonItems.Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
+        await apiContext
+            .PlayerEventSummonData.Where(x => x.ViewerId == viewerId)
+            .ExecuteDeleteAsync();
     }
 
     public async Task<DbPlayer> Create()


### PR DESCRIPTION
We 're-run' events by messing with the start and end date of an existing event in the assets. This is simpler to do, but means that anyone who participated in that run of the event and imported a save with this progress will already have it partially complete from day 1 of our 're-run'. 

Fix this by explicitly resetting this data if found when going through event entry endpoints.