### PR TITLE
Fix Arsene dragon stories not unlocked on receipt

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Reward/RewardServiceTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/Reward/RewardServiceTest.cs
@@ -1,6 +1,9 @@
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Features.Shared.Reward.Handlers;
 using DragaliaAPI.Shared.Definitions.Enums.Summon;
+using DragaliaAPI.Shared.MasterAsset;
+using DragaliaAPI.Shared.MasterAsset.Models.Story;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace DragaliaAPI.Integration.Test.Features.Reward;
@@ -98,5 +101,58 @@ public class RewardServiceTest : TestFixture
             .SelectMany(x => x.SupportedTypes);
 
         supportedTypes.Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task GrantArsene_AddsDragonStories()
+    {
+        (
+            await this.ApiContext.PlayerStoryState.CountAsync(
+                x => x.StoryType == StoryTypes.Dragon,
+                cancellationToken: TestContext.Current.CancellationToken
+            )
+        )
+            .Should()
+            .Be(0);
+
+        DbPlayerPresent present = new()
+        {
+            EntityType = EntityTypes.Dragon,
+            EntityQuantity = 1,
+            EntityId = (int)DragonId.Arsene,
+        };
+
+        await this.AddToDatabase(present);
+
+        await this.Client.PostMsgpack(
+            "/present/receive",
+            new PresentReceiveRequest() { PresentIdList = [(ulong)present.PresentId] },
+            cancellationToken: TestContext.Current.CancellationToken
+        );
+
+        StoryData arseneStories = MasterAsset.DragonStories[(int)DragonId.Arsene];
+
+        List<DbPlayerStoryState> dragonStories = await this
+            .ApiContext.PlayerStoryState.Where(x => x.StoryType == StoryTypes.Dragon)
+            .ToListAsync(cancellationToken: TestContext.Current.CancellationToken);
+
+        dragonStories
+            .Should()
+            .BeEquivalentTo([
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryType = StoryTypes.Dragon,
+                    State = 0,
+                    StoryId = arseneStories.StoryIds[0],
+                },
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryType = StoryTypes.Dragon,
+                    State = 0,
+                    StoryId = arseneStories.StoryIds[1],
+                },
+            ]);
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/ISavefileUpdateTest.cs
@@ -17,7 +17,7 @@ public class ISavefileUpdateTest : TestFixture
     public void ISavefileUpdate_HasExpectedCount()
     {
         // Update this test when adding a new update.
-        this.updates.Should().HaveCount(27);
+        this.updates.Should().HaveCount(28);
     }
 
     [Fact]

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
@@ -58,40 +58,6 @@ public class V28UpdateTest : SavefileUpdateTestFixture
     }
 
     [Fact]
