### PR TITLE
Fix incorrect CDN URL on website homepage

### DIFF
--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -111,8 +111,8 @@
         </li>
         <li>
           Leave the CDN address field blank. You can try entering
-          <a rel="external" class="link" href="https://minty.sbs">https://minty.sbs</a> if this
-          is not accepted.
+          <a rel="external" class="link" href="https://minty.sbs">https://minty.sbs</a> if this is
+          not accepted.
         </li>
         <li>Press the &apos;Patch App&apos; button in the lower right corner.</li>
         <li>

--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -111,8 +111,8 @@
         </li>
         <li>
           Leave the CDN address field blank. You can try entering
-          <a rel="external" class="link" href="https://minty.sbs">https://minty.sbs</a> if this is
-          not accepted.
+          <a rel="external" class="link" href="https://minty.sbs">https://minty.sbs</a> if this is not
+          accepted.
         </li>
         <li>Press the &apos;Patch App&apos; button in the lower right corner.</li>
         <li>

--- a/Website/src/routes/(main)/(home)/+page.svelte
+++ b/Website/src/routes/(main)/(home)/+page.svelte
@@ -111,7 +111,7 @@
         </li>
         <li>
           Leave the CDN address field blank. You can try entering
-          <a rel="external" class="link" href="https://cdn.minty.sbs">https://cdn.minty.sbs</a> if this
+          <a rel="external" class="link" href="https://minty.sbs">https://minty.sbs</a> if this
           is not accepted.
         </li>
         <li>Press the &apos;Patch App&apos; button in the lower right corner.</li>


### PR DESCRIPTION
Fixes the Dragalipatch setup instructions on the homepage, which incorrectly told users to enter `https://cdn.minty.sbs` as the CDN address. The correct value is `https://minty.sbs`.

Closes #1515.

Generated with [Claude Code](https://claude.ai/code)