### PR TITLE
Fix QuestDropInfo drops increasing

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -105,8 +105,8 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.10.85" />
     <PackageVersion Include="Respawn" Version="7.0.0" />
-    <PackageVersion Include="Testcontainers" Version="4.13.0" />
-    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.13.0" />
+    <PackageVersion Include="Testcontainers" Version="4.14.0" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.14.0" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
     <PackageVersion Include="Moq.EntityFrameworkCore" Version="10.0.0.2" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
@@ -115,7 +115,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="9.0.6" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
-
     <!-- Transitive pin to fix CVE-2026-49451 from Microsoft.AspNetCore.OpenApi -->
     <PackageVersion Include="Microsoft.OpenApi" Version="2.7.5" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,10 +22,6 @@
     <PackageVersion Include="MessagePack.AspNetCoreMvcFormatter" Version="3.1.7" />
     <PackageVersion Include="MessagePackAnalyzer" Version="3.1.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageVersion
-      Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore"
-      Version="10.0.9"
-    />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="5.6.0" />
     <!-- 

--- a/DragaliaAPI/Directory.Build.props
+++ b/DragaliaAPI/Directory.Build.props
@@ -18,5 +18,6 @@
 
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <BuildToolsVerbose>false</BuildToolsVerbose>
   </PropertyGroup>
 </Project>

--- a/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/ApiContext.cs
@@ -1,6 +1,5 @@
 using DragaliaAPI.Database.Entities;
 using DragaliaAPI.Shared.PlayerDetails;
-using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace DragaliaAPI.Database;
@@ -8,7 +7,7 @@ namespace DragaliaAPI.Database;
 /// <summary>
 /// Base database context.
 /// </summary>
-public class ApiContext : DbContext, IDataProtectionKeyContext
+public class ApiContext : DbContext
 {
     private readonly IPlayerIdentityService playerIdentityService;
 
@@ -130,8 +129,6 @@ public class ApiContext : DbContext, IDataProtectionKeyContext
     public DbSet<DbQuestTreasureList> QuestTreasureList { get; set; } = null!;
 
     public DbSet<DbPlayerQuestWall> PlayerQuestWalls { get; set; } = null!;
-
-    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
 
     public DbSet<DbWallRewardDate> WallRewardDates { get; set; } = null!;
 

--- a/DragaliaAPI/DragaliaAPI.Database/DragaliaAPI.Database.csproj
+++ b/DragaliaAPI/DragaliaAPI.Database/DragaliaAPI.Database.csproj
@@ -1,6 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20260827181111_RemoveDataProtection.Designer.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20260827181111_RemoveDataProtection.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DragaliaAPI.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DragaliaAPI.Database.Migrations
 {
     [DbContext(typeof(ApiContext))]
-    partial class ApiContextModelSnapshot : ModelSnapshot
+    [Migration("20260827181111_RemoveDataProtection")]
+    partial class RemoveDataProtection
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DragaliaAPI/DragaliaAPI.Database/Migrations/20260827181111_RemoveDataProtection.cs
+++ b/DragaliaAPI/DragaliaAPI.Database/Migrations/20260827181111_RemoveDataProtection.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DragaliaAPI.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveDataProtection : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    FriendlyName = table.Column<string>(type: "text", nullable: true),
+                    Xml = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+    }
+}

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -1,9 +1,10 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
 
-public record QuestDropInfo(int QuestId, int Rupies, int Mana, List<DropEntity> Drops);
+public record QuestDropInfo(int QuestId, int Rupies, int Mana, FrozenSet<DropEntity> Drops);
 
 public record DropEntity(int Id, EntityTypes EntityType, double Quantity)
 {

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -148,11 +148,11 @@ public partial class QuestEnemyService : IQuestEnemyService
         );
     }
 
-    private static IPick<T> GetPicker<T>(IReadOnlyCollection<T> elements, Func<T, int> weight) =>
+    private static IPick<T> GetPicker<T>(IReadOnlyList<T> elements, Func<T, int> weight) =>
         // Workaround for FluentRandomPicker throwing when passing in single-element collections
         elements.Count switch
         {
-            1 => new SingleValuePicker<T>(elements.First()),
+            1 => new SingleValuePicker<T>(elements[0]),
             > 1 => Out.Of().PrioritizedElements(elements).WithWeightSelector(weight),
             _ => throw new ArgumentException("Invalid value count", nameof(elements)),
         };

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -34,15 +34,17 @@ public partial class QuestEnemyService : IQuestEnemyService
             return enemyList;
         }
 
-        questDropInfo.Drops.AddRange(eventDropService.GenerateEventMaterialDrops(questData));
+        List<DropEntity> drops = new(questDropInfo.Drops);
 
-        if (questDropInfo.Drops.Count == 0 || enemyList.Length == 0)
+        drops.AddRange(eventDropService.GenerateEventMaterialDrops(questData));
+
+        if (drops.Count == 0 || enemyList.Length == 0)
         {
             return enemyList;
         }
 
         int areaCount = MasterAsset.QuestData[questId].AreaInfo.Count;
-        int totalQuantity = (int)Math.Round(questDropInfo.Drops.Sum(x => x.Quantity) / areaCount);
+        int totalQuantity = (int)Math.Round(drops.Sum(x => x.Quantity) / areaCount);
 
         int totalRupies = AddVariance(questDropInfo.Rupies) / areaCount;
         int rupieSlice = totalRupies / totalQuantity;
@@ -50,7 +52,7 @@ public partial class QuestEnemyService : IQuestEnemyService
         int totalMana = AddVariance(questDropInfo.Mana) / areaCount;
         int manaSlice = totalMana / totalQuantity;
 
-        IPick<DropEntity> dropPicker = GetDropPicker(questDropInfo);
+        IPick<DropEntity> dropPicker = GetPicker(drops, entity => entity.Weight);
         IPick<AtgenEnemy> enemyPicker = GetEnemyPicker(enemyList);
 
         for (int i = 0; i < totalQuantity; i++)
@@ -146,14 +148,11 @@ public partial class QuestEnemyService : IQuestEnemyService
         );
     }
 
-    private static IPick<DropEntity> GetDropPicker(QuestDropInfo questDropInfo) =>
-        GetPicker(questDropInfo.Drops, entity => entity.Weight);
-
-    private static IPick<T> GetPicker<T>(IList<T> elements, Func<T, int> weight) =>
+    private static IPick<T> GetPicker<T>(IReadOnlyCollection<T> elements, Func<T, int> weight) =>
         // Workaround for FluentRandomPicker throwing when passing in single-element collections
         elements.Count switch
         {
-            1 => new SingleValuePicker<T>(elements[0]),
+            1 => new SingleValuePicker<T>(elements.First()),
             > 1 => Out.Of().PrioritizedElements(elements).WithWeightSelector(weight),
             _ => throw new ArgumentException("Invalid value count", nameof(elements)),
         };

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -14,7 +14,6 @@ using DragaliaAPI.Shared.MasterAsset;
 using Hangfire;
 using LinqToDB.Data;
 using LinqToDB.EntityFrameworkCore;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Options;
 using Microsoft.FeatureManagement;
 using Serilog;

--- a/DragaliaAPI/DragaliaAPI/Program.cs
+++ b/DragaliaAPI/DragaliaAPI/Program.cs
@@ -65,8 +65,6 @@ if (hangfireOptions is { Enabled: true })
     builder.Services.ConfigureHangfire();
 }
 
-builder.Services.AddDataProtection().PersistKeysToDbContext<ApiContext>();
-
 builder
     .Services.AddAuthorization()
     .ConfigureAuthentication()


### PR DESCRIPTION
BuildQuestEnemyList mutated the List<DropEntity> inside the singleton drop instance for the quest, which would cause the number of available drops to grow without bound.

Fix this by making the record property immutable and using it to create a separate mutable list.