-    public async Task V28Update_UnlocksOneStoryForDragonAtLevel5()
-    {
-        await this.AddRangeToDatabase([
-            new DbPlayerDragonReliability() { DragonId = DragonId.Arsene, Level = 7 },
-        ]);
-
-        StoryData arseneStories = MasterAsset.DragonStories[(int)DragonId.Arsene];
-
-        this.ApiContext.ChangeTracker.Clear();
-
-        await this.LoadIndex();
-
-        List<DbPlayerStoryState> dragonStories = ApiContext
-            .PlayerStoryState.Where(x => x.StoryType == StoryTypes.Dragon)
-            .ToList();
-
-        dragonStories
-            .Should()
-            .Contain(x => x.StoryId == arseneStories.StoryIds[0])
-            .Which.Should()
-            .BeEquivalentTo(
-                new DbPlayerStoryState()
-                {
-                    ViewerId = this.ViewerId,
-                    StoryId = arseneStories.StoryIds[0],
-                    StoryType = StoryTypes.Dragon,
-                    State = StoryState.Unlocked,
-                }
-            );
-
-        dragonStories.Should().NotContain(x => x.StoryId == arseneStories.StoryIds[1]);
-    }
-
-    [Fact]
     public async Task V28Update_DoesNotDuplicateExistingStories()
     {
         await this.AddRangeToDatabase([

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
@@ -14,6 +14,10 @@ public class V28UpdateTest : SavefileUpdateTestFixture
     [Fact]
     public async Task V28Update_UnlocksBothStoriesForDragonAtLevel30()
     {
+        this.ApiContext.PlayerStoryState.Count(x => x.StoryType == StoryTypes.Dragon)
+            .Should()
+            .Be(0);
+
         await this.AddRangeToDatabase([
             new DbPlayerDragonReliability() { DragonId = DragonId.Arsene, Level = 30 },
         ]);

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
@@ -1,0 +1,131 @@
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.MasterAsset;
+using DragaliaAPI.Shared.MasterAsset.Models.Story;
+
+namespace DragaliaAPI.Integration.Test.Features.SavefileUpdate;
+
+public class V28UpdateTest : SavefileUpdateTestFixture
+{
+    protected override int StartingVersion => 27;
+
+    public V28UpdateTest(CustomWebApplicationFactory factory, ITestOutputHelper outputHelper)
+        : base(factory, outputHelper) { }
+
+    [Fact]
+    public async Task V28Update_UnlocksBothStoriesForDragonAtLevel30()
+    {
+        await this.AddRangeToDatabase([
+            new DbPlayerDragonReliability() { DragonId = DragonId.Arsene, Level = 30 },
+        ]);
+
+        StoryData arseneStories = MasterAsset.DragonStories[(int)DragonId.Arsene];
+
+        this.ApiContext.ChangeTracker.Clear();
+
+        await this.LoadIndex();
+
+        List<DbPlayerStoryState> dragonStories = ApiContext
+            .PlayerStoryState.Where(x => x.StoryType == StoryTypes.Dragon)
+            .ToList();
+
+        dragonStories
+            .Should()
+            .Contain(x => x.StoryId == arseneStories.StoryIds[0])
+            .Which.Should()
+            .BeEquivalentTo(
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = arseneStories.StoryIds[0],
+                    StoryType = StoryTypes.Dragon,
+                    State = StoryState.Unlocked,
+                }
+            );
+
+        dragonStories
+            .Should()
+            .Contain(x => x.StoryId == arseneStories.StoryIds[1])
+            .Which.Should()
+            .BeEquivalentTo(
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = arseneStories.StoryIds[1],
+                    StoryType = StoryTypes.Dragon,
+                    State = StoryState.Unlocked,
+                }
+            );
+    }
+
+    [Fact]
+    public async Task V28Update_UnlocksOneStoryForDragonAtLevel5()
+    {
+        await this.AddRangeToDatabase([
+            new DbPlayerDragonReliability() { DragonId = DragonId.Arsene, Level = 7 },
+        ]);
+
+        StoryData arseneStories = MasterAsset.DragonStories[(int)DragonId.Arsene];
+
+        this.ApiContext.ChangeTracker.Clear();
+
+        await this.LoadIndex();
+
+        List<DbPlayerStoryState> dragonStories = ApiContext
+            .PlayerStoryState.Where(x => x.StoryType == StoryTypes.Dragon)
+            .ToList();
+
+        dragonStories
+            .Should()
+            .Contain(x => x.StoryId == arseneStories.StoryIds[0])
+            .Which.Should()
+            .BeEquivalentTo(
+                new DbPlayerStoryState()
+                {
+                    ViewerId = this.ViewerId,
+                    StoryId = arseneStories.StoryIds[0],
+                    StoryType = StoryTypes.Dragon,
+                    State = StoryState.Unlocked,
+                }
+            );
+
+        dragonStories.Should().NotContain(x => x.StoryId == arseneStories.StoryIds[1]);
+    }
+
+    [Fact]
+    public async Task V28Update_DoesNotDuplicateExistingStories()
+    {
+        await this.AddRangeToDatabase([
+            new DbPlayerDragonReliability() { DragonId = DragonId.Arsene, Level = 30 },
+        ]);
+
+        StoryData arseneStories = MasterAsset.DragonStories[(int)DragonId.Arsene];
+
+        await this.AddRangeToDatabase([
+            new DbPlayerStoryState()
+            {
+                StoryId = arseneStories.StoryIds[0],
+                StoryType = StoryTypes.Dragon,
+            },
+            new DbPlayerStoryState()
+            {
+                StoryId = arseneStories.StoryIds[1],
+                StoryType = StoryTypes.Dragon,
+            },
+        ]);
+
+        this.ApiContext.ChangeTracker.Clear();
+
+        await this.LoadIndex();
+
+        ApiContext
+            .PlayerStoryState.Where(x =>
+                x.StoryType == StoryTypes.Dragon
+                && (
+                    x.StoryId == arseneStories.StoryIds[0]
+                    || x.StoryId == arseneStories.StoryIds[1]
+                )
+            )
+            .Should()
+            .HaveCount(2);
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Features/SavefileUpdate/V28UpdateTest.cs
@@ -87,8 +87,7 @@ public class V28UpdateTest : SavefileUpdateTestFixture
             .PlayerStoryState.Where(x =>
                 x.StoryType == StoryTypes.Dragon
                 && (
-                    x.StoryId == arseneStories.StoryIds[0]
-                    || x.StoryId == arseneStories.StoryIds[1]
+                    x.StoryId == arseneStories.StoryIds[0] || x.StoryId == arseneStories.StoryIds[1]
                 )
             )
             .Should()

--- a/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
@@ -23,13 +23,11 @@ public partial class V28Update(
 
     public async Task Apply()
     {
-        List<int> arseneLevels = await apiContext
-            .PlayerDragonReliability.Where(x => x.DragonId == DragonId.Arsene && x.Level >= 5)
-            .Select(x => x.Level)
-            .ToListAsync();
+        DbPlayerDragonReliability? arsene = await apiContext
+            .PlayerDragonReliability.FirstOrDefaultAsync(x => x.DragonId == DragonId.Arsene);
 
         if (
-            arseneLevels.Count == 0
+            arsene is null
             || !MasterAsset.DragonStories.TryGetValue((int)DragonId.Arsene, out StoryData? data)
         )
         {
@@ -37,25 +35,17 @@ public partial class V28Update(
             return;
         }
 
-        List<DbPlayerStoryState> intendedStoryStates = new(arseneLevels.Count * 2);
-
-        foreach (int level in arseneLevels)
-        {
-            int storiesToUnlock = level >= 15 ? 2 : 1;
-
-            for (int i = 0; i < storiesToUnlock; i++)
+        // Arsene's default reliability level is 30, so any existing reliability entry implies
+        // both stories should be unlocked -- there is no need to check the level.
+        List<DbPlayerStoryState> intendedStoryStates = data
+            .StoryIds.Select(storyId => new DbPlayerStoryState()
             {
-                intendedStoryStates.Add(
-                    new DbPlayerStoryState()
-                    {
-                        ViewerId = playerIdentityService.ViewerId,
-                        StoryId = data.StoryIds[i],
-                        State = StoryState.Unlocked,
-                        StoryType = StoryTypes.Dragon,
-                    }
-                );
-            }
-        }
+                ViewerId = playerIdentityService.ViewerId,
+                StoryId = storyId,
+                State = StoryState.Unlocked,
+                StoryType = StoryTypes.Dragon,
+            })
+            .ToList();
 
         int rowsAffected = await apiContext
             .PlayerStoryState.Merge()

--- a/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
@@ -23,8 +23,10 @@ public partial class V28Update(
 
     public async Task Apply()
     {
-        DbPlayerDragonReliability? arsene = await apiContext
-            .PlayerDragonReliability.FirstOrDefaultAsync(x => x.DragonId == DragonId.Arsene);
+        DbPlayerDragonReliability? arsene =
+            await apiContext.PlayerDragonReliability.FirstOrDefaultAsync(x =>
+                x.DragonId == DragonId.Arsene
+            );
 
         if (
             arsene is null

--- a/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
@@ -1,0 +1,70 @@
+using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
+using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.MasterAsset;
+using DragaliaAPI.Shared.MasterAsset.Models.Story;
+using DragaliaAPI.Shared.PlayerDetails;
+using LinqToDB;
+using Microsoft.EntityFrameworkCore;
+
+namespace DragaliaAPI.Features.Login.SavefileUpdate;
+
+/// <summary>
+/// Fixes missing dragon stories for dragons whose default reliability level is >= 5 (e.g. Arsene).
+/// </summary>
+public partial class V28Update(
+    ApiContext apiContext,
+    IPlayerIdentityService playerIdentityService,
+    ILogger<V28Update> logger
+) : ISavefileUpdate
+{
+    public int SavefileVersion => 28;
+
+    public async Task Apply()
+    {
+        var dragonsAtOrOver5Bond = await apiContext
+            .PlayerDragonReliability.Where(x => x.Level >= 5)
+            .Select(x => new { x.DragonId, x.Level })
+            .ToListAsync();
+
+        List<DbPlayerStoryState> intendedStoryStates = new(dragonsAtOrOver5Bond.Count * 2);
+
+        foreach (var info in dragonsAtOrOver5Bond)
+        {
+            if (!MasterAsset.DragonStories.TryGetValue((int)info.DragonId, out StoryData? data))
+            {
+                continue;
+            }
+
+            int storiesToUnlock = info.Level >= 15 ? Math.Min(2, data.StoryIds.Length) : 1;
+
+            for (int i = 0; i < storiesToUnlock; i++)
+            {
+                intendedStoryStates.Add(
+                    new DbPlayerStoryState()
+                    {
+                        ViewerId = playerIdentityService.ViewerId,
+                        StoryId = data.StoryIds[i],
+                        State = StoryState.Unlocked,
+                        StoryType = StoryTypes.Dragon,
+                    }
+                );
+            }
+        }
+
+        int rowsAffected = await apiContext
+            .PlayerStoryState.Merge()
+            .Using(intendedStoryStates)
+            .OnTargetKey()
+            .InsertWhenNotMatched()
+            .MergeAsync();
+
+        Log.AddedNewStories(logger, rowsAffected);
+    }
+
+    private static partial class Log
+    {
+        [LoggerMessage(LogLevel.Information, "V28Update added {Count} missing dragon stories")]
+        public static partial void AddedNewStories(ILogger logger, int count);
+    }
+}

--- a/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Login/SavefileUpdate/V28Update.cs
@@ -10,7 +10,8 @@ using Microsoft.EntityFrameworkCore;
 namespace DragaliaAPI.Features.Login.SavefileUpdate;
 
 /// <summary>
-/// Fixes missing dragon stories for dragons whose default reliability level is >= 5 (e.g. Arsene).
+/// Fixes missing dragon stories for Arsene, whose default reliability level of 30 meant that
+/// stories were not unlocked on receipt (unlike level-up, which is handled by <see cref="V25Update"/>).
 /// </summary>
 public partial class V28Update(
     ApiContext apiContext,
@@ -22,21 +23,25 @@ public partial class V28Update(
 
     public async Task Apply()
     {
-        var dragonsAtOrOver5Bond = await apiContext
-            .PlayerDragonReliability.Where(x => x.Level >= 5)
-            .Select(x => new { x.DragonId, x.Level })
+        List<int> arseneLevels = await apiContext
+            .PlayerDragonReliability.Where(x => x.DragonId == DragonId.Arsene && x.Level >= 5)
+            .Select(x => x.Level)
             .ToListAsync();
 
-        List<DbPlayerStoryState> intendedStoryStates = new(dragonsAtOrOver5Bond.Count * 2);
-
-        foreach (var info in dragonsAtOrOver5Bond)
+        if (
+            arseneLevels.Count == 0
+            || !MasterAsset.DragonStories.TryGetValue((int)DragonId.Arsene, out StoryData? data)
+        )
         {
-            if (!MasterAsset.DragonStories.TryGetValue((int)info.DragonId, out StoryData? data))
-            {
-                continue;
-            }
+            Log.AddedNewStories(logger, 0);
+            return;
+        }
 
-            int storiesToUnlock = info.Level >= 15 ? Math.Min(2, data.StoryIds.Length) : 1;
+        List<DbPlayerStoryState> intendedStoryStates = new(arseneLevels.Count * 2);
+
+        foreach (int level in arseneLevels)
+        {
+            int storiesToUnlock = level >= 15 ? 2 : 1;
 
             for (int i = 0; i < storiesToUnlock; i++)
             {

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/DragonHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/DragonHandler.cs
@@ -1,5 +1,8 @@
 using DragaliaAPI.Database;
+using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.Definitions.Enums;
+using DragaliaAPI.Shared.MasterAsset;
+using DragaliaAPI.Shared.MasterAsset.Models.Story;
 using DragaliaAPI.Shared.PlayerDetails;
 using Microsoft.EntityFrameworkCore;
 
@@ -47,7 +50,9 @@ public partial class DragonHandler(
             && !await apiContext.PlayerDragonReliability.AnyAsync(x => x.DragonId == dragon)
         )
         {
-            apiContext.PlayerDragonReliability.Add(new(playerIdentityService.ViewerId, dragon));
+            DbPlayerDragonReliability reliability = new(playerIdentityService.ViewerId, dragon);
+            apiContext.PlayerDragonReliability.Add(reliability);
+            this.AddDefaultLevelStories(dragon, reliability.Level);
         }
 
         return GrantReturn.Added();
@@ -99,8 +104,10 @@ public partial class DragonHandler(
                 && !apiContext.PlayerDragonReliability.Local.Any(x => x.DragonId == dragon)
             )
             {
-                apiContext.PlayerDragonReliability.Add(new(playerIdentityService.ViewerId, dragon));
+                DbPlayerDragonReliability reliability = new(playerIdentityService.ViewerId, dragon);
+                apiContext.PlayerDragonReliability.Add(reliability);
                 ownedReliabilities.Add(dragon);
+                this.AddDefaultLevelStories(dragon, reliability.Level);
             }
 
             resultDict.Add(key, GrantReturn.Added());
@@ -108,6 +115,33 @@ public partial class DragonHandler(
         }
 
         return resultDict;
+    }
+
+    private void AddDefaultLevelStories(DragonId dragon, int reliabilityLevel)
+    {
+        if (
+            reliabilityLevel < 5
+            || !MasterAsset.DragonStories.TryGetValue((int)dragon, out StoryData? storyData)
+        )
+        {
+            return;
+        }
+
+        int storiesToUnlock = reliabilityLevel >= 15
+            ? Math.Min(2, storyData.StoryIds.Length)
+            : 1;
+
+        for (int i = 0; i < storiesToUnlock; i++)
+        {
+            apiContext.PlayerStoryState.Add(
+                new DbPlayerStoryState()
+                {
+                    ViewerId = playerIdentityService.ViewerId,
+                    StoryType = StoryTypes.Dragon,
+                    StoryId = storyData.StoryIds[i],
+                }
+            );
+        }
     }
 
     private static partial class Log

--- a/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/DragonHandler.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Shared/Reward/Handlers/DragonHandler.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.Definitions.Enums;
@@ -127,9 +128,12 @@ public partial class DragonHandler(
             return;
         }
 
-        int storiesToUnlock = reliabilityLevel >= 15
-            ? Math.Min(2, storyData.StoryIds.Length)
-            : 1;
+        Debug.Assert(
+            storyData.StoryIds.Length == 2,
+            "Expected all dragons to have exactly two stories"
+        );
+
+        int storiesToUnlock = reliabilityLevel >= 15 ? 2 : 1;
 
         for (int i = 0; i < storiesToUnlock; i++)
         {


### PR DESCRIPTION
Fixes #1503

**Root cause:** `DragonHandler` created the `PlayerDragonReliability` entry but never unlocked dragon stories (unlike `CharaHandler` which unlocks the first story on receipt). Arsene has `DefaultReliabilityLevel = 30`, so his bond starts at 30, but story unlocks only fire through bond level progression in `DragonService`.

**Changes:**
- `DragonHandler.cs`: Added `AddDefaultLevelStories()` called when the reliability entry is first created. Unlocks story 1 (bond ≥ 5) and story 2 (bond ≥ 15) based on `DefaultReliabilityLevel`. Generic fix for any dragon with a high default bond.
- `V28Update.cs`: Retroactively unlocks stories for existing users whose dragons are at bond ≥ 5 but missing the corresponding story states.

Generated with [Claude Code](https://claude.ai/code)