### PR TITLE
Fix QuestDropInfo drops increasing 

### DIFF
--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -1,9 +1,10 @@
-﻿using DragaliaAPI.Shared.Definitions.Enums;
+﻿using System.Collections.Frozen;
+using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
 
-public record QuestDropInfo(int QuestId, int Rupies, int Mana, List<DropEntity> Drops);
+public record QuestDropInfo(int QuestId, int Rupies, int Mana, FrozenSet<DropEntity> Drops);
 
 public record DropEntity(int Id, EntityTypes EntityType, double Quantity)
 {

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -4,7 +4,7 @@ using MessagePack;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;
 
-public record QuestDropInfo(int QuestId, int Rupies, int Mana, FrozenSet<DropEntity> Drops);
+public record QuestDropInfo(int QuestId, int Rupies, int Mana, IReadOnlyList<DropEntity> Drops);
 
 public record DropEntity(int Id, EntityTypes EntityType, double Quantity)
 {

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -1,5 +1,4 @@
 using DragaliaAPI.Shared.Definitions.Enums;
-using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 
 namespace DragaliaAPI.Shared.MasterAsset.Models.QuestDrops;

--- a/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
+++ b/DragaliaAPI/DragaliaAPI.Shared/MasterAsset/Models/QuestDrops/QuestDropInfo.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Frozen;
+using DragaliaAPI.Shared.Definitions.Enums;
 using DragaliaAPI.Shared.Definitions.Enums;
 using MessagePack;
 

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -148,11 +148,11 @@ public partial class QuestEnemyService : IQuestEnemyService
         );
     }
 
-    private static IPick<T> GetPicker<T>(IReadOnlyCollection<T> elements, Func<T, int> weight) =>
+    private static IPick<T> GetPicker<T>(IReadOnlyList<T> elements, Func<T, int> weight) =>
         // Workaround for FluentRandomPicker throwing when passing in single-element collections
         elements.Count switch
         {
-            1 => new SingleValuePicker<T>(elements.First()),
+            1 => new SingleValuePicker<T>(elements[0]),
             > 1 => Out.Of().PrioritizedElements(elements).WithWeightSelector(weight),
             _ => throw new ArgumentException("Invalid value count", nameof(elements)),
         };

--- a/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
+++ b/DragaliaAPI/DragaliaAPI/Features/Dungeon/QuestEnemyService.cs
@@ -34,15 +34,17 @@ public partial class QuestEnemyService : IQuestEnemyService
             return enemyList;
         }
 
-        questDropInfo.Drops.AddRange(eventDropService.GenerateEventMaterialDrops(questData));
+        List<DropEntity> drops = new(questDropInfo.Drops);
 
-        if (questDropInfo.Drops.Count == 0 || enemyList.Length == 0)
+        drops.AddRange(eventDropService.GenerateEventMaterialDrops(questData));
+
+        if (drops.Count == 0 || enemyList.Length == 0)
         {
             return enemyList;
         }
 
         int areaCount = MasterAsset.QuestData[questId].AreaInfo.Count;
-        int totalQuantity = (int)Math.Round(questDropInfo.Drops.Sum(x => x.Quantity) / areaCount);
+        int totalQuantity = (int)Math.Round(drops.Sum(x => x.Quantity) / areaCount);
 
         int totalRupies = AddVariance(questDropInfo.Rupies) / areaCount;
         int rupieSlice = totalRupies / totalQuantity;
@@ -50,7 +52,7 @@ public partial class QuestEnemyService : IQuestEnemyService
         int totalMana = AddVariance(questDropInfo.Mana) / areaCount;
         int manaSlice = totalMana / totalQuantity;
 
-        IPick<DropEntity> dropPicker = GetDropPicker(questDropInfo);
+        IPick<DropEntity> dropPicker = GetPicker(drops, entity => entity.Weight);
         IPick<AtgenEnemy> enemyPicker = GetEnemyPicker(enemyList);
 
         for (int i = 0; i < totalQuantity; i++)
@@ -146,14 +148,11 @@ public partial class QuestEnemyService : IQuestEnemyService
         );
     }
 
-    private static IPick<DropEntity> GetDropPicker(QuestDropInfo questDropInfo) =>
-        GetPicker(questDropInfo.Drops, entity => entity.Weight);
-
-    private static IPick<T> GetPicker<T>(IList<T> elements, Func<T, int> weight) =>
+    private static IPick<T> GetPicker<T>(IReadOnlyCollection<T> elements, Func<T, int> weight) =>
         // Workaround for FluentRandomPicker throwing when passing in single-element collections
         elements.Count switch
         {
-            1 => new SingleValuePicker<T>(elements[0]),
+            1 => new SingleValuePicker<T>(elements.First()),
             > 1 => Out.Of().PrioritizedElements(elements).WithWeightSelector(weight),
             _ => throw new ArgumentException("Invalid value count", nameof(elements)),
         };


### PR DESCRIPTION
BuildQuestEnemyList mutated the List<DropEntity> inside the singleton drop instance for the quest, which would cause the number of available drops to grow without bound.

Fix this by making the record property immutable and using it to create a separate mutable list.