### PR TITLE
Route HTTP request logs to test output

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Integration.Test/CustomWebApplicationFactory.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/CustomWebApplicationFactory.cs
@@ -1,10 +1,12 @@
 using DragaliaAPI.Database;
 using DragaliaAPI.Features.CoOp;
 using DragaliaAPI.Features.Shared;
+using DragaliaAPI.Integration.Test.Other;
 using DragaliaAPI.Shared.MasterAsset;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
@@ -52,6 +54,29 @@ public sealed class CustomWebApplicationFactory : WebApplicationFactory<Program>
         {
             services.AddScoped(_ => this.MockBaasApi.Object);
             services.AddScoped(_ => this.MockPhotonStateApi.Object);
+
+            // Replace the production Serilog configuration for the test host: route all log events to
+            // the currently-running test's output rather than to the console. Registered here (after
+            // the app's own UseSerilog) so this factory wins. The HttpContextAccessor lets the sink
+            // correlate request-thread logs back to the originating test via the Xunit-Test-Id header.
+            services.AddHttpContextAccessor();
+            services.AddSerilog(
+                (serviceProvider, loggerConfiguration) =>
+                    loggerConfiguration
+                        .MinimumLevel.Verbose()
+                        .MinimumLevel.Override("Microsoft.AspNetCore", LogEventLevel.Warning)
+                        .MinimumLevel.Override(
+                            "Microsoft.EntityFrameworkCore",
+                            LogEventLevel.Warning
+                        )
+                        .MinimumLevel.Override("LinqToDB", LogEventLevel.Warning)
+                        .Enrich.FromLogContext()
+                        .WriteTo.Sink(
+                            new TestOutputSink(
+                                serviceProvider.GetRequiredService<IHttpContextAccessor>()
+                            )
+                        )
+            );
 
             services.RemoveAll<DbContextOptions<ApiContext>>();
             services.RemoveAll<IDistributedCache>();

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -110,6 +110,12 @@ public static class HttpClientExtensions
     {
         ByteArrayContent result = new(MessagePackSerializer.Serialize(content));
         result.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
+
+        if (TestContext.Current.Test is not null)
+        {
+            result.Headers.Add("Xunit-Test-Id", TestContext.Current.Test.UniqueID);
+        }
+
         return result;
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/HttpClientExtensions.cs
@@ -111,11 +111,6 @@ public static class HttpClientExtensions
         ByteArrayContent result = new(MessagePackSerializer.Serialize(content));
         result.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
 
-        if (TestContext.Current.Test is not null)
-        {
-            result.Headers.Add("Xunit-Test-Id", TestContext.Current.Test.UniqueID);
-        }
-
         return result;
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/TestOutputSink.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/TestOutputSink.cs
@@ -1,0 +1,88 @@
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting.Display;
+
+namespace DragaliaAPI.Integration.Test.Other;
+
+/// <summary>
+/// Serilog sink that routes log events emitted by the shared test web server to the
+/// <see cref="ITestOutputHelper"/> of the test that triggered them.
+/// </summary>
+/// <remarks>
+/// A single web server is shared across all tests, which may run in parallel, so
+/// <see cref="TestContext.Current"/> is not reliable when a log is emitted on a request-handling
+/// thread. Tests register their output helper via <see cref="Register"/> and tag their requests
+/// with an <c>Xunit-Test-Id</c> header (see <see cref="HttpClientExtensions"/>); the sink uses that
+/// header to resolve the correct helper for each event.
+/// </remarks>
+internal sealed class TestOutputSink : ILogEventSink
+{
+    private const string TestIdHeader = "Xunit-Test-Id";
+
+    private static readonly ConcurrentDictionary<string, ITestOutputHelper> OutputHelpers = new();
+
+    private readonly IHttpContextAccessor httpContextAccessor;
+    private readonly MessageTemplateTextFormatter formatter = new(
+        "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}"
+    );
+
+    public TestOutputSink(IHttpContextAccessor httpContextAccessor)
+    {
+        this.httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>
+    /// Associates a test's unique ID with its output helper so that logs emitted while handling that
+    /// test's requests can be routed back to it.
+    /// </summary>
+    public static void Register(string testId, ITestOutputHelper outputHelper) =>
+        OutputHelpers[testId] = outputHelper;
+
+    public void Emit(LogEvent logEvent)
+    {
+        ITestOutputHelper? outputHelper = this.ResolveOutputHelper();
+        if (outputHelper is null)
+        {
+            return;
+        }
+
+        using StringWriter writer = new();
+        this.formatter.Format(logEvent, writer);
+
+        try
+        {
+            outputHelper.Write(writer.ToString());
+        }
+        catch (InvalidOperationException)
+        {
+            // The test owning this output helper has already finished; drop the late log rather than
+            // crashing the shared server.
+        }
+    }
+
+    private ITestOutputHelper? ResolveOutputHelper()
+    {
+        // Logs emitted on the test's own thread (e.g. during setup) carry the ambient test context.
+        if (TestContext.Current is { TestOutputHelper: { } helper })
+        {
+            return helper;
+        }
+
+        // Logs emitted while handling a request run on a server thread with no ambient test context,
+        // so fall back to the test ID that the client stamped onto the request.
+        if (
+            this.httpContextAccessor.HttpContext is { } httpContext
+            && httpContext.Request.Headers.TryGetValue(TestIdHeader, out StringValues testIds)
+            && testIds is [{ } testId]
+            && OutputHelpers.TryGetValue(testId, out ITestOutputHelper? requestHelper)
+        )
+        {
+            return requestHelper;
+        }
+
+        return null;
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/Other/TestOutputSink.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/Other/TestOutputSink.cs
@@ -15,8 +15,8 @@ namespace DragaliaAPI.Integration.Test.Other;
 /// A single web server is shared across all tests, which may run in parallel, so
 /// <see cref="TestContext.Current"/> is not reliable when a log is emitted on a request-handling
 /// thread. Tests register their output helper via <see cref="Register"/> and tag their requests
-/// with an <c>Xunit-Test-Id</c> header (see <see cref="HttpClientExtensions"/>); the sink uses that
-/// header to resolve the correct helper for each event.
+/// with an <c>Xunit-Test-Id</c> header (see <see cref="TestFixture.CreateClient"/>); the sink uses that
+/// header to resolve the correct output helper for each event.
 /// </remarks>
 internal sealed class TestOutputSink : ILogEventSink
 {
@@ -38,28 +38,34 @@ internal sealed class TestOutputSink : ILogEventSink
     /// Associates a test's unique ID with its output helper so that logs emitted while handling that
     /// test's requests can be routed back to it.
     /// </summary>
-    public static void Register(string testId, ITestOutputHelper outputHelper) =>
+    public static void Register(string testId, ITestOutputHelper outputHelper)
+    {
         OutputHelpers[testId] = outputHelper;
+    }
+
+    /// <summary>
+    /// Removes a test's ITestOutputHelper from the global logger store.
+    /// </summary>
+    /// <param name="testId">The test ID to remove.</param>
+    public static void Deregister(string testId)
+    {
+        OutputHelpers.TryRemove(testId, out _);
+    }
 
     public void Emit(LogEvent logEvent)
     {
-        ITestOutputHelper? outputHelper = this.ResolveOutputHelper();
-        if (outputHelper is null)
-        {
-            return;
-        }
-
         using StringWriter writer = new();
         this.formatter.Format(logEvent, writer);
 
-        try
+        ITestOutputHelper? outputHelper = this.ResolveOutputHelper();
+        if (outputHelper is not null)
         {
             outputHelper.Write(writer.ToString());
         }
-        catch (InvalidOperationException)
+        else
         {
-            // The test owning this output helper has already finished; drop the late log rather than
-            // crashing the shared server.
+            // Background output may not be associated with a test - these can be written as diagnostic messages
+            TestContext.Current.SendDiagnosticMessage(writer.ToString());
         }
     }
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -10,6 +10,7 @@ using DragaliaAPI.Features.Login.Savefile;
 using DragaliaAPI.Features.Shared;
 using DragaliaAPI.Features.Shared.Options;
 using DragaliaAPI.Infrastructure.Results;
+using DragaliaAPI.Integration.Test.Other;
 using DragaliaAPI.Shared.PlayerDetails;
 using DragaliaAPI.Shared.Serialization;
 using Microsoft.AspNetCore.Hosting;
@@ -40,6 +41,14 @@ public class TestFixture
     protected TestFixture(CustomWebApplicationFactory factory, ITestOutputHelper testOutputHelper)
     {
         this.TestOutputHelper = testOutputHelper;
+
+        // Register this test's output so the shared server's Serilog sink can route request-thread
+        // logs back to it via the Xunit-Test-Id header (see TestOutputSink).
+        if (TestContext.Current.Test is { } test)
+        {
+            TestOutputSink.Register(test.UniqueID, testOutputHelper);
+        }
+
         this.MockBaasApi = factory.MockBaasApi;
         this.MockPhotonStateApi = factory.MockPhotonStateApi;
 

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -1,4 +1,5 @@
-﻿using DragaliaAPI.Database;
+﻿using System.Diagnostics.CodeAnalysis;
+using DragaliaAPI.Database;
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Database.Entities.Abstract;
 using DragaliaAPI.Extensions;
@@ -19,12 +20,11 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Time.Testing;
 using static DragaliaAPI.Infrastructure.DragaliaHttpConstants;
 
 namespace DragaliaAPI.Integration.Test;
 
-public class TestFixture
+public class TestFixture : IDisposable
 {
     /// <summary>
     /// The device account ID which links to the seeded savefiles <see cref="SeedDatabase"/>
@@ -198,6 +198,11 @@ public class TestFixture
         client.DefaultRequestHeaders.Add("Platform", "2");
         client.DefaultRequestHeaders.Add("Res-Ver", "y2XM6giU6zz56wCm");
 
+        if (TestContext.Current.Test is not null)
+        {
+            client.DefaultRequestHeaders.Add("Xunit-Test-Id", TestContext.Current.Test.UniqueID);
+        }
+
         return client;
     }
 
@@ -330,5 +335,22 @@ public class TestFixture
         );
         cache.SetString($":session:session_id:{sessionId}", JsonSerializer.Serialize(session));
         cache.SetString($":session_id:device_account_id:{deviceAccountId}", sessionId);
+    }
+
+    [SuppressMessage(
+        "Microsoft.Usage",
+        "CA1816:CallGCSuppressFinalizeCorrectly",
+        Justification = "Derived test classes are unlikely to implement finalizers"
+    )]
+    public void Dispose()
+    {
+        this.factory.Dispose();
+        this.Client.Dispose();
+        this.ApiContext.Dispose();
+
+        if (TestContext.Current.Test is { } test)
+        {
+            TestOutputSink.Deregister(test.UniqueID);
+        }
     }
 }

--- a/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
+++ b/DragaliaAPI/DragaliaAPI.Integration.Test/TestFixture.cs
@@ -344,9 +344,10 @@ public class TestFixture : IDisposable
     )]
     public void Dispose()
     {
-        this.factory.Dispose();
         this.Client.Dispose();
         this.ApiContext.Dispose();
+
+        // Do _not_ dispose this.factory - that is shared by the entire assembly
 
         if (TestContext.Current.Test is { } test)
         {


### PR DESCRIPTION
Our integration tests spin up a single HTTP server and send parallel requests to it as different users, for performance reasons. This unfortunately makes it hard to associate logs to any particular test run: parallelism means that if you just capture stdout, you will start to see logs from other tests that ran at the same time.

This is a little experiment to see if we can make a 'smart' logger that uses a HTTP header to redirect output to the appropriate test.