### PR TITLE
Fix Chronos Clash exception

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Dungeon/DungeonRecordTest.cs
@@ -1913,6 +1913,51 @@ public partial class DungeonRecordTest : TestFixture
         response.IngameResultData.GrowRecord.TakePlayerExp.Should().NotBe(0);
     }
 
+    [Fact]
+    public async Task Record_ChronosClash_DoesNotThrow()
+    {
+        const int eventId = 20427; // Fractured Futures
+        const int questId = 204270302; // Chronos Clash
+
+        await AddToDatabase(new DbQuest() { QuestId = questId, State = 0 });
+
+        await Client.PostMsgpack<MemoryEventActivateResponse>(
+            "/memory_event/activate",
+            new MemoryEventActivateRequest() { EventId = eventId },
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        string key = await this.StartDungeon(
+            new DungeonStartStartRequest()
+            {
+                QuestId = questId,
+                PartyNoList = new List<int>() { 1 },
+            }
+        );
+
+        DragaliaResponse<DungeonRecordRecordResponse> response =
+            await Client.PostMsgpack<DungeonRecordRecordResponse>(
+                "/dungeon_record/record",
+                new DungeonRecordRecordRequest()
+                {
+                    DungeonKey = key,
+                    PlayRecord = new()
+                    {
+                        Time = 10,
+                        TreasureRecord = new List<AtgenTreasureRecord>(),
+                        LiveUnitNoList = new List<int>(),
+                        DamageRecord = new List<AtgenDamageRecord>(),
+                        DragonDamageRecord = new List<AtgenDamageRecord>(),
+                        BattleRoyalRecord = new(),
+                    },
+                },
+                ensureSuccessHeader: false,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        response.DataHeaders.ResultCode.Should().Be(ResultCode.Success);
+    }
+
     private async Task<string> StartDungeon(DungeonSession session)
     {
         string key = this.DungeonService.CreateSession(session);
@@ -1926,6 +1971,18 @@ public partial class DungeonRecordTest : TestFixture
         DragaliaResponse<DungeonStartStartAssignUnitResponse> response =
             await this.Client.PostMsgpack<DungeonStartStartAssignUnitResponse>(
                 "/dungeon_start/start_assign_unit",
+                request,
+                cancellationToken: TestContext.Current.CancellationToken
+            );
+
+        return response.Data.IngameData.DungeonKey;
+    }
+
+    private async Task<string> StartDungeon(DungeonStartStartRequest request)
+    {
+        DragaliaResponse<DungeonStartStartResponse> response =
+            await this.Client.PostMsgpack<DungeonStartStartResponse>(
+                "/dungeon_start/start",
                 request,
                 cancellationToken: TestContext.Current.CancellationToken
             );

--- a/DragaliaAPI/DragaliaAPI/Features/Quest/QuestService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Quest/QuestService.cs
@@ -10,6 +10,7 @@ using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.MasterAsset;
 using DragaliaAPI.Shared.MasterAsset.Models;
 using DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
+using DragaliaAPI.Shared.MasterAsset.Models.QuestRewards;
 
 namespace DragaliaAPI.Features.Quest;
 
@@ -369,17 +370,24 @@ public partial class QuestService(
                 questData.VariationType
             );
         }
-        else if (questData.IsEventChallengeBattle)
+        else if (questData.IsEventChallengeBattle && questData.EventKindType != EventKindType.Raid)
         {
             int questScoreMissionId = MasterAsset.QuestRewardData[questData.Id].QuestScoreMissionId;
-            int waveCount = MasterAsset.QuestScoreMissionData[questScoreMissionId].WaveCount;
 
-            missionProgressionService.OnEventChallengeBattleCleared(
-                questData.Gid,
-                questData.VariationType,
-                playRecord.Wave >= waveCount,
-                questData.Id
-            );
+            if (
+                MasterAsset.QuestScoreMissionData.TryGetValue(
+                    questScoreMissionId,
+                    out QuestScoreMissionData? questScoreMission
+                )
+            )
+            {
+                missionProgressionService.OnEventChallengeBattleCleared(
+                    questData.Gid,
+                    questData.VariationType,
+                    playRecord.Wave >= questScoreMission.WaveCount,
+                    questData.Id
+                );
+            }
         }
         else if (questData.IsEventTrial)
         {


### PR DESCRIPTION
Fix a KeyNotFoundException being thrown when clearing Chronos Clash and certain other quests. The updated definition of 'challenge battle' introduced in #1478 caused these quests to enter a branch that treated them like wave battle quests which threw when attempting to access the number of waves in the quest.

The fix is to not enter this branch, and also make the branch itself more defensive